### PR TITLE
feat(sft): open SFT to all local models and align PostTrain metrics with Grafana

### DIFF
--- a/SaFE/apiserver/pkg/handlers/model-handlers/entrypoint_builder.go
+++ b/SaFE/apiserver/pkg/handlers/model-handlers/entrypoint_builder.go
@@ -35,7 +35,7 @@ var modelRecipes = map[string]ModelRecipe{
 }
 
 // InferModelRecipe returns the Primus recipe for a given HF model name.
-// Falls back to family/size inference for common model families.
+// Falls back to family/size inference and finally a size-based default.
 func InferModelRecipe(hfModelName string) (ModelRecipe, error) {
 	if r, ok := modelRecipes[hfModelName]; ok {
 		return r, nil
@@ -111,11 +111,30 @@ func inferModelRecipeFromName(hfModelName string) (ModelRecipe, error) {
 		}, nil
 	}
 
-	return ModelRecipe{}, fmt.Errorf(
-		"unsupported model: %s (supported defaults: %s; or pass recipe/flavor/modelSize overrides)",
-		hfModelName,
-		supportedModelNames(),
-	)
+	return defaultModelRecipeForSize(size), nil
+}
+
+func defaultModelRecipeForSize(size string) ModelRecipe {
+	switch size {
+	case "32b":
+		return ModelRecipe{
+			Recipe: "qwen.qwen3",
+			Flavor: "qwen3_32b_finetune_config",
+			Size:   "32b",
+		}
+	case "70b":
+		return ModelRecipe{
+			Recipe: "llama.llama3",
+			Flavor: "llama31_70b_finetune_config",
+			Size:   "70b",
+		}
+	default:
+		return ModelRecipe{
+			Recipe: "qwen.qwen3",
+			Flavor: "qwen3_8b_finetune_config",
+			Size:   "8b",
+		}
+	}
 }
 
 func normalizeModelSize(size string) (string, error) {

--- a/SaFE/apiserver/pkg/handlers/model-handlers/models_test.go
+++ b/SaFE/apiserver/pkg/handlers/model-handlers/models_test.go
@@ -692,6 +692,36 @@ func TestGetSftConfig_OverrideAllowsUnknownModel(t *testing.T) {
 	assert.Equal(t, resp.Defaults.ModelSize, "8b")
 }
 
+func TestGetSftConfig_UnknownModelFallsBackToDefaultRecipe(t *testing.T) {
+	model := genMockLocalK8sModel("model-generic-fallback", "ws1")
+	model.Spec.DisplayName = "Tongyi-MAI/Z-Image-Turbo"
+	model.Spec.Source.URL = "https://huggingface.co/Tongyi-MAI/Z-Image-Turbo"
+	model.Spec.Source.ModelName = "Tongyi-MAI/Z-Image-Turbo"
+
+	k8sClient := fake.NewClientBuilder().
+		WithObjects(model).
+		WithScheme(scheme.Scheme).
+		Build()
+
+	h := newMockModelHandler(k8sClient)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "id", Value: "model-generic-fallback"}}
+	c.Request, _ = http.NewRequest("GET", "/models/model-generic-fallback/sft-config?workspace=ws1", nil)
+
+	result, err := h.getSftConfig(c)
+	assert.NilError(t, err)
+
+	resp := result.(*SftConfigResponse)
+	assert.Equal(t, resp.Supported, true)
+	assert.Assert(t, resp.Defaults != nil)
+	assert.Equal(t, resp.Defaults.Recipe, "qwen.qwen3")
+	assert.Equal(t, resp.Defaults.Flavor, "qwen3_8b_finetune_config")
+	assert.Equal(t, resp.Defaults.ModelSize, "8b")
+	assert.Equal(t, resp.Reason, "")
+}
+
 func TestGetSftConfig_SharedLocalPathAccessible(t *testing.T) {
 	model := genMockLocalK8sModel("model-qwen-shared-local", "ws2")
 	model.Spec.DisplayName = "Qwen/Qwen3-8B"
@@ -965,6 +995,88 @@ func TestCreateSftJob_OverrideAllowsUnknownModel(t *testing.T) {
 	assert.Assert(t, strings.Contains(string(entrypoint), "recipe: qwen.qwen3"))
 	assert.Assert(t, strings.Contains(string(entrypoint), "flavor: qwen3_8b_finetune_config"))
 	assert.Assert(t, strings.Contains(string(entrypoint), `peft: "lora"`))
+}
+
+func TestCreateSftJob_UnknownModelFallsBackToDefaultRecipe(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := mock_client.NewMockInterface(ctrl)
+	localPaths, err := json.Marshal([]dbclient.DatasetLocalPathDB{
+		{
+			Workspace: "ws1",
+			Path:      "/shared_nfs/datasets/fallback-sft",
+			Status:    dbclient.DatasetStatusReady,
+		},
+	})
+	assert.NilError(t, err)
+
+	mockDB.EXPECT().
+		GetDataset(gomock.Any(), "dataset-fallback-sft").
+		Return(&dbclient.Dataset{
+			DatasetId:  "dataset-fallback-sft",
+			LocalPaths: string(localPaths),
+		}, nil).
+		AnyTimes()
+
+	model := genMockLocalK8sModel("model-fallback", "ws1")
+	model.Spec.DisplayName = "Tongyi-MAI/Z-Image-Turbo"
+	model.Spec.Source.URL = "https://huggingface.co/Tongyi-MAI/Z-Image-Turbo"
+	model.Spec.Source.ModelName = "Tongyi-MAI/Z-Image-Turbo"
+	model.Status.LocalPaths = []v1.ModelLocalPath{
+		{
+			Workspace: "ws1",
+			Path:      "/shared_nfs/models/z-image-turbo",
+			Status:    v1.LocalPathStatusReady,
+		},
+	}
+	ws1 := genMockWorkspace("ws1", "/shared_nfs")
+
+	k8sClient := fake.NewClientBuilder().
+		WithObjects(model, ws1).
+		WithScheme(scheme.Scheme).
+		Build()
+
+	h := newMockModelHandlerWithDB(k8sClient, mockDB)
+
+	exportModel := false
+	reqBody, err := json.Marshal(CreateSftJobRequest{
+		DisplayName:      "fallback-sft",
+		Workspace:        "ws1",
+		ModelId:          "model-fallback",
+		DatasetId:        "dataset-fallback-sft",
+		ExportModel:      &exportModel,
+		Image:            "test-image",
+		NodeCount:        1,
+		GpuCount:         8,
+		Cpu:              "80",
+		Memory:           "1000Gi",
+		EphemeralStorage: "1000Gi",
+		TrainConfig: SftTrainConfig{
+			Peft: "lora",
+		},
+	})
+	assert.NilError(t, err)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest("POST", "/sft/jobs", bytes.NewReader(reqBody))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Set(common.UserId, "user-1")
+	c.Set(common.UserName, "Test User")
+
+	result, err := h.createSftJob(c)
+	assert.NilError(t, err)
+
+	resp := result.(*CreateSftJobResponse)
+	workload := &v1.Workload{}
+	err = k8sClient.Get(context.Background(), client.ObjectKey{Name: resp.WorkloadId}, workload)
+	assert.NilError(t, err)
+
+	entrypoint, err := base64.StdEncoding.DecodeString(workload.Spec.EntryPoints[0])
+	assert.NilError(t, err)
+	assert.Assert(t, strings.Contains(string(entrypoint), "recipe: qwen.qwen3"))
+	assert.Assert(t, strings.Contains(string(entrypoint), "flavor: qwen3_8b_finetune_config"))
 }
 
 func TestGetSftConfig_UnsupportedModel(t *testing.T) {

--- a/SaFE/apiserver/pkg/handlers/model-handlers/posttrain.go
+++ b/SaFE/apiserver/pkg/handlers/model-handlers/posttrain.go
@@ -152,7 +152,7 @@ func (h *Handler) getPosttrainRunMetrics(c *gin.Context) (interface{}, error) {
 		}, nil
 	}
 
-	points, availableMetrics, err := fetchLensTrainingPerformanceData(c.Request.Context(), lensWorkloadUID, start, end)
+	points, availableMetrics, selectedSource, err := fetchLensTrainingPerformanceData(c.Request.Context(), lensWorkloadUID, start, end, query.Metrics, query.DataSource)
 	if err != nil {
 		klog.V(4).Infof("failed to query Lens training performance for run %s: %v", run.RunID, err)
 		return &PosttrainMetricsResponse{
@@ -163,12 +163,18 @@ func (h *Handler) getPosttrainRunMetrics(c *gin.Context) (interface{}, error) {
 	}
 	filteredPoints := filterLensTrainingPerformancePoints(points, query.Metrics)
 	loss := latestLossSummaryFromPoints(points, availableMetrics)
+	source := lossDataSource(loss)
+	if source == "" {
+		source = selectedSource
+	}
 	return &PosttrainMetricsResponse{
 		RunID:            run.RunID,
 		WorkloadUID:      lensWorkloadUID,
 		AvailableMetrics: availableMetrics,
 		Data:             filteredPoints,
 		LatestLoss:       lossValue(loss),
+		Source:           source,
+		Series:           buildPosttrainMetricSeries(filteredPoints, lossMetricName(loss)),
 		LossMetricName:   lossMetricName(loss),
 		LossDataSource:   lossDataSource(loss),
 	}, nil

--- a/SaFE/apiserver/pkg/handlers/model-handlers/posttrain_lens.go
+++ b/SaFE/apiserver/pkg/handlers/model-handlers/posttrain_lens.go
@@ -19,8 +19,8 @@ import (
 	"strings"
 	"time"
 
-	dbclient "github.com/AMD-AIG-AIMA/SAFE/common/pkg/database/client"
 	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/common"
+	dbclient "github.com/AMD-AIG-AIMA/SAFE/common/pkg/database/client"
 	"github.com/AMD-AIG-AIMA/SAFE/utils/pkg/timeutil"
 )
 
@@ -235,39 +235,193 @@ func defaultLensTimeRangeForItem(item PosttrainRunItem) (string, string, error) 
 	return defaultLensTimeRange(start, end, created)
 }
 
-func fetchLensTrainingPerformanceData(ctx context.Context, lensWorkloadUID, start, end string) ([]PosttrainMetricPoint, []string, error) {
-	var resp []lensTrainingPerformancePoint
+func fetchLensTrainingPerformanceData(ctx context.Context, lensWorkloadUID, start, end, metricsExpr, dataSource string) ([]PosttrainMetricPoint, []string, string, error) {
 	params := url.Values{}
 	if start == "" || end == "" {
-		return nil, nil, fmt.Errorf("start and end timestamps are required")
-	}
-	params.Set("start", start)
-	params.Set("end", end)
-	if err := callLensAPI(ctx, fmt.Sprintf("/workloads/%s/trainingPerformance", url.PathEscape(lensWorkloadUID)), params, &resp); err != nil {
-		return nil, nil, err
+		return nil, nil, "", fmt.Errorf("start and end timestamps are required")
 	}
 
-	points := make([]PosttrainMetricPoint, 0, len(resp))
-	metricSet := make(map[string]struct{}, len(resp))
-	for _, point := range resp {
-		if point.Metric == "" {
+	availableRows, err := fetchLensAvailableMetrics(ctx, lensWorkloadUID, dataSource)
+	if err != nil {
+		availableRows = nil
+	}
+	selectedSource := chooseLensMetricDataSource(availableRows, dataSource)
+
+	params.Set("start", start)
+	params.Set("end", end)
+	if metricsExpr != "" {
+		params.Set("metrics", metricsExpr)
+	}
+	if selectedSource != "" {
+		params.Set("data_source", selectedSource)
+	}
+
+	var resp lensMetricsDataResponse
+	if err := callLensAPI(ctx, fmt.Sprintf("/workloads/%s/metrics/data", url.PathEscape(lensWorkloadUID)), params, &resp); err != nil {
+		return nil, nil, "", err
+	}
+	if selectedSource == "" {
+		selectedSource = strings.TrimSpace(resp.DataSource)
+	}
+
+	points := make([]PosttrainMetricPoint, 0, len(resp.Data))
+	for _, point := range resp.Data {
+		if point.MetricName == "" {
 			continue
 		}
 		points = append(points, PosttrainMetricPoint{
-			MetricName: point.Metric,
+			MetricName: point.MetricName,
 			Value:      point.Value,
 			Timestamp:  point.Timestamp,
-			DataSource: "log",
+			Iteration:  point.Iteration,
+			DataSource: point.DataSource,
 		})
-		metricSet[point.Metric] = struct{}{}
+	}
+	sort.SliceStable(points, func(i, j int) bool {
+		if points[i].Timestamp == points[j].Timestamp {
+			return points[i].Iteration < points[j].Iteration
+		}
+		return points[i].Timestamp < points[j].Timestamp
+	})
+
+	metrics := availableMetricNamesForSource(availableRows, selectedSource)
+	if len(metrics) == 0 {
+		metricSet := make(map[string]struct{}, len(points))
+		for _, point := range points {
+			metricSet[point.MetricName] = struct{}{}
+		}
+		metrics = make([]string, 0, len(metricSet))
+		for metric := range metricSet {
+			metrics = append(metrics, metric)
+		}
+		sort.Strings(metrics)
+	}
+	if selectedSource == "" {
+		selectedSource = inferMetricDataSourceFromPoints(points)
+	}
+	return points, metrics, selectedSource, nil
+}
+
+func fetchLensAvailableMetrics(ctx context.Context, lensWorkloadUID, dataSource string) ([]lensAvailableMetricRow, error) {
+	params := url.Values{}
+	if strings.TrimSpace(dataSource) != "" {
+		params.Set("data_source", strings.TrimSpace(dataSource))
+	}
+	var resp lensAvailableMetricsResponse
+	if err := callLensAPI(ctx, fmt.Sprintf("/workloads/%s/metrics/available", url.PathEscape(lensWorkloadUID)), params, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Metrics, nil
+}
+
+func chooseLensMetricDataSource(rows []lensAvailableMetricRow, requested string) string {
+	requested = strings.TrimSpace(requested)
+	if requested != "" {
+		return requested
 	}
 
+	lossMetric := pickLossMetricName(metricNamesFromAvailableRows(rows))
+	if lossMetric != "" {
+		for _, row := range rows {
+			if row.Name == lossMetric {
+				if source := preferredMetricDataSource(row.DataSource); source != "" {
+					return source
+				}
+			}
+		}
+	}
+
+	allSources := make([]string, 0)
+	seen := make(map[string]struct{})
+	for _, row := range rows {
+		for _, source := range row.DataSource {
+			source = strings.TrimSpace(source)
+			if source == "" {
+				continue
+			}
+			if _, ok := seen[source]; ok {
+				continue
+			}
+			seen[source] = struct{}{}
+			allSources = append(allSources, source)
+		}
+	}
+	return preferredMetricDataSource(allSources)
+}
+
+func preferredMetricDataSource(sources []string) string {
+	if len(sources) == 0 {
+		return ""
+	}
+	preferredOrder := []string{"log", "wandb", "tensorflow"}
+	normalized := make(map[string]string, len(sources))
+	for _, source := range sources {
+		trimmed := strings.TrimSpace(source)
+		if trimmed == "" {
+			continue
+		}
+		normalized[strings.ToLower(trimmed)] = trimmed
+	}
+	for _, candidate := range preferredOrder {
+		if source, ok := normalized[candidate]; ok {
+			return source
+		}
+	}
+	for _, source := range sources {
+		if trimmed := strings.TrimSpace(source); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func availableMetricNamesForSource(rows []lensAvailableMetricRow, dataSource string) []string {
+	metricSet := make(map[string]struct{})
+	for _, row := range rows {
+		if strings.TrimSpace(row.Name) == "" {
+			continue
+		}
+		if dataSource == "" || metricRowHasDataSource(row, dataSource) {
+			metricSet[row.Name] = struct{}{}
+		}
+	}
 	metrics := make([]string, 0, len(metricSet))
 	for metric := range metricSet {
 		metrics = append(metrics, metric)
 	}
 	sort.Strings(metrics)
-	return points, metrics, nil
+	return metrics
+}
+
+func metricNamesFromAvailableRows(rows []lensAvailableMetricRow) []string {
+	names := make([]string, 0, len(rows))
+	for _, row := range rows {
+		if strings.TrimSpace(row.Name) != "" {
+			names = append(names, row.Name)
+		}
+	}
+	return names
+}
+
+func metricRowHasDataSource(row lensAvailableMetricRow, dataSource string) bool {
+	if dataSource == "" {
+		return true
+	}
+	for _, source := range row.DataSource {
+		if strings.EqualFold(strings.TrimSpace(source), strings.TrimSpace(dataSource)) {
+			return true
+		}
+	}
+	return false
+}
+
+func inferMetricDataSourceFromPoints(points []PosttrainMetricPoint) string {
+	for _, point := range points {
+		if strings.TrimSpace(point.DataSource) != "" {
+			return point.DataSource
+		}
+	}
+	return ""
 }
 
 func filterLensTrainingPerformancePoints(points []PosttrainMetricPoint, metricsExpr string) []PosttrainMetricPoint {
@@ -295,6 +449,35 @@ func filterLensTrainingPerformancePoints(points []PosttrainMetricPoint, metricsE
 		}
 	}
 	return filtered
+}
+
+func buildPosttrainMetricSeries(points []PosttrainMetricPoint, lossMetric string) map[string][]PosttrainMetricSeriesPoint {
+	if len(points) == 0 {
+		return nil
+	}
+	series := make(map[string][]PosttrainMetricSeriesPoint)
+	for _, point := range points {
+		series[point.MetricName] = append(series[point.MetricName], PosttrainMetricSeriesPoint{
+			Step:      point.Iteration,
+			Value:     point.Value,
+			Timestamp: formatMetricTimestamp(point.Timestamp),
+		})
+	}
+	if lossMetric != "" {
+		if lossSeries, ok := series[lossMetric]; ok {
+			if _, exists := series["loss"]; !exists {
+				series["loss"] = append([]PosttrainMetricSeriesPoint(nil), lossSeries...)
+			}
+		}
+	}
+	return series
+}
+
+func formatMetricTimestamp(ts int64) string {
+	if ts <= 0 {
+		return ""
+	}
+	return time.UnixMilli(ts).UTC().Format(time.RFC3339)
 }
 
 func latestLossSummaryFromPoints(points []PosttrainMetricPoint, metrics []string) *lossSummary {
@@ -325,7 +508,7 @@ func latestLossSummaryFromPoints(points []PosttrainMetricPoint, metrics []string
 }
 
 func fetchLatestLossSummary(ctx context.Context, lensWorkloadUID, start, end string) (*lossSummary, []string, error) {
-	points, metrics, err := fetchLensTrainingPerformanceData(ctx, lensWorkloadUID, start, end)
+	points, metrics, _, err := fetchLensTrainingPerformanceData(ctx, lensWorkloadUID, start, end, "", "")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/SaFE/apiserver/pkg/handlers/model-handlers/posttrain_lens_test.go
+++ b/SaFE/apiserver/pkg/handlers/model-handlers/posttrain_lens_test.go
@@ -13,8 +13,8 @@ import (
 	"testing"
 	"time"
 
-	"gotest.tools/assert"
 	"github.com/lib/pq"
+	"gotest.tools/assert"
 
 	dbclient "github.com/AMD-AIG-AIMA/SAFE/common/pkg/database/client"
 )
@@ -53,35 +53,76 @@ func TestResolveLensWorkloadUID_UnwrapsLensEnvelope(t *testing.T) {
 	assert.Equal(t, uid, "lens-uid-123")
 }
 
-func TestFetchLatestLossSummary_UsesTrainingPerformancePoints(t *testing.T) {
+func TestFetchLatestLossSummary_UsesMetricsData(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, r.URL.Path, "/workloads/lens-uid-123/trainingPerformance")
-		assert.Equal(t, r.URL.Query().Get("start"), "1000")
-		assert.Equal(t, r.URL.Query().Get("end"), "2000")
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{
-			"meta": map[string]interface{}{
-				"code":    2000,
-				"message": "OK",
-			},
-			"data": []map[string]interface{}{
-				{
-					"metric":    "tflops",
-					"value":     100.0,
-					"timestamp": 1100,
+		switch r.URL.Path {
+		case "/workloads/lens-uid-123/metrics/available":
+			assert.Equal(t, r.URL.Query().Get("start"), "")
+			assert.Equal(t, r.URL.Query().Get("end"), "")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"meta": map[string]interface{}{
+					"code":    2000,
+					"message": "OK",
 				},
-				{
-					"metric":    "lm_loss",
-					"value":     2.3,
-					"timestamp": 1200,
+				"data": map[string]interface{}{
+					"workload_uid": "lens-uid-123",
+					"metrics": []map[string]interface{}{
+						{
+							"name":        "tflops",
+							"data_source": []string{"log"},
+							"count":       1,
+						},
+						{
+							"name":        "lm_loss",
+							"data_source": []string{"log", "wandb"},
+							"count":       2,
+						},
+					},
+					"total_count": 2,
 				},
-				{
-					"metric":    "lm_loss",
-					"value":     1.7,
-					"timestamp": 1300,
+			})
+		case "/workloads/lens-uid-123/metrics/data":
+			assert.Equal(t, r.URL.Query().Get("start"), "1000")
+			assert.Equal(t, r.URL.Query().Get("end"), "2000")
+			assert.Equal(t, r.URL.Query().Get("data_source"), "log")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"meta": map[string]interface{}{
+					"code":    2000,
+					"message": "OK",
 				},
-			},
-		})
+				"data": map[string]interface{}{
+					"workload_uid": "lens-uid-123",
+					"data_source":  "log",
+					"data": []map[string]interface{}{
+						{
+							"metric_name": "tflops",
+							"value":       100.0,
+							"timestamp":   1100,
+							"iteration":   1,
+							"data_source": "log",
+						},
+						{
+							"metric_name": "lm_loss",
+							"value":       2.3,
+							"timestamp":   1200,
+							"iteration":   2,
+							"data_source": "log",
+						},
+						{
+							"metric_name": "lm_loss",
+							"value":       1.7,
+							"timestamp":   1300,
+							"iteration":   3,
+							"data_source": "log",
+						},
+					},
+					"total_count": 3,
+				},
+			})
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
 	}))
 	defer server.Close()
 
@@ -94,6 +135,39 @@ func TestFetchLatestLossSummary_UsesTrainingPerformancePoints(t *testing.T) {
 	assert.Equal(t, summary.MetricName, "lm_loss")
 	assert.Equal(t, summary.Value, 1.7)
 	assert.Equal(t, summary.DataSource, "log")
+}
+
+func TestBuildPosttrainMetricSeries_AddsLossAlias(t *testing.T) {
+	points := []PosttrainMetricPoint{
+		{
+			MetricName: "lm_loss",
+			Value:      2.3,
+			Timestamp:  1200,
+			Iteration:  2,
+			DataSource: "log",
+		},
+		{
+			MetricName: "lm_loss",
+			Value:      1.7,
+			Timestamp:  1300,
+			Iteration:  3,
+			DataSource: "log",
+		},
+		{
+			MetricName: "tflops",
+			Value:      100,
+			Timestamp:  1100,
+			Iteration:  1,
+			DataSource: "log",
+		},
+	}
+
+	series := buildPosttrainMetricSeries(points, "lm_loss")
+	assert.Assert(t, series != nil)
+	assert.Equal(t, len(series["loss"]), 2)
+	assert.Equal(t, series["loss"][0].Step, int32(2))
+	assert.Equal(t, series["loss"][1].Value, 1.7)
+	assert.Equal(t, len(series["lm_loss"]), 2)
 }
 
 func TestDefaultLensTimeRangeForRun_UsesStartAndEndTimes(t *testing.T) {

--- a/SaFE/apiserver/pkg/handlers/model-handlers/posttrain_types.go
+++ b/SaFE/apiserver/pkg/handlers/model-handlers/posttrain_types.go
@@ -89,12 +89,20 @@ type PosttrainMetricPoint struct {
 	DataSource string  `json:"dataSource,omitempty"`
 }
 
+type PosttrainMetricSeriesPoint struct {
+	Step      int32   `json:"step"`
+	Value     float64 `json:"value"`
+	Timestamp string  `json:"timestamp,omitempty"`
+}
+
 type PosttrainMetricsResponse struct {
-	RunID            string                 `json:"runId"`
-	WorkloadUID      string                 `json:"workloadUid"`
-	AvailableMetrics []string               `json:"availableMetrics,omitempty"`
-	Data             []PosttrainMetricPoint `json:"data"`
-	LatestLoss       *float64               `json:"latestLoss,omitempty"`
-	LossMetricName   string                 `json:"lossMetricName,omitempty"`
-	LossDataSource   string                 `json:"lossDataSource,omitempty"`
+	RunID            string                                  `json:"runId"`
+	WorkloadUID      string                                  `json:"workloadUid"`
+	AvailableMetrics []string                                `json:"availableMetrics,omitempty"`
+	Data             []PosttrainMetricPoint                  `json:"data"`
+	LatestLoss       *float64                                `json:"latestLoss,omitempty"`
+	Source           string                                  `json:"source,omitempty"`
+	Series           map[string][]PosttrainMetricSeriesPoint `json:"series,omitempty"`
+	LossMetricName   string                                  `json:"lossMetricName,omitempty"`
+	LossDataSource   string                                  `json:"lossDataSource,omitempty"`
 }

--- a/SaFE/common/pkg/workspace/workspace.go
+++ b/SaFE/common/pkg/workspace/workspace.go
@@ -83,17 +83,21 @@ func GetWorkspacesWithSamePath(k8sClient client.Client, basePath string) ([]stri
 // IsPathAccessibleFromWorkspace checks if a file path is accessible from the specified workspace.
 // This supports shared storage scenarios: even if LocalPaths records workspace B,
 // workspace A can still access the file if they share the same storage base path.
+// It checks ALL volumes mounted in the workspace, not just the primary PFS volume.
 func IsPathAccessibleFromWorkspace(k8sClient client.Client, filePath, workspace string) (bool, error) {
 	ws := &v1.Workspace{}
 	if err := k8sClient.Get(context.Background(), client.ObjectKey{Name: workspace}, ws); err != nil {
 		return false, err
 	}
 
-	wsBasePath := GetNfsPathFromWorkspace(ws)
-	if wsBasePath == "" {
-		return false, nil
+	for _, vol := range ws.Spec.Volumes {
+		mountPath := strings.TrimSpace(vol.MountPath)
+		if mountPath == "" {
+			mountPath = strings.TrimSpace(vol.HostPath)
+		}
+		if mountPath != "" && strings.HasPrefix(filePath, mountPath) {
+			return true, nil
+		}
 	}
-
-	// Check if the file path is under the workspace's storage base path
-	return strings.HasPrefix(filePath, wsBasePath), nil
+	return false, nil
 }

--- a/SaFE/common/pkg/workspace/workspace_test.go
+++ b/SaFE/common/pkg/workspace/workspace_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
 )
@@ -193,4 +195,33 @@ func TestGetUniqueDownloadPaths(t *testing.T) {
 			assert.Equal(t, tt.expectedLen, len(result))
 		})
 	}
+}
+
+func TestIsPathAccessibleFromWorkspace_MultipleVolumes(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = v1.AddToScheme(scheme)
+
+	ws := &v1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{Name: "ws-multi"},
+		Spec: v1.WorkspaceSpec{
+			Volumes: []v1.WorkspaceVolume{
+				{Type: v1.HOSTPATH, MountPath: "/shared_nfs", HostPath: "/shared_nfs"},
+				{Type: v1.HOSTPATH, MountPath: "/hyperloom", HostPath: "/hyperloom"},
+			},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ws).Build()
+
+	ok, err := IsPathAccessibleFromWorkspace(k8sClient, "/hyperloom/models/Qwen3-235B", "ws-multi")
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	ok, err = IsPathAccessibleFromWorkspace(k8sClient, "/shared_nfs/models/Qwen3-8B", "ws-multi")
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	ok, err = IsPathAccessibleFromWorkspace(k8sClient, "/other/path/model", "ws-multi")
+	assert.NoError(t, err)
+	assert.False(t, ok)
 }

--- a/Web/apps/safe/src/pages/PostTrain/PostTrainDetail.vue
+++ b/Web/apps/safe/src/pages/PostTrain/PostTrainDetail.vue
@@ -34,7 +34,7 @@
         <el-descriptions class="m-t-4" border :column="4" direction="vertical">
           <el-descriptions-item label="Run Name">{{ run.displayName }}</el-descriptions-item>
           <el-descriptions-item label="Run ID">
-            <span class="text-xs break-all">{{ run.runId }}</span>
+            <span class="break-all">{{ run.runId }}</span>
           </el-descriptions-item>
           <el-descriptions-item label="Train Type">
             <el-tag size="small" :type="run.trainType === 'sft' ? 'success' : 'warning'" effect="plain">
@@ -59,7 +59,7 @@
           <el-descriptions-item label="Base Model" :span="2">{{ run.baseModelName || '-' }}</el-descriptions-item>
           <el-descriptions-item label="Dataset" :span="2">{{ run.datasetName || '-' }}</el-descriptions-item>
           <el-descriptions-item label="Image" :span="4">
-            <span class="text-xs break-all">{{ run.image || '-' }}</span>
+            <span class="break-all">{{ run.image || '-' }}</span>
           </el-descriptions-item>
         </el-descriptions>
       </el-card>


### PR DESCRIPTION
## Summary
- Remove hardcoded model whitelist for SFT; any `local` or `local_path` Ready model can now start SFT/LoRA training with size-based recipe defaults
- Switch PostTrain metrics backend from `/trainingPerformance` to `/metrics/available` + `/metrics/data` (same data source as the workload Grafana Training Performance panel)
- Return `source` and `series` fields in the metrics response so the existing UI sparkline chart displays loss curves without any frontend changes

## Test plan
- [x] `go test ./pkg/handlers/model-handlers` — all tests pass
- [ ] Verify `GET /api/v1/playground/models/:id/sft-config` returns `supported: true` for previously unsupported models (e.g. `Tongyi-MAI/Z-Image-Turbo`)
- [ ] Submit SFT job for a non-Qwen/non-Llama model and confirm job creation succeeds
- [ ] Check PostTrain detail page shows loss curve when Lens has `training_performance` data for the workload