### PR TITLE
fix: StaleRunCleaner bypasses collection pipeline for long-running workflows

### DIFF
--- a/Lens/modules/exporters/github-runners-exporter/pkg/processor/runner_state_processor.go
+++ b/Lens/modules/exporters/github-runners-exporter/pkg/processor/runner_state_processor.go
@@ -271,7 +271,10 @@ func (p *RunnerStateProcessor) getOrCreateWorkflowRun(
 		return existingRun, nil
 	}
 
-	// Find matching config for additional metadata
+	// Find matching config for additional metadata.
+	// First try by runner_set_id; if nothing found, fall back to namespace+name
+	// to handle cases where the ARS was recreated with a new DB id but the
+	// config still references the old id.
 	var configID int64
 	configFacade := database.GetFacade().GetGithubWorkflowConfig()
 	configs, err := configFacade.ListByRunnerSetID(ctx, runnerSet.ID)
@@ -280,6 +283,17 @@ func (p *RunnerStateProcessor) getOrCreateWorkflowRun(
 			if config.Enabled && matchesConfig(state, config) {
 				configID = config.ID
 				break
+			}
+		}
+	}
+	if configID == 0 {
+		configs, err = configFacade.ListByRunnerSet(ctx, runnerSet.Namespace, runnerSet.Name)
+		if err == nil {
+			for _, config := range configs {
+				if config.Enabled && matchesConfig(state, config) {
+					configID = config.ID
+					break
+				}
 			}
 		}
 	}

--- a/Lens/modules/exporters/github-runners-exporter/pkg/processor/stale_run_cleaner.go
+++ b/Lens/modules/exporters/github-runners-exporter/pkg/processor/stale_run_cleaner.go
@@ -5,11 +5,14 @@ package processor
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
 	"github.com/AMD-AGI/Primus-SaFE/Lens/core/pkg/clientsets"
+	"github.com/AMD-AGI/Primus-SaFE/Lens/core/pkg/constant"
 	"github.com/AMD-AGI/Primus-SaFE/Lens/core/pkg/database"
+	"github.com/AMD-AGI/Primus-SaFE/Lens/core/pkg/database/model"
 	"github.com/AMD-AGI/Primus-SaFE/Lens/core/pkg/logger/log"
 	"github.com/AMD-AGI/Primus-SaFE/Lens/github-runners-exporter/pkg/types"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -161,19 +164,47 @@ func (c *StaleRunCleaner) checkAndCleanStaleRuns(ctx context.Context) {
 			continue
 		}
 
-		// EphemeralRunner is gone from K8s - mark as completed
+		// EphemeralRunner is gone from K8s - transition to pending (ready for collection)
+		// instead of completed, so the collection pipeline can still process it.
 		if updateErr := runFacade.UpdateFields(ctx, run.ID, map[string]interface{}{
-			"status": database.WorkflowRunStatusCompleted,
+			"status":                database.WorkflowRunStatusPending,
+			"workload_completed_at": time.Now(),
 		}); updateErr != nil {
-			log.Warnf("StaleRunCleaner: failed to mark run %d (%s) as completed: %v", run.ID, name, updateErr)
+			log.Warnf("StaleRunCleaner: failed to mark run %d (%s) as pending: %v", run.ID, name, updateErr)
 		} else {
 			cleaned++
-			log.Infof("StaleRunCleaner: marked stale run %d (%s/%s) as completed - EphemeralRunner no longer exists",
+			log.Infof("StaleRunCleaner: marked stale run %d (%s/%s) as pending for collection - EphemeralRunner no longer exists",
 				run.ID, ns, name)
+			c.submitCollectionTask(ctx, run)
 		}
 	}
 
 	if cleaned > 0 {
-		log.Infof("StaleRunCleaner: cleaned %d stale runs in this cycle", cleaned)
+		log.Infof("StaleRunCleaner: recovered %d stale runs for collection in this cycle", cleaned)
 	}
+}
+
+// submitCollectionTask creates a collection task so stale runs still get data extracted.
+func (c *StaleRunCleaner) submitCollectionTask(ctx context.Context, run *model.GithubWorkflowRuns) {
+	taskFacade := database.NewWorkloadTaskFacade()
+
+	taskUID := fmt.Sprintf("collection-%d", run.ID)
+	collectionTask := &model.WorkloadTaskState{
+		WorkloadUID: taskUID,
+		TaskType:    constant.TaskTypeGithubWorkflowCollection,
+		Status:      constant.TaskStatusPending,
+		Ext: model.ExtType{
+			"run_id":        run.ID,
+			"runner_set_id": run.RunnerSetID,
+			"config_id":     run.ConfigID,
+			"workload_name": run.WorkloadName,
+		},
+	}
+
+	if err := taskFacade.UpsertTask(ctx, collectionTask); err != nil {
+		log.Warnf("StaleRunCleaner: failed to create collection task for run %d: %v", run.ID, err)
+		return
+	}
+
+	log.Infof("StaleRunCleaner: submitted collection task %s for stale run %d", taskUID, run.ID)
 }


### PR DESCRIPTION
## Summary
- **StaleRunCleaner now routes stale runs through the collection pipeline** instead of directly marking them as completed. When an EphemeralRunner disappears from K8s, the run is set to `pending` status with `workload_completed_at` timestamp, and a collection task is submitted so data extraction still happens.
- **Config lookup fallback by namespace+name** added to `getOrCreateWorkflowRun`. When ARS is recreated with a new DB id, the config lookup by `runner_set_id` may fail; this adds a fallback to `ListByRunnerSet(namespace, name)` to match the config correctly.

## Changes
- `stale_run_cleaner.go`: Changed stale run status from `completed` to `pending`, added `submitCollectionTask()` to create a collection task via `WorkloadTaskFacade.UpsertTask`
- `runner_state_processor.go`: Added fallback config lookup by namespace+name when `ListByRunnerSetID` returns no matching enabled config

## Test plan
- [ ] Verify stale runs transition to `pending` and collection tasks are created
- [ ] Verify collection pipeline picks up and processes the submitted tasks
- [ ] Verify config fallback works when ARS is recreated with new DB id
- [ ] Verify existing normal flow (non-stale runs) is unaffected


Made with [Cursor](https://cursor.com)