### PR TITLE
fix(safe-web): accept new Claw response envelope + allow splitting /c…

### DIFF
--- a/Web/apps/safe/.env.example
+++ b/Web/apps/safe/.env.example
@@ -41,6 +41,11 @@
 # Backend for /lens, /root-cause, /agent/ops (default: same as PROXY_API_TARGET)
 # PROXY_BACKEND_TARGET=http://localhost:8088
 
+# PrimusClaw backend for /claw-api (default: same as PROXY_API_TARGET)
+# Override this when the main API target runs an older Claw build than the
+# environment you actually want to test plugins/tools against.
+# PROXY_CLAW_TARGET=http://localhost:8088
+
 # WebSocket backend (default: derived from PROXY_API_TARGET)
 # PROXY_WS_TARGET=ws://localhost:8088
 

--- a/Web/apps/safe/src/services/request.ts
+++ b/Web/apps/safe/src/services/request.ts
@@ -194,8 +194,16 @@ clawRequest.interceptors.response.use(
     if (response.config.rawResponse === true) return response
 
     const rawData = response.data
-    if (rawData && typeof rawData === 'object' && 'code' in rawData && rawData.code >= 200 && rawData.code < 300) {
-      return rawData.data
+    if (rawData && typeof rawData === 'object') {
+      // Accept both envelope shapes: legacy `{ code, data }` (oci-slc) and
+      // the newer `{ ok, data }` (core42). Anything with a `data` field and
+      // either a 2xx `code` or a truthy `ok` is treated as success.
+      const codeOk = 'code' in rawData && typeof rawData.code === 'number'
+        && rawData.code >= 200 && rawData.code < 300
+      const okTrue = 'ok' in rawData && rawData.ok === true
+      if ((codeOk || okTrue) && 'data' in rawData) {
+        return rawData.data
+      }
     }
 
     const msg = rawData?.message ?? rawData?.error ?? 'Claw API Error'

--- a/Web/apps/safe/vite.config.ts
+++ b/Web/apps/safe/vite.config.ts
@@ -12,6 +12,10 @@ export default defineConfig(({ mode }) => {
 
   const API_TARGET = env.PROXY_API_TARGET || 'http://localhost:8088'
   const BACKEND_TARGET = env.PROXY_BACKEND_TARGET || API_TARGET
+  // Allow pointing /claw-api at a different backend than /api. Useful when
+  // the main API target still hosts an older PrimusClaw build while a newer
+  // one lives on a separate environment (e.g. core42 vs. oci-slc).
+  const CLAW_TARGET = env.PROXY_CLAW_TARGET || API_TARGET
   const WS_TARGET = env.PROXY_WS_TARGET || API_TARGET.replace(/^http/, 'ws')
   const MCP_TARGET = env.PROXY_MCP_TARGET || API_TARGET
   const MCP_REWRITE_PREFIX = env.PROXY_MCP_REWRITE_PREFIX || '/mcp'
@@ -79,7 +83,7 @@ export default defineConfig(({ mode }) => {
           rewrite: (path) => path,
         },
         '/claw-api': {
-          target: API_TARGET,
+          target: CLAW_TARGET,
           changeOrigin: true,
           secure: false,
           timeout: 300000,


### PR DESCRIPTION
…law-api proxy

The core42 PrimusClaw backend now returns `{ ok: true, data }` instead of the legacy `{ code, data }` envelope, which caused the strict clawRequest interceptor to treat every success as a biz error ("Claw API Error" + "Failed to load plugins"). The interceptor now accepts either envelope shape while still rejecting malformed responses.

Also add an optional PROXY_CLAW_TARGET dev-server variable so local development can point /claw-api at a different environment than the main API — useful when the main target hosts an older Claw build that rejects default-user sessions (e.g. oci-slc vs. core42).

Made-with: Cursor