### PR TITLE
Upgrade Higress to 2.2.0 and add deployment health test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -235,3 +235,7 @@ Web/pnpm-debug.log*
 Web/apps/*/.env.development.local
 Web/apps/*/.env.production
 *.tsbuildinfo
+
+# ── Bootstrap ────────────────────────────────────────────────────
+Bootstrap/kubespray/
+Bootstrap/kubespray-venv/

--- a/Bootstrap/higress/higress.sh
+++ b/Bootstrap/higress/higress.sh
@@ -80,8 +80,8 @@ install_higress() {
     # --namespace: specify the installation namespace
     # --create-namespace: create namespace if it doesn't exist
     # -f: specify custom configuration file
-    helm upgrade --install higress oci://registry-1.docker.io/primussafe/higress \
-        --namespace higress-system --version 2.1.8 \
+    helm upgrade --install higress higress.io/higress \
+        --namespace higress-system --version 2.2.0 \
         --create-namespace \
         -f "${SCRIPT_DIR}/values.yaml"
     
@@ -92,9 +92,7 @@ install_higress() {
 install_gateway_api() {
     log_info "Deploying Kubernetes Gateway API CRDs..."
     
-    # Install Gateway API v1.0.0 experimental version
-    # Includes GatewayClass, Gateway, HTTPRoute, TCPRoute and other CRDs
-    kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.0.0/experimental-install.yaml
+    kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.0/experimental-install.yaml
     
     log_info "Gateway API CRDs deployment completed"
 }

--- a/Bootstrap/tests/.chainsaw.yaml
+++ b/Bootstrap/tests/.chainsaw.yaml
@@ -8,6 +8,6 @@ spec:
     assert: 10s
     exec: 15s
   cleanup:
-    skipDelete: true
+    skipDelete: false
   execution:
     failFast: true

--- a/Bootstrap/tests/.chainsaw.yaml
+++ b/Bootstrap/tests/.chainsaw.yaml
@@ -1,0 +1,13 @@
+apiVersion: chainsaw.kyverno.io/v1alpha2
+kind: Configuration
+metadata:
+  name: bootstrap-tests
+spec:
+  timeouts:
+    apply: 30s
+    assert: 120s
+    exec: 60s
+  cleanup:
+    skipDelete: true
+  execution:
+    failFast: true

--- a/Bootstrap/tests/.chainsaw.yaml
+++ b/Bootstrap/tests/.chainsaw.yaml
@@ -4,9 +4,9 @@ metadata:
   name: bootstrap-tests
 spec:
   timeouts:
-    apply: 30s
-    assert: 120s
-    exec: 60s
+    apply: 10s
+    assert: 10s
+    exec: 15s
   cleanup:
     skipDelete: true
   execution:

--- a/Bootstrap/tests/README.md
+++ b/Bootstrap/tests/README.md
@@ -1,30 +1,26 @@
 # Bootstrap Infrastructure Tests
 
-End-to-end tests for Bootstrap components using [Kyverno Chainsaw](https://kyverno.github.io/chainsaw/latest/).
+Infrastructure unit tests for Bootstrap components using [Kyverno Chainsaw](https://kyverno.github.io/chainsaw/latest/).
 
 ## Prerequisites
 
-Install Chainsaw: https://kyverno.github.io/chainsaw/latest/quick-start/install/
+Quickstart Chainsaw: https://kyverno.github.io/chainsaw/latest/quick-start/install/
 
 You also need `kubectl` configured with access to the target cluster.
 
 ## Running Tests
 
-From the repo root:
+From the `Bootstrap` directory:
 
 ```bash
-chainsaw test Bootstrap/tests/higress/ --config Bootstrap/tests/.chainsaw.yaml
-```
-
-Or with Docker:
-
-```bash
-docker run --rm --network=host \
-  -v $(pwd)/Bootstrap/tests:/chainsaw \
-  -v ${HOME}/.kube:/etc/kubeconfig \
-  -e KUBECONFIG=/etc/kubeconfig/config \
-  ghcr.io/kyverno/chainsaw:<version> \
-  test /chainsaw/higress --config /chainsaw/.chainsaw.yaml
+cd ~/Primus-SaFE/Bootstrap
+sudo nerdctl run --rm \
+    -v ./tests/:/chainsaw/ \
+    -v ${HOME}/.kube/:/etc/kubeconfig/ \
+    -e KUBECONFIG=/etc/kubeconfig/config \
+    --network=host \
+    ghcr.io/kyverno/chainsaw \
+    test /chainsaw --config /chainsaw/.chainsaw.yaml
 ```
 
 ## Test Structure

--- a/Bootstrap/tests/README.md
+++ b/Bootstrap/tests/README.md
@@ -1,6 +1,6 @@
 # Bootstrap Infrastructure Tests
 
-Infrastructure unit tests for Bootstrap components using [Kyverno Chainsaw](https://kyverno.github.io/chainsaw/latest/).
+Infrastructure integration tests for Bootstrap components using [Kyverno Chainsaw](https://kyverno.github.io/chainsaw/latest/).
 
 ## Prerequisites
 

--- a/Bootstrap/tests/README.md
+++ b/Bootstrap/tests/README.md
@@ -1,0 +1,46 @@
+# Bootstrap Infrastructure Tests
+
+End-to-end tests for Bootstrap components using [Kyverno Chainsaw](https://kyverno.github.io/chainsaw/latest/).
+
+## Prerequisites
+
+Install Chainsaw: https://kyverno.github.io/chainsaw/latest/quick-start/install/
+
+You also need `kubectl` configured with access to the target cluster.
+
+## Running Tests
+
+From the repo root:
+
+```bash
+chainsaw test Bootstrap/tests/higress/ --config Bootstrap/tests/.chainsaw.yaml
+```
+
+Or with Docker:
+
+```bash
+docker run --rm --network=host \
+  -v $(pwd)/Bootstrap/tests:/chainsaw \
+  -v ${HOME}/.kube:/etc/kubeconfig \
+  -e KUBECONFIG=/etc/kubeconfig/config \
+  ghcr.io/kyverno/chainsaw:<version> \
+  test /chainsaw/higress --config /chainsaw/.chainsaw.yaml
+```
+
+## Test Structure
+
+Each Bootstrap component gets its own folder containing a `chainsaw-test.yaml`:
+
+```
+tests/
+  .chainsaw.yaml          # Shared configuration
+  higress/
+    chainsaw-test.yaml    # Higress deployment health checks
+  README.md
+```
+
+## Available Tests
+
+| Test | What it verifies |
+|------|------------------|
+| `higress/` | higress-controller ready, higress-gateway pods running, Gateway resource exists |

--- a/Bootstrap/tests/higress/chainsaw-test.yaml
+++ b/Bootstrap/tests/higress/chainsaw-test.yaml
@@ -21,12 +21,16 @@ spec:
   # Step 2: At least one higress-gateway pod is Running
   - name: higress-gateway-pods-running
     try:
-    - script:
-        content: |
-          kubectl get pods -n higress-system -l app=higress-gateway \
-            -o jsonpath='{.items[0].status.phase}'
-        check:
-          ($stdout): Running
+    - assert:
+        resource:
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            namespace: higress-system
+            labels:
+              app: higress-gateway
+          status:
+            phase: Running
 
   # Step 3: Gateway resource exists in the cluster
   - name: gateway-resource-exists

--- a/Bootstrap/tests/higress/chainsaw-test.yaml
+++ b/Bootstrap/tests/higress/chainsaw-test.yaml
@@ -1,0 +1,40 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: higress-deployment-health
+spec:
+  description: Verify that the Higress gateway deployment is healthy after running Bootstrap/higress/higress.sh
+  steps:
+  # Step 1: higress-controller Deployment has ready replicas
+  - name: higress-controller-is-ready
+    try:
+    - assert:
+        resource:
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: higress-controller
+            namespace: higress-system
+          status:
+            (readyReplicas > `0`): true
+
+  # Step 2: At least one higress-gateway pod is Running
+  - name: higress-gateway-pods-running
+    try:
+    - script:
+        content: |
+          kubectl get pods -n higress-system -l app=higress-gateway \
+            -o jsonpath='{.items[0].status.phase}'
+        check:
+          ($stdout): Running
+
+  # Step 3: Gateway resource exists in the cluster
+  - name: gateway-resource-exists
+    try:
+    - assert:
+        resource:
+          apiVersion: gateway.networking.k8s.io/v1
+          kind: Gateway
+          metadata:
+            name: ssh-gateway
+            namespace: higress-system


### PR DESCRIPTION
### Problem

When installing Higress 2.2.0 via `Bootstrap/higress/higress.sh`, the Higress controller fails to become ready. The `higress-controller` pod shows `0/2 Running` and the `higress-gateway` pods get stuck in `ContainerCreating`.

**Root cause:** The script installs Gateway API CRDs v1.0.0, which only exposes `BackendTLSPolicy` as `v1alpha2`. Higress 2.2.0 expects `v1.BackendTLSPolicy`, which doesn't exist in that version.

You can confirm this by checking the controller logs:

```bash
kubectl logs -n higress-system -l app=higress-controller -c higress-core --tail=50
```

The key error is:

```
failed to list *v1.BackendTLSPolicy: the server could not find the requested resource (get backendtlspolicies.gateway.networking.k8s.io)
```

### Summary

- Upgrade the Higress Helm chart from 2.1.8 to 2.2.0 and switch the chart source from the private OCI registry (`registry-1.docker.io/primussafe/higress`) to the public Higress repo (`higress.io/higress`), since the private registry only hosts 2.1.8.
- Upgrade Gateway API CRDs from v1.0.0 to v1.4.0 with `--server-side` apply. Higress 2.2.0 expects `v1.BackendTLSPolicy`, which only ships in Gateway API v1.4.0 (v1.0.0 only provides `v1alpha2`). Without this, the controller fails with `failed to list *v1.BackendTLSPolicy`.
- Add a Kyverno Chainsaw infrastructure test for verifying the Higress deployment health.
- Add `Bootstrap/kubespray/` and `Bootstrap/kubespray-venv/` to `.gitignore` (generated at runtime by `bootstrap.sh`).

### What changed

| File | Change |
|------|--------|
| `Bootstrap/higress/higress.sh` | Helm chart source changed to `higress.io/higress`, version bumped to 2.2.0. Gateway API CRDs updated to v1.4.0 with `--server-side`. |
| `Bootstrap/tests/higress/chainsaw-test.yaml` | New Chainsaw test that asserts: (1) `higress-controller` deployment has ready replicas, (2) at least one `higress-gateway` pod is Running, (3) `ssh-gateway` Gateway resource exists. |
| `Bootstrap/tests/.chainsaw.yaml` | Shared Chainsaw configuration (timeouts, fail-fast). |
| `Bootstrap/tests/README.md` | Documentation for running the infrastructure tests. |
| `.gitignore` | Ignore `Bootstrap/kubespray/` and `Bootstrap/kubespray-venv/`. |

### Why Gateway API v1.4.0?

The experimental channel (`experimental-install.yaml`) is required because Higress uses CRDs that the standard channel does not include (`TCPRoute`, `BackendTLSPolicy`, etc.). Version 1.4.0 is the minimum that serves `v1.BackendTLSPolicy`, which Higress 2.2.0 requires.

### Test plan

Run the deployment script and then the Chainsaw test:

```bash
cd ~/Primus-SaFE/Bootstrap
bash higress/higress.sh

sudo nerdctl run --rm \
    -v ./tests/:/chainsaw/ \
    -v ${HOME}/.kube/:/etc/kubeconfig/ \
    -e KUBECONFIG=/etc/kubeconfig/config \
    --network=host \
    ghcr.io/kyverno/chainsaw \
    test /chainsaw --config /chainsaw/.chainsaw.yaml
```

**Expected result:** All 3 checks pass.

<!-- Paste your Chainsaw test screenshots here -->

### Known limitation

The controller logs show non-fatal RBAC warnings for experimental `gateway.networking.x-k8s.io` resources (`xbackendtrafficpolicies`, `xlistenersets`). These do not prevent the controller from reaching Ready state. The Higress Helm chart does not ship RBAC for these experimental CRDs; this can be addressed in a follow-up if needed.

### Testing
Screenshot Installation works: 
<details>
<img width="934" height="420" alt="Screenshot 2026-04-07 204129" src="https://github.com/user-attachments/assets/db4496fc-2773-43c8-b97b-615654073b47" />

</details> 

Screenshot of infra test passing -- pods are running. 
<details> 
<img width="920" height="951" alt="Screenshot 2026-04-07 204154" src="https://github.com/user-attachments/assets/d32d264f-a606-4c0f-afa5-ce50d1e6e461" />

</details> 

Screenshot showing higress gateway is accessible: 
<details> 
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/fa100a34-72a2-4be3-a63f-f5f6183bd8f3" />

</details> 