### PR TITLE
feat(charts): add notification email configuration support

### DIFF
--- a/SaFE/charts/primus-safe/templates/resource-manager/config.yaml
+++ b/SaFE/charts/primus-safe/templates/resource-manager/config.yaml
@@ -17,7 +17,8 @@ data:
       # Ingress component name selected during install.sh
       ingress: {{ .Values.net.ingress }}
     notification:
-      enable: false
+      enable: {{ and .Values.notification .Values.notification.email .Values.notification.email.smtp_host | default false }}
+      secret_path: /etc/secrets/notification
     health_check:
       # Whether to enable health check
       enable: {{ default true (default .Values.k8s).enable_health_check }}

--- a/SaFE/charts/primus-safe/templates/resource-manager/deployment.yaml
+++ b/SaFE/charts/primus-safe/templates/resource-manager/deployment.yaml
@@ -75,6 +75,11 @@ spec:
               mountPath: {{ .Values.opensearch.secret_path }}
               readOnly: true
             {{- end }}
+            {{- if and .Values.notification .Values.notification.email .Values.notification.email.smtp_host }}
+            - name: notification-secret
+              mountPath: /etc/secrets/notification
+              readOnly: true
+            {{- end }}
           {{- if default true (default .Values.k8s).enable_health_check }}
           ports:
             - containerPort: {{ default 8081 (default .Values.resource_manager).health_port }}
@@ -119,6 +124,11 @@ spec:
         - name: opensearch-secret
           secret:
             secretName: {{ .Values.opensearch.secret }}
+        {{- end }}
+        {{- if and .Values.notification .Values.notification.email .Values.notification.email.smtp_host }}
+        - name: notification-secret
+          secret:
+            secretName: {{ .Release.Name }}-notification
         {{- end }}
         - name: server-config
           configMap:

--- a/SaFE/charts/primus-safe/templates/secrets/notification_secret.yaml
+++ b/SaFE/charts/primus-safe/templates/secrets/notification_secret.yaml
@@ -1,0 +1,30 @@
+#
+# Copyright (C) 2025-2025, Advanced Micro Devices, Inc. All rights reserved.
+# See LICENSE for license information.
+#
+
+{{- if and .Values.notification .Values.notification.email .Values.notification.email.smtp_host }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-notification
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+type: Opaque
+stringData:
+  config: |
+    {
+      "email": {
+        "smtp_host": "{{ .Values.notification.email.smtp_host }}",
+        "smtp_port": {{ .Values.notification.email.smtp_port }},
+        "username": "{{ .Values.notification.email.username }}",
+        "password": "{{ .Values.notification.email.password }}",
+        "from": "{{ .Values.notification.email.from }}",
+        "use_tls": {{ .Values.notification.email.use_tls }}
+      }
+    }
+{{- end }}

--- a/SaFE/charts/primus-safe/values.yaml
+++ b/SaFE/charts/primus-safe/values.yaml
@@ -120,6 +120,22 @@ s3:
   secret: "primus-safe-s3"
   # Path to mount S3 secret
   secret_path: "/etc/secrets/s3"
+notification:
+  # Email notification configuration (optional)
+  # If configured, notifications will be enabled automatically
+  email:
+    # SMTP server host
+    smtp_host: ""
+    # SMTP server port (587 for STARTTLS, 465 for SSL)
+    smtp_port: 587
+    # SMTP authentication username
+    username: ""
+    # SMTP authentication password
+    password: ""
+    # Email address used as sender
+    from: ""
+    # Use TLS/SSL (true for port 465, false for port 587 STARTTLS)
+    use_tls: false
 grafana:
   # Enable Grafana for monitoring metrics display (requires primus-lens)
   enable: false


### PR DESCRIPTION
## Summary
Add support for email notification configuration in Helm charts.

## Changes
- **values.yaml**: Add `notification` section with email SMTP configuration options
- **notification_secret.yaml**: New template for storing email credentials as Kubernetes Secret
- **config.yaml**: Enable notification based on `smtp_host` configuration
- **deployment.yaml**: Mount notification secret volume when configured

## Configuration Example
```yaml
notification:
  email:
    smtp_host: "smtp.example.com"
    smtp_port: 465
    username: "user@example.com"
    password: "password"
    from: "noreply@example.com"
    use_tls: true
```

## Behavior
- Notification is **automatically enabled** when `smtp_host` is configured
- If `smtp_host` is empty, notification remains disabled and no Secret/volume is created
- Supports both SSL (port 465, `use_tls: true`) and STARTTLS (port 587, `use_tls: false`)

## Testing
- [x] Tested email sending with 163.com SMTP server
- [x] Verified Secret creation and deployment mounting in tw-proj2 cluster