### PR TITLE
fix(addon): use release namespace for Helm REST client instead of def…

### DIFF
--- a/SaFE/resource-manager/pkg/resource/addon_controller.go
+++ b/SaFE/resource-manager/pkg/resource/addon_controller.go
@@ -452,7 +452,8 @@ func (r *AddonController) configureHelmClient(ctx context.Context, actionConfig 
 		return err
 	}
 
-	if err = actionConfig.Init(getter, GetReleaseNamespace(addon), helmDriver, klog.Infof); err != nil {
+	releaseNamespace := GetReleaseNamespace(addon)
+	if err = actionConfig.Init(getter.WithNamespace(releaseNamespace), releaseNamespace, helmDriver, klog.Infof); err != nil {
 		return fmt.Errorf("helm initializ action failed %s", err)
 	}
 	settings.KubeInsecureSkipTLSVerify = true

--- a/SaFE/resource-manager/pkg/resource/addon_helper.go
+++ b/SaFE/resource-manager/pkg/resource/addon_helper.go
@@ -78,6 +78,14 @@ func (c *RESTClientGetter) setDefaults() {
 	}
 }
 
+// WithNamespace returns a shallow copy of the RESTClientGetter with the given namespace,
+// leaving the original getter unchanged so that cached instances are not mutated.
+func (c *RESTClientGetter) WithNamespace(ns string) *RESTClientGetter {
+	cpy := *c
+	cpy.namespace = ns
+	return &cpy
+}
+
 // NewRESTClientGetter returns a new RESTClientGetter.
 func NewRESTClientGetter(cfg *rest.Config, opts ...Option) *RESTClientGetter {
 	g := &RESTClientGetter{


### PR DESCRIPTION
…ault

RESTClientGetter cached by ClustersGetter always had namespace="default" because NewRESTClientGetter was called without a namespace option. This caused Helm to deploy namespace-unscoped resources (Deployments, SAs, ConfigMaps) into the "default" namespace instead of the addon's configured helmDefaultNamespace (e.g. kube-amd-gpu), while ClusterRoleBindings referencing {{ .Release.Namespace }} pointed to the correct namespace, creating a namespace mismatch that broke RBAC for the GPU operator.

Add WithNamespace() to RESTClientGetter that returns a shallow copy with the desired namespace, and call it in configureHelmClient so that the Helm action uses the addon's release namespace for resource creation.

Made-with: Cursor