### PR TITLE
feat: add user settings page with email notification toggle

### DIFF
--- a/Web/apps/safe/src/components/Base/UserInfo.vue
+++ b/Web/apps/safe/src/components/Base/UserInfo.vue
@@ -9,12 +9,9 @@
     <template #reference>
       <el-button class="user-card-btn w-full !h-auto !p-3 !justify-between" text>
         <div class="flex items-center gap-3 overflow-hidden">
-          <!-- Avatar (first letter) -->
           <div class="avatar">
             <span>{{ initial }}</span>
           </div>
-
-          <!-- Text -->
           <div class="flex-1 min-w-0 text-left">
             <div class="name ellipsis" :title="displayName">{{ displayName }}</div>
             <div class="subtle ellipsis" :title="roleDisplayText">
@@ -25,9 +22,9 @@
       </el-button>
     </template>
 
-    <!-- Popover content: block layout -->
+    <!-- Popover content -->
     <div class="space-y-3">
-      <!-- Top avatar + name -->
+      <!-- Header: avatar + name + logout -->
       <div class="flex justify-between items-center">
         <div class="flex items-center gap-3">
           <div class="avatar avatar-lg">
@@ -40,18 +37,11 @@
         </div>
 
         <div v-if="store.userId">
-          <el-tooltip content="change your password">
-            <el-button
-              size="small"
-              type="warning"
-              :icon="Key"
-              plain
-              @click="editPwdVisible = true"
-            />
-          </el-tooltip>
           <el-button size="small" type="danger" plain @click="onLogout">Logout</el-button>
         </div>
-        <el-button size="small" type="primary" plain @click="onLogin" v-else>Login</el-button>
+        <el-button size="small" type="primary" plain @click="router.push('/login')" v-else>
+          Login
+        </el-button>
       </div>
 
       <el-divider style="margin: 6px 0" v-if="store.userId" />
@@ -65,14 +55,7 @@
 
         <div class="key">
           Email
-          <template v-if="!emailEdit">
-            <div class="val truncate" :title="emailText">{{ emailText || '—' }}</div>
-            <el-link class="ml-2" :icon="Edit" @click="emailEdit = !emailEdit" />
-          </template>
-          <template v-else>
-            <el-input v-model="form.email" size="small" class="ml-2" />
-            <el-link class="ml-2" :icon="Check" @click="submitEditEmail" />
-          </template>
+          <div class="val truncate" :title="emailText">{{ emailText || '—' }}</div>
         </div>
 
         <div class="key">
@@ -84,63 +67,38 @@
           Role
           <div class="val">{{ store.displayRole }}</div>
         </div>
+      </div>
 
-        <div class="key">
-          My Public Keys
-          <el-button size="small" plain type="primary" class="ml-3" @click="onManageKey"
-            >Manage</el-button
-          >
-        </div>
+      <!-- Settings link -->
+      <div v-if="store.userId" class="pt-1">
+        <el-divider style="margin: 6px 0" />
+        <el-link type="primary" :underline="false" class="mt-1" @click="router.push('/settings')">
+          <el-icon class="mr-1"><Setting /></el-icon>Settings
+        </el-link>
       </div>
     </div>
   </el-popover>
-
-  <el-dialog
-    v-model="editPwdVisible"
-    title="Change password"
-    width="520px"
-    :close-on-click-modal="false"
-  >
-    <el-form :model="form" label-width="auto" style="max-width: 600px" class="p-5">
-      <el-form-item label="New Password">
-        <el-input v-model="form.password" />
-      </el-form-item>
-    </el-form>
-
-    <template #footer>
-      <el-button @click="editPwdVisible = false">Cancel</el-button>
-      <el-button type="primary" :loading="editLoading" @click="handleChangePwd">Confirm</el-button>
-    </template>
-  </el-dialog>
 </template>
 
 <script setup lang="ts">
-import { computed, ref, reactive, nextTick } from 'vue'
+import { computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useUserStore } from '@/stores/user'
 import { ElMessageBox, ElMessage } from 'element-plus'
-import { editUser } from '@/services'
-import { Edit, Check, Key } from '@element-plus/icons-vue'
+import { Setting } from '@element-plus/icons-vue'
 import { formatTimeStr } from '@/utils'
 
 const store = useUserStore()
 const router = useRouter()
 
-const editPwdVisible = ref(false)
-const editLoading = ref(false)
-const emailEdit = ref(false)
-
 const displayName = computed(
   () => (store.profile as any)?.name || (store.profile as any)?.username || store.userId || 'Guest',
 )
 const emailText = computed(() => (store.profile as any)?.email || '')
-
 const initial = computed(() => displayName.value?.charAt(0)?.toUpperCase() || 'U')
 
-// Simplify role display
 const roleDisplayText = computed(() => {
   const role = store.displayRole
-  // Simplify long role names
   const roleMap: Record<string, string> = {
     'system-admin': 'sys-admin',
     'system-admin-readonly': 'sys-admin (ro)',
@@ -149,65 +107,16 @@ const roleDisplayText = computed(() => {
   return roleMap[role] || role
 })
 
-const initialForm = () => ({
-  password: '',
-  email: store.profile?.email as string,
-})
-const form = reactive({ ...initialForm() })
-
 async function onLogout() {
-  ElMessageBox.confirm('Confirm sign out? You’ll be redirected to the sign-in page.', 'Warning', {
+  ElMessageBox.confirm('Confirm sign out? You will be redirected to the sign-in page.', 'Warning', {
     confirmButtonText: 'OK',
     cancelButtonText: 'Cancel',
     type: 'warning',
   }).then(async () => {
     await store.logout()
     router.replace('/login')
-    ElMessage({
-      type: 'success',
-      message: 'Logout completed',
-    })
+    ElMessage({ type: 'success', message: 'Logout completed' })
   })
-}
-
-const submitEditEmail = async () => {
-  await editUser(store.userId, { email: form.email })
-  ElMessage({ message: 'Edit successful', type: 'success' })
-  emailEdit.value = false
-  await store.fetchUser(true)
-  Object.assign(form, initialForm())
-}
-
-const handleChangePwd = async () => {
-  try {
-    editLoading.value = true
-
-    // Cache current name (prevent being cleared by logout)
-    const displayName = store.profile?.name ?? ''
-
-    await editUser(store.userId, { password: form.password })
-
-    ElMessage({
-      message: 'Password updated. Please sign in again.',
-      type: 'success',
-      duration: 2000,
-    })
-
-    await store.logout()
-    await nextTick()
-    router.push({ path: '/login', query: { name: displayName } })
-  } finally {
-    editPwdVisible.value = false
-    editLoading.value = false
-  }
-}
-
-const onLogin = () => {
-  router.push('/login')
-}
-
-const onManageKey = () => {
-  router.push('/publickeys')
 }
 </script>
 
@@ -232,7 +141,6 @@ const onManageKey = () => {
   white-space: nowrap;
 }
 
-/* Avatar */
 .avatar {
   flex: 0 0 auto;
   width: 32px;
@@ -251,7 +159,6 @@ const onManageKey = () => {
   font-size: 14px;
 }
 
-/* Text styles */
 .name {
   font-weight: 700;
   color: var(--el-text-color-primary);
@@ -262,7 +169,6 @@ const onManageKey = () => {
   color: var(--el-text-color-secondary);
 }
 
-/* More compact popover content */
 :global(.user-popover) {
   --el-popover-padding: 12px;
 }

--- a/Web/apps/safe/src/pages/Settings/index.vue
+++ b/Web/apps/safe/src/pages/Settings/index.vue
@@ -1,0 +1,315 @@
+<template>
+  <div class="settings-wrapper">
+    <div class="settings-content">
+      <!-- Profile -->
+      <el-card class="safe-card" shadow="never">
+        <template #header>
+          <span class="card-title">Profile</span>
+        </template>
+
+        <div class="flex items-start gap-5">
+          <div class="avatar-circle">
+            <span>{{ initial }}</span>
+          </div>
+
+          <div class="profile-grid flex-1 min-w-0">
+            <span class="label">Name</span>
+            <span class="value">{{ displayName }}</span>
+
+            <span class="label">User ID</span>
+            <span class="value uid">{{ userStore.userId || '—' }}</span>
+
+            <span class="label">Role</span>
+            <div><el-tag size="small" type="info" effect="plain">{{ userStore.displayRole }}</el-tag></div>
+
+            <span class="label">Created</span>
+            <span class="value">{{ formatTimeStr(userStore.profile?.creationTime) }}</span>
+
+            <span class="label">Email</span>
+            <div class="value flex items-center gap-2 min-w-0">
+              <template v-if="!emailEditing">
+                <span class="truncate">{{ emailText || '—' }}</span>
+                <el-link :icon="Edit" @click="startEditEmail" />
+              </template>
+              <template v-else>
+                <el-input v-model="emailDraft" size="small" style="width: 240px" />
+                <el-link :icon="Check" @click="submitEmail" />
+                <el-link :icon="Close" @click="emailEditing = false" />
+              </template>
+            </div>
+          </div>
+        </div>
+      </el-card>
+
+      <!-- Notifications -->
+      <el-card class="safe-card" shadow="never">
+        <template #header>
+          <span class="card-title">Notifications</span>
+        </template>
+
+        <div class="setting-row">
+          <div>
+            <div class="setting-label">Email Notifications</div>
+            <div class="setting-desc">
+              Receive email alerts when your workloads change status (Running, Succeeded, Failed,
+              Stopped).
+            </div>
+          </div>
+          <el-switch
+            v-model="enableNotification"
+            :loading="notifLoading"
+            @change="onNotifChange"
+          />
+        </div>
+      </el-card>
+
+      <!-- Security -->
+      <el-card class="safe-card" shadow="never">
+        <template #header>
+          <span class="card-title">Security</span>
+        </template>
+
+        <div class="setting-row">
+          <div>
+            <div class="setting-label">Password</div>
+            <div class="setting-desc">Update your account password.</div>
+          </div>
+          <el-button size="small" plain @click="pwdVisible = true">Change Password</el-button>
+        </div>
+
+        <el-divider style="margin: 14px 0" />
+
+        <div class="setting-row">
+          <div>
+            <div class="setting-label">SSH Public Keys</div>
+            <div class="setting-desc">Manage SSH keys for secure access.</div>
+          </div>
+          <el-button size="small" plain @click="router.push('/publickeys')">Manage</el-button>
+        </div>
+
+        <el-divider style="margin: 14px 0" />
+
+        <div class="setting-row">
+          <div>
+            <div class="setting-label">API Keys</div>
+            <div class="setting-desc">Manage API keys for programmatic access.</div>
+          </div>
+          <el-button size="small" plain @click="router.push('/manageapikeys')">Manage</el-button>
+        </div>
+      </el-card>
+
+      <!-- Danger zone -->
+      <el-card class="safe-card" shadow="never">
+        <template #header>
+          <span class="card-title">Account</span>
+        </template>
+        <div class="setting-row">
+          <div>
+            <div class="setting-label">Sign Out</div>
+            <div class="setting-desc">Sign out of your current session.</div>
+          </div>
+          <el-button size="small" type="danger" plain @click="onLogout">Logout</el-button>
+        </div>
+      </el-card>
+    </div>
+
+    <!-- Change Password Dialog -->
+    <el-dialog
+      v-model="pwdVisible"
+      title="Change Password"
+      width="480px"
+      :close-on-click-modal="false"
+      destroy-on-close
+    >
+      <el-form label-width="auto" class="p-4">
+        <el-form-item label="New Password">
+          <el-input v-model="newPassword" type="password" show-password />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="pwdVisible = false">Cancel</el-button>
+        <el-button type="primary" :loading="pwdLoading" @click="handleChangePwd">
+          Confirm
+        </el-button>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, onMounted, nextTick } from 'vue'
+import { useRouter } from 'vue-router'
+import { useUserStore } from '@/stores/user'
+import { editUser, getUserSettings, updateUserSettings } from '@/services'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import { Edit, Check, Close } from '@element-plus/icons-vue'
+import { formatTimeStr } from '@/utils'
+
+defineOptions({ name: 'UserSettings' })
+
+const router = useRouter()
+const userStore = useUserStore()
+
+const displayName = computed(
+  () =>
+    (userStore.profile as any)?.name ||
+    (userStore.profile as any)?.username ||
+    userStore.userId ||
+    'Guest',
+)
+const emailText = computed(() => (userStore.profile as any)?.email || '')
+const initial = computed(() => displayName.value?.charAt(0)?.toUpperCase() || 'U')
+
+// ── Email editing ──
+const emailEditing = ref(false)
+const emailDraft = ref('')
+
+function startEditEmail() {
+  emailDraft.value = emailText.value
+  emailEditing.value = true
+}
+
+async function submitEmail() {
+  await editUser(userStore.userId, { email: emailDraft.value })
+  ElMessage.success('Email updated')
+  emailEditing.value = false
+  await userStore.fetchUser(true)
+}
+
+// ── Notification settings ──
+const enableNotification = ref(false)
+const notifLoading = ref(false)
+
+async function fetchSettings() {
+  try {
+    const res = await getUserSettings()
+    enableNotification.value = res.enableNotification ?? false
+  } catch {
+    // API may not be deployed yet; silently default to off
+  }
+}
+
+async function onNotifChange(val: boolean | string | number) {
+  notifLoading.value = true
+  try {
+    await updateUserSettings({ enableNotification: !!val })
+    ElMessage.success(val ? 'Notifications enabled' : 'Notifications disabled')
+  } catch {
+    enableNotification.value = !val
+  } finally {
+    notifLoading.value = false
+  }
+}
+
+// ── Password ──
+const pwdVisible = ref(false)
+const pwdLoading = ref(false)
+const newPassword = ref('')
+
+async function handleChangePwd() {
+  try {
+    pwdLoading.value = true
+    const name = (userStore.profile as any)?.name ?? ''
+    await editUser(userStore.userId, { password: newPassword.value })
+    ElMessage.success('Password updated. Please sign in again.')
+    await userStore.logout()
+    await nextTick()
+    router.push({ path: '/login', query: { name } })
+  } finally {
+    pwdVisible.value = false
+    pwdLoading.value = false
+    newPassword.value = ''
+  }
+}
+
+// ── Logout ──
+async function onLogout() {
+  ElMessageBox.confirm('Confirm sign out? You will be redirected to the sign-in page.', 'Warning', {
+    confirmButtonText: 'OK',
+    cancelButtonText: 'Cancel',
+    type: 'warning',
+  }).then(async () => {
+    await userStore.logout()
+    router.replace('/login')
+    ElMessage({ type: 'success', message: 'Logout completed' })
+  })
+}
+
+onMounted(fetchSettings)
+</script>
+
+<style scoped>
+.settings-wrapper {
+  display: flex;
+  justify-content: center;
+  padding-top: 12px;
+}
+
+.settings-content {
+  width: 100%;
+  max-width: 560px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.card-title {
+  font-weight: 600;
+  font-size: 14px;
+}
+
+/* Avatar */
+.avatar-circle {
+  flex: 0 0 auto;
+  width: 48px;
+  height: 48px;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  background: var(--el-fill-color-dark);
+  color: var(--el-text-color-primary);
+  font-weight: 700;
+  font-size: 18px;
+}
+
+/* Profile grid */
+.profile-grid {
+  display: grid;
+  grid-template-columns: 72px 1fr;
+  gap: 8px 14px;
+  font-size: 13px;
+  align-items: center;
+}
+.profile-grid .label {
+  color: var(--el-text-color-secondary);
+  white-space: nowrap;
+}
+.profile-grid .value {
+  color: var(--el-text-color-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.profile-grid .value.uid {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+}
+
+/* Setting row */
+.setting-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+.setting-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--el-text-color-primary);
+}
+.setting-desc {
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+  margin-top: 2px;
+}
+</style>

--- a/Web/apps/safe/src/router/index.ts
+++ b/Web/apps/safe/src/router/index.ts
@@ -244,6 +244,11 @@ const router = createRouter({
           component: () => import('@/pages/PublicKeys/index.vue'),
         },
         {
+          path: '/settings',
+          name: 'UserSettings',
+          component: () => import('@/pages/Settings/index.vue'),
+        },
+        {
           path: '/addontemplate',
           name: 'AddonTemp',
           component: () => import('@/pages/AddonTemp/index.vue'),

--- a/Web/apps/safe/src/services/login/index.ts
+++ b/Web/apps/safe/src/services/login/index.ts
@@ -8,6 +8,7 @@ import type {
   UsersItemResp,
   EnvsResp,
   EditUserResp,
+  UserSettings,
 } from './type'
 
 export const login = (data: LoginReq): Promise<LoginResp> => postForm<LoginResp>(`/login`, data)
@@ -49,3 +50,9 @@ export const getUserDataList = (): Promise<UsersItemResp> => request.get(`/users
 
 // Get log-related user permissions
 export const getEnvs = (): Promise<EnvsResp> => request.get(`/envs`)
+
+export const getUserSettings = (name = 'self'): Promise<UserSettings> =>
+  request.get(`/users/${name}/settings`)
+
+export const updateUserSettings = (data: Partial<UserSettings>, name = 'self'): Promise<void> =>
+  request.put(`/users/${name}/settings`, data)

--- a/Web/apps/safe/src/services/login/type.ts
+++ b/Web/apps/safe/src/services/login/type.ts
@@ -64,3 +64,7 @@ export interface EnvsResp {
   // cd
   cdRequireApproval?: boolean
 }
+
+export interface UserSettings {
+  enableNotification: boolean
+}


### PR DESCRIPTION
- Add /settings route with dedicated settings page (profile, notifications, security, account)

- Simplify UserInfo popover: keep user details, remove inline edit actions, add Settings link

- Add getUserSettings / updateUserSettings API for notification preferences

- Add UserSettings type (enableNotification)

Made-with: Cursor