### PR TITLE
fix: update metrics port configuration in ray_job_template.yaml

### DIFF
--- a/SaFE/charts/primus-safe/templates/configmap/ray_job_template.yaml
+++ b/SaFE/charts/primus-safe/templates/configmap/ray_job_template.yaml
@@ -124,6 +124,9 @@ data:
                 - containerPort: 8265
                   name: dashboard
                   protocol: TCP
+                - containerPort: 18081
+                  name: metrics
+                  protocol: TCP
                 imagePullPolicy: IfNotPresent
                 volumeMounts:
                   - name: shared-data
@@ -205,6 +208,10 @@ data:
                     fieldRef:
                       apiVersion: v1
                       fieldPath: metadata.namespace
+                ports:                       
+                - containerPort: 18081
+                  name: metrics
+                  protocol: TCP
                 imagePullPolicy: IfNotPresent
                 volumeMounts:
                   - name: shared-data
@@ -285,6 +292,10 @@ data:
                     fieldRef:
                       apiVersion: v1
                       fieldPath: metadata.namespace
+                ports:                       
+                - containerPort: 18081
+                  name: metrics
+                  protocol: TCP
                 imagePullPolicy: IfNotPresent
                 volumeMounts:
                   - name: shared-data


### PR DESCRIPTION
ray job uses default port of 8080 for metrics, which has been occupied by ceph-csi on core42. update the ray job template to use a less common port for metrics.