### PR TITLE
fix(resource-manager/exportimage): bypass containerd hosts.toml for nerdctl login/push

### DIFF
--- a/SaFE/resource-manager/pkg/ops_job/exportimage_job_controller.go
+++ b/SaFE/resource-manager/pkg/ops_job/exportimage_job_controller.go
@@ -40,6 +40,19 @@ const (
 
 	// Registry project name
 	registryProject = "Custom"
+
+	// emptyHostsDir is used as --hosts-dir for nerdctl login/push/rmi to
+	// bypass /etc/containerd/certs.d/*/hosts.toml. On clusters that configure
+	// a Dragonfly (or similar) image-pull mirror there, nerdctl's login
+	// authorizer hits known host/port resolution bugs (see
+	// https://github.com/containerd/nerdctl/issues/3047,
+	// https://github.com/containerd/nerdctl/issues/3245) and fails with
+	// `rh.Authorizer.AddResponses: expected acArg to be "<host>:443", got
+	// "<host>"`. Pointing nerdctl at an empty hosts-dir avoids the problem
+	// for these registry-auth operations without affecting containerd's
+	// own pull path (kubelet + containerd still read the default hosts-dir,
+	// so Dragonfly P2P pull acceleration is preserved).
+	emptyHostsDir = "/opt/primus-safe-nerdctl-empty-hosts"
 )
 
 // RegistryAuth represents Docker registry authentication structure
@@ -428,8 +441,13 @@ func (r *ExportImageJobReconciler) loginHarbor(sshClient *ssh.Client, registry, 
 	klog.Infof("Logging into Harbor registry %s as user %s", registry, username)
 
 	// Use nerdctl login with password stdin for security
-	// Password won't appear in process list or command history
-	cmd := fmt.Sprintf("echo '%s' | sudo nerdctl login %s -u %s --password-stdin", password, registry, username)
+	// Password won't appear in process list or command history.
+	// --hosts-dir points at an empty dir (created on-demand) to bypass the
+	// system hosts.toml which may break nerdctl's login authorizer on
+	// clusters with Dragonfly/mirror configured. See emptyHostsDir doc.
+	cmd := fmt.Sprintf(
+		"sudo mkdir -p %s && echo '%s' | sudo nerdctl --hosts-dir %s login %s -u %s --password-stdin",
+		emptyHostsDir, password, emptyHostsDir, registry, username)
 
 	klog.V(4).Infof("Executing nerdctl login for registry %s", registry)
 
@@ -458,7 +476,7 @@ func (r *ExportImageJobReconciler) pushImage(sshClient *ssh.Client, imageName st
 	}
 	defer session.Close()
 
-	cmd := fmt.Sprintf("sudo nerdctl push %s", imageName)
+	cmd := fmt.Sprintf("sudo nerdctl --hosts-dir %s push %s", emptyHostsDir, imageName)
 	klog.V(4).Infof("Pushing image: %s", imageName)
 
 	output, err := session.CombinedOutput(cmd)
@@ -480,8 +498,9 @@ func (r *ExportImageJobReconciler) deleteImage(ctx context.Context, sshClient *s
 
 	klog.Infof("Deleting image: %s", imageName)
 
-	// Use nerdctl rmi to remove image
-	cmd := fmt.Sprintf("sudo nerdctl rmi %s", imageName)
+	// Use nerdctl rmi to remove image (same --hosts-dir workaround as login/push
+	// so that rmi does not trigger host.toml resolver bugs either).
+	cmd := fmt.Sprintf("sudo nerdctl --hosts-dir %s rmi %s", emptyHostsDir, imageName)
 	klog.V(4).Infof("Executing: %s", cmd)
 
 	output, err := session.CombinedOutput(cmd)


### PR DESCRIPTION
## Summary

- `ExportImageJobReconciler` shells into the Pod's admin node and runs `sudo nerdctl login` / `push`. On clusters whose `/etc/containerd/certs.d/<harbor>/hosts.toml` configures a Dragonfly (or similar) pull-through mirror — e.g. core42's `http://127.0.0.1:4001` with `X-Dragonfly-Registry` header — nerdctl 2.0.5 trips over a known authorizer port-resolution bug while initializing the login authorizer: `failed to call rh.Authorizer.AddResponses: expected acArg to be "<host>:443", got "<host>"` / `"127.0.0.1:4001"`. `login` exits with status 1, `push` never runs, the OpsJob is marked `Failed` with no `target` in `outputs`, and the Save-as-Image tab ends up rendering `Save failed – no image generated`.
- Fix: point nerdctl at an empty `--hosts-dir` (`/opt/primus-safe-nerdctl-empty-hosts`, created on-demand by the `login` cmd) for `login` / `push` / `rmi` so the registry-auth code path skips the buggy hosts.toml resolver entirely. `commit` is left alone (local-only, doesn't hit a registry).
- Side effects: **none on Dragonfly pull acceleration** — containerd itself still reads the default `/etc/containerd/certs.d`, so kubelet pulls keep using the Dragonfly mirror. The workaround only affects the three nerdctl CLI calls issued by this reconciler.

Refs: [containerd/nerdctl#3047](https://github.com/containerd/nerdctl/issues/3047), [containerd/nerdctl#3245](https://github.com/containerd/nerdctl/issues/3245)

## Test plan

Already validated end-to-end on core42:

- [x] Rebuilt image `harbor.core42.primus-safe.amd.com/primussafe/resource-manager:202604190514-hostsdir` from this branch, rolled `primus-safe-resource-manager` Deployment, 2/2 pods Ready on new image.
- [x] Triggered `POST /api/v1/opsjobs` with `type=exportimage, workload=jiang-test-7ctfs`:
  - Before fix: `login` failed on `127.0.0.1:4001` / `harbor.core42.primus-safe.amd.com`, OpsJob Failed in <1s, `imageName` empty.
  - After fix: OpsJob `custom-jiang-test-7ctfs-8kvg8` → `Succeeded` in ~45s. Outputs include `target=harbor.core42.primus-safe.amd.com/custom/rocm/megatron-lm:202604190624`. `GET /api/v1/images/custom?workload=jiang-test-7ctfs` returns the new record with non-empty `imageName` and `log=Image exported successfully`. Verified the artifact exists via Harbor API: `GET /api/v2.0/projects/custom/repositories/custom%2Frocm%2Fmegatron-lm/artifacts`.
- [x] Manually ran `sudo nerdctl --hosts-dir /opt/primus-safe-nerdctl-empty-hosts login harbor.core42.primus-safe.amd.com -u admin --password-stdin` on the GPU node → `Login Succeeded`. Without `--hosts-dir`, 5/5 attempts fail with the port-resolution error.

Reviewer checklist for other clusters (OCI / Project1 / Project2 — no Dragonfly mirror configured):

- [ ] Confirm export-image OpsJob still succeeds after this change. Behavior is unchanged because there is no `[host."..."]` entry in `/etc/containerd/certs.d/<harbor>/hosts.toml` to bypass, and an empty `--hosts-dir` just makes nerdctl fall back to the `server` URL.
