### PR TITLE
fix(ssh): remove weak SHA-1 based MAC algorithms

### DIFF
--- a/SaFE/apiserver/pkg/handlers/ssh-handlers/ssh.go
+++ b/SaFE/apiserver/pkg/handlers/ssh-handlers/ssh.go
@@ -61,7 +61,18 @@ func NewSshHandler(ctx context.Context, mgr ctrlruntime.Manager) (*SshHandler, e
 			}
 		}
 
-		config := &ssh.ServerConfig{}
+		config := &ssh.ServerConfig{
+			Config: ssh.Config{
+				// Explicitly allowlist strong MACs; exclude SHA-1 based MACs
+				// (hmac-sha1, hmac-sha1-96) flagged by security scans as weak.
+				MACs: []string{
+					"hmac-sha2-256-etm@openssh.com",
+					"hmac-sha2-512-etm@openssh.com",
+					"hmac-sha2-256",
+					"hmac-sha2-512",
+				},
+			},
+		}
 		privateData := commonconfig.GetSSHRsaPrivate()
 		if len(privateData) == 0 {
 			err = fmt.Errorf("id_rsa is empty")


### PR DESCRIPTION
## Summary

Security scan (IT audit) flagged the apiserver SSH endpoint as supporting weak SHA-1 based MAC algorithms (`hmac-sha1`, `hmac-sha1-96`). The current code initializes `ssh.ServerConfig{}` without an explicit `Config.MACs`, so `golang.org/x/crypto/ssh` falls back to its built-in defaults which include those weak MACs.

This PR explicitly allowlists only SHA-2 based MACs:

- `hmac-sha2-256-etm@openssh.com`
- `hmac-sha2-512-etm@openssh.com`
- `hmac-sha2-256`
- `hmac-sha2-512`

KEX and Ciphers are intentionally left untouched in this PR — IT only requested removal of weak MACs. If a future scan flags KEX/Ciphers, those will be addressed in a follow-up.

## Changes

- `SaFE/apiserver/pkg/handlers/ssh-handlers/ssh.go`: set `ssh.ServerConfig.Config.MACs` to a strong-only allowlist in `NewSshHandler`.

## Compatibility

All mainstream SSH clients (OpenSSH 6.2+, PuTTY, Xshell, MobaXterm, recent JSch) support `hmac-sha2-256/512`. Only very old (10+ years) clients that *only* speak `hmac-sha1` would break — such clients should be upgraded anyway.

## Test plan

- [x] `go build ./pkg/handlers/ssh-handlers/...` passes locally
- [ ] Deploy to a test cluster and verify:
  - `ssh -vv -o MACs=hmac-sha1 <user>@<host> -p <port>` → expected: `no matching MAC found`
  - `ssh -vv -o MACs=hmac-sha2-256 <user>@<host> -p <port>` → expected: connects normally
- [ ] IT re-runs the security scan and confirms the weak-MAC finding is gone

Made with [Cursor](https://cursor.com)