### PR TITLE
fix(gpu-operator): add tolerate-all to helmDefaultValues for all comp…

### DIFF
--- a/SaFE/charts/primus-safe-cr/templates/addon_template/amd-gpu-operator.v1.4.0.yaml
+++ b/SaFE/charts/primus-safe-cr/templates/addon_template/amd-gpu-operator.v1.4.0.yaml
@@ -21,3 +21,22 @@ spec:
   version: v1.4.0
   type: helm
   helmDefaultNamespace: kube-amd-gpu
+  helmDefaultValues: |
+    controllerManager:
+      manager:
+        tolerations:
+          - operator: Exists
+    deviceConfig:
+      spec:
+        devicePlugin:
+          devicePluginTolerations:
+            - operator: Exists
+          nodeLabellerTolerations:
+            - operator: Exists
+        metricsExporter:
+          tolerations:
+            - operator: Exists
+    node-feature-discovery:
+      worker:
+        tolerations:
+          - operator: Exists


### PR DESCRIPTION
…onents

Without tolerations, GPU operator components (controller-manager Deployment, device-plugin / node-labeller / metrics-exporter DaemonSets, and NFD worker) cannot be scheduled on nodes that carry custom taints (e.g. primus-safe.005, primus-safe.014 maintenance taints), resulting in desired=0 for DaemonSets and Pending pods for the controller manager.

Add operator: Exists tolerations via helmDefaultValues so that new cluster installations automatically tolerate any node taint.

Made-with: Cursor