### PR TITLE
fix(image-import): fix Docker Hub private image auth and extend DB fi…

### DIFF
--- a/SaFE/apiserver/pkg/handlers/image-handlers/image.go
+++ b/SaFE/apiserver/pkg/handlers/image-handlers/image.go
@@ -1194,7 +1194,7 @@ func (h *ImageHandler) checkImageExistsUsingLibrary(ctx context.Context, imageNa
 	if len(list) != 2 {
 		return commonerrors.NewBadRequest("invalid os/arch format")
 	}
-	hostName := strings.Split(imageInfo.SourceImageName, "/")[0]
+	hostName := extractRegistryHost(imageInfo.SourceImageName)
 	os, arch := list[0], list[1]
 
 	sysCtx, err := h.getImageSystemCtx(ctx, hostName, imageName, userSecret)
@@ -1765,4 +1765,21 @@ func (h *ImageHandler) getAndValidateImageSecret(ctx context.Context, secretId s
 	}
 
 	return secret, nil
+}
+
+// extractRegistryHost extracts the registry host from an image name.
+// For Docker Hub images without an explicit host (e.g. "rocm/image:tag" or "library/alpine"),
+// returns "docker.io". For images with an explicit registry (e.g. "ghcr.io/org/image:tag"),
+// returns the registry host. A path segment is considered a registry host if it contains
+// a dot or a colon (port).
+func extractRegistryHost(imageName string) string {
+	firstSlash := strings.Index(imageName, "/")
+	if firstSlash == -1 {
+		return "docker.io"
+	}
+	host := imageName[:firstSlash]
+	if strings.ContainsAny(host, ".:") {
+		return host
+	}
+	return "docker.io"
 }

--- a/SaFE/apiserver/pkg/handlers/inferencex/handler.go
+++ b/SaFE/apiserver/pkg/handlers/inferencex/handler.go
@@ -68,10 +68,11 @@ type BenchmarkRow struct {
 }
 
 type BenchmarksResponse struct {
-	Items      []BenchmarkRow `json:"items"`
-	TotalCount int            `json:"totalCount"`
-	CSV        string         `json:"csv,omitempty"`
-	CachedAt   string         `json:"cachedAt"`
+	Items               []BenchmarkRow `json:"items"`
+	TotalCount          int            `json:"totalCount"`
+	AvailablePrecisions []string       `json:"availablePrecisions"`
+	CSV                 string         `json:"csv,omitempty"`
+	CachedAt            string         `json:"cachedAt"`
 }
 
 type FiltersResponse struct {
@@ -108,12 +109,24 @@ func (h *Handler) GetBenchmarks(c *gin.Context) {
 		return
 	}
 
-	filtered := filterRows(rows, gpu, c.Query("isl"), c.Query("osl"), c.Query("framework"), c.Query("precision"))
+	// Filter by gpu/isl/osl first (without precision) to extract available precisions
+	gpuFiltered := filterRows(rows, gpu, c.Query("isl"), c.Query("osl"), c.Query("framework"), "")
+	precSet := make(map[string]bool)
+	for _, r := range gpuFiltered {
+		precSet[r.Precision] = true
+	}
+
+	// Then apply precision filter if specified
+	filtered := gpuFiltered
+	if c.Query("precision") != "" {
+		filtered = filterRows(rows, gpu, c.Query("isl"), c.Query("osl"), c.Query("framework"), c.Query("precision"))
+	}
 
 	resp := BenchmarksResponse{
-		Items:      filtered,
-		TotalCount: len(filtered),
-		CachedAt:   cachedAt.Format(time.RFC3339),
+		Items:               filtered,
+		TotalCount:          len(filtered),
+		AvailablePrecisions: setToSlice(precSet),
+		CachedAt:            cachedAt.Format(time.RFC3339),
 	}
 
 	if c.Query("format") == "csv" {

--- a/SaFE/charts/primus-safe/templates/database/sql_config.yaml
+++ b/SaFE/charts/primus-safe/templates/database/sql_config.yaml
@@ -211,6 +211,9 @@ data:
 
     alter table image add column if not exists secret_id varchar(64);
 
+    ALTER TABLE image ALTER COLUMN tag TYPE varchar(512);
+    ALTER TABLE image ALTER COLUMN source TYPE varchar(512);
+
     CREATE TABLE IF NOT EXISTS public_key (
        id BIGSERIAL PRIMARY KEY,
        user_id VARCHAR(64) NOT NULL,


### PR DESCRIPTION
…eld length

- Extract registry host correctly for Docker Hub images without docker.io/ prefix

  (e.g. rocm/image:tag now correctly resolves to docker.io for secret matching)

- Extend image.tag and image.source from varchar(128) to varchar(512)

  to support long image names (ALTER is safe for existing data)

