### PR TITLE
fix(bootstrap): remove hardcoded secrets from benchmark and harbor co…

### DIFF
--- a/Bootstrap/benchmark/templates/secret.yaml
+++ b/Bootstrap/benchmark/templates/secret.yaml
@@ -4,4 +4,4 @@ metadata:
   name: secret-{{.Replica}}
 type: Opaque
 data:
-  password: Zm9vb29vb29vb29vb29vbwo=
+  password: {{ randAlphaNum 16 | b64enc }}

--- a/Bootstrap/harbor/values.yaml
+++ b/Bootstrap/harbor/values.yaml
@@ -234,7 +234,7 @@ persistence:
     swift:
       authurl: https://storage.myprovider.com/v3/auth
       username: username
-      password: password
+      password: ""  # set via existingSecret or helm --set
       container: containername
       # keys in existing secret must be REGISTRY_STORAGE_SWIFT_PASSWORD, REGISTRY_STORAGE_SWIFT_SECRETKEY, REGISTRY_STORAGE_SWIFT_ACCESSKEY
       existingSecret: ""
@@ -763,7 +763,7 @@ registry:
   relativeurls: false
   credentials:
     username: "harbor_registry_user"
-    password: "harbor_registry_password"
+    password: ""  # set via existingSecret or helm --set
     # If using existingSecret, the key must be REGISTRY_PASSWD and REGISTRY_HTPASSWD
     existingSecret: ""
     # Login and password in htpasswd string format. Excludes `registry.credentials.username`  and `registry.credentials.password`. May come in handy when integrating with tools like argocd or flux. This allows the same line to be generated each time the template is rendered, instead of the `htpasswd` function from helm, which generates different lines each time because of the salt.


### PR DESCRIPTION
…nfigs

- benchmark/templates/secret.yaml: replace static password with randAlphaNum so each deployment generates a unique value
- harbor/values.yaml: clear placeholder passwords, use existingSecret or helm --set at deploy time

Made-with: Cursor