### PR TITLE
feat: add MCP (Model Context Protocol) server to apiserver

### DIFF
--- a/SaFE/apiserver/pkg/handlers/handlers.go
+++ b/SaFE/apiserver/pkg/handlers/handlers.go
@@ -186,7 +186,7 @@ func initMCPRoutes(engine *gin.Engine) {
 // routing layer without bringing up a full apiserver.
 func mountMCPRoutes(engine *gin.Engine, srv *mcpserver.Server, basePath string) {
 	if basePath == "" {
-		basePath = "/mcp"
+		basePath = "/api/v1/mcp"
 	}
 	cleanBase := strings.TrimRight(basePath, "/")
 

--- a/SaFE/apiserver/pkg/handlers/handlers.go
+++ b/SaFE/apiserver/pkg/handlers/handlers.go
@@ -7,7 +7,6 @@ package handlers
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -29,10 +28,8 @@ import (
 	proxyhandlers "github.com/AMD-AIG-AIMA/SAFE/apiserver/pkg/handlers/proxy-handlers"
 	reshandler "github.com/AMD-AIG-AIMA/SAFE/apiserver/pkg/handlers/resources"
 	sshhandler "github.com/AMD-AIG-AIMA/SAFE/apiserver/pkg/handlers/ssh-handlers"
-	mcpserver "github.com/AMD-AIG-AIMA/SAFE/common/pkg/mcp/server"
-	mcptools "github.com/AMD-AIG-AIMA/SAFE/apiserver/pkg/mcp/tools"
+	mcprouter "github.com/AMD-AIG-AIMA/SAFE/apiserver/pkg/mcp/router"
 	apiutils "github.com/AMD-AIG-AIMA/SAFE/apiserver/pkg/utils"
-	"github.com/AMD-AIG-AIMA/SAFE/apiserver/pkg/mcp/unified"
 	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/common"
 	commonconfig "github.com/AMD-AIG-AIMA/SAFE/common/pkg/config"
 	dbclient "github.com/AMD-AIG-AIMA/SAFE/common/pkg/database/client"
@@ -154,77 +151,10 @@ func InitHttpHandlers(_ context.Context, mgr ctrlruntime.Manager) (*gin.Engine, 
 
 	// MCP (Model Context Protocol) server
 	if commonconfig.IsMCPEnable() {
-		initMCPRoutes(engine)
+		mcprouter.InitRoutes(engine)
 	}
 
 	return engine, nil
-}
-
-// initMCPRoutes initializes MCP server routes under the configured base path.
-func initMCPRoutes(engine *gin.Engine) {
-	srv := mcpserver.New()
-
-	unifiedTools := unified.GetRegistry().GetMCPTools()
-	srv.RegisterTools(unifiedTools)
-	klog.Infof("MCP Server: Registered %d tools from unified registry", len(unifiedTools))
-
-	builtinTools := mcptools.RegisterAllTools()
-	srv.RegisterTools(builtinTools)
-	klog.Infof("MCP Server: Registered %d built-in tools", len(builtinTools))
-
-	if instructions := commonconfig.GetMCPInstructions(); instructions != "" {
-		srv.SetInstructions(instructions)
-	} else {
-		srv.SetInstructions("SaFE API Server - GPU Cluster Management Tools via MCP")
-	}
-
-	mountMCPRoutes(engine, srv, commonconfig.GetMCPBasePath())
-}
-
-// mountMCPRoutes mounts SSE / streamable HTTP / health / index endpoints for the
-// given MCP server under basePath. Exported for tests so they can verify the
-// routing layer without bringing up a full apiserver.
-func mountMCPRoutes(engine *gin.Engine, srv *mcpserver.Server, basePath string) {
-	if basePath == "" {
-		basePath = "/api/v1/mcp"
-	}
-	cleanBase := strings.TrimRight(basePath, "/")
-
-	sseTransport := mcpserver.NewSSETransport(srv)
-	sseTransport.MessageEndpointPath = cleanBase + "/message"
-	streamableTransport := mcpserver.NewStreamableHTTPTransport(srv)
-
-	mcpGroup := engine.Group(basePath)
-	{
-		mcpGroup.GET("/sse", func(c *gin.Context) { sseTransport.HandleSSE(c.Writer, c.Request) })
-		mcpGroup.POST("/message", func(c *gin.Context) { sseTransport.HandleMessage(c.Writer, c.Request) })
-		mcpGroup.POST("/rpc", func(c *gin.Context) { streamableTransport.HandleRPC(c.Writer, c.Request) })
-
-		mcpGroup.GET("/health", func(c *gin.Context) {
-			c.JSON(200, gin.H{
-				"status":      "ok",
-				"server":      "SaFE MCP Server",
-				"version":     mcpserver.MCPVersion,
-				"total_tools": srv.ToolCount(),
-			})
-		})
-
-		mcpGroup.GET("/", func(c *gin.Context) {
-			toolNames := srv.GetToolNames()
-			c.JSON(200, gin.H{
-				"server":       "SaFE MCP Server",
-				"version":      mcpserver.MCPVersion,
-				"sse_endpoint": cleanBase + "/sse",
-				"rpc_endpoint": cleanBase + "/rpc",
-				"total_tools":  len(toolNames),
-				"tools":        toolNames,
-			})
-		})
-	}
-
-	klog.Infof("MCP Server: Routes registered under %s", basePath)
-	klog.Infof("MCP Server: SSE endpoint: %s/sse", cleanBase)
-	klog.Infof("MCP Server: RPC endpoint: %s/rpc (for testing)", cleanBase)
 }
 
 // InitModelHandlers initializes the model handlers for the API server.

--- a/SaFE/apiserver/pkg/handlers/handlers.go
+++ b/SaFE/apiserver/pkg/handlers/handlers.go
@@ -7,6 +7,7 @@ package handlers
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -28,7 +29,10 @@ import (
 	proxyhandlers "github.com/AMD-AIG-AIMA/SAFE/apiserver/pkg/handlers/proxy-handlers"
 	reshandler "github.com/AMD-AIG-AIMA/SAFE/apiserver/pkg/handlers/resources"
 	sshhandler "github.com/AMD-AIG-AIMA/SAFE/apiserver/pkg/handlers/ssh-handlers"
+	mcpserver "github.com/AMD-AIG-AIMA/SAFE/common/pkg/mcp/server"
+	mcptools "github.com/AMD-AIG-AIMA/SAFE/apiserver/pkg/mcp/tools"
 	apiutils "github.com/AMD-AIG-AIMA/SAFE/apiserver/pkg/utils"
+	"github.com/AMD-AIG-AIMA/SAFE/apiserver/pkg/mcp/unified"
 	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/common"
 	commonconfig "github.com/AMD-AIG-AIMA/SAFE/common/pkg/config"
 	dbclient "github.com/AMD-AIG-AIMA/SAFE/common/pkg/database/client"
@@ -148,7 +152,79 @@ func InitHttpHandlers(_ context.Context, mgr ctrlruntime.Manager) (*gin.Engine, 
 	infxHandler := inferencexhandlers.NewHandler(24 * time.Hour)
 	inferencexhandlers.InitInferenceXRouters(engine, infxHandler)
 
+	// MCP (Model Context Protocol) server
+	if commonconfig.IsMCPEnable() {
+		initMCPRoutes(engine)
+	}
+
 	return engine, nil
+}
+
+// initMCPRoutes initializes MCP server routes under the configured base path.
+func initMCPRoutes(engine *gin.Engine) {
+	srv := mcpserver.New()
+
+	unifiedTools := unified.GetRegistry().GetMCPTools()
+	srv.RegisterTools(unifiedTools)
+	klog.Infof("MCP Server: Registered %d tools from unified registry", len(unifiedTools))
+
+	builtinTools := mcptools.RegisterAllTools()
+	srv.RegisterTools(builtinTools)
+	klog.Infof("MCP Server: Registered %d built-in tools", len(builtinTools))
+
+	if instructions := commonconfig.GetMCPInstructions(); instructions != "" {
+		srv.SetInstructions(instructions)
+	} else {
+		srv.SetInstructions("SaFE API Server - GPU Cluster Management Tools via MCP")
+	}
+
+	mountMCPRoutes(engine, srv, commonconfig.GetMCPBasePath())
+}
+
+// mountMCPRoutes mounts SSE / streamable HTTP / health / index endpoints for the
+// given MCP server under basePath. Exported for tests so they can verify the
+// routing layer without bringing up a full apiserver.
+func mountMCPRoutes(engine *gin.Engine, srv *mcpserver.Server, basePath string) {
+	if basePath == "" {
+		basePath = "/mcp"
+	}
+	cleanBase := strings.TrimRight(basePath, "/")
+
+	sseTransport := mcpserver.NewSSETransport(srv)
+	sseTransport.MessageEndpointPath = cleanBase + "/message"
+	streamableTransport := mcpserver.NewStreamableHTTPTransport(srv)
+
+	mcpGroup := engine.Group(basePath)
+	{
+		mcpGroup.GET("/sse", func(c *gin.Context) { sseTransport.HandleSSE(c.Writer, c.Request) })
+		mcpGroup.POST("/message", func(c *gin.Context) { sseTransport.HandleMessage(c.Writer, c.Request) })
+		mcpGroup.POST("/rpc", func(c *gin.Context) { streamableTransport.HandleRPC(c.Writer, c.Request) })
+
+		mcpGroup.GET("/health", func(c *gin.Context) {
+			c.JSON(200, gin.H{
+				"status":      "ok",
+				"server":      "SaFE MCP Server",
+				"version":     mcpserver.MCPVersion,
+				"total_tools": srv.ToolCount(),
+			})
+		})
+
+		mcpGroup.GET("/", func(c *gin.Context) {
+			toolNames := srv.GetToolNames()
+			c.JSON(200, gin.H{
+				"server":       "SaFE MCP Server",
+				"version":      mcpserver.MCPVersion,
+				"sse_endpoint": cleanBase + "/sse",
+				"rpc_endpoint": cleanBase + "/rpc",
+				"total_tools":  len(toolNames),
+				"tools":        toolNames,
+			})
+		})
+	}
+
+	klog.Infof("MCP Server: Routes registered under %s", basePath)
+	klog.Infof("MCP Server: SSE endpoint: %s/sse", cleanBase)
+	klog.Infof("MCP Server: RPC endpoint: %s/rpc (for testing)", cleanBase)
 }
 
 // InitModelHandlers initializes the model handlers for the API server.

--- a/SaFE/apiserver/pkg/handlers/handlers_mcp_test.go
+++ b/SaFE/apiserver/pkg/handlers/handlers_mcp_test.go
@@ -1,0 +1,242 @@
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+// See LICENSE for license information.
+
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	mcpserver "github.com/AMD-AIG-AIMA/SAFE/common/pkg/mcp/server"
+)
+
+// newTestEngineWithMCP returns a fresh Gin engine that has the given MCP server
+// mounted under basePath plus a minimal fake REST backend at /api/v1/echo that
+// echoes back the headers it received. Tests use the same engine as both the
+// MCP entrypoint and the REST backend so APICall loops back over loopback.
+func newTestEngineWithMCP(t *testing.T, srv *mcpserver.Server, basePath string) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.GET("/api/v1/echo", func(c *gin.Context) {
+		hdrs := map[string]string{}
+		for k, v := range c.Request.Header {
+			if len(v) > 0 {
+				hdrs[k] = v[0]
+			}
+		}
+		c.JSON(http.StatusOK, gin.H{"headers": hdrs, "ok": true})
+	})
+	mountMCPRoutes(engine, srv, basePath)
+	return engine
+}
+
+// doRPC issues a JSON-RPC POST against the MCP /rpc endpoint and decodes the response.
+func doRPC(t *testing.T, ts *httptest.Server, basePath string, payload any, headers map[string]string) (int, map[string]any) {
+	t.Helper()
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, ts.URL+strings.TrimRight(basePath, "/")+"/rpc", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	if len(raw) == 0 {
+		return resp.StatusCode, nil
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("decode response %q: %v", string(raw), err)
+	}
+	return resp.StatusCode, out
+}
+
+// TestMCPRoutes_DefaultBasePath verifies the four routes are reachable through Gin
+// when mounted under the default /mcp prefix.
+func TestMCPRoutes_DefaultBasePath(t *testing.T) {
+	srv := mcpserver.New()
+	ts := httptest.NewServer(newTestEngineWithMCP(t, srv, "/mcp"))
+	defer ts.Close()
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		body   io.Reader
+		want   int
+	}{
+		{"index", http.MethodGet, "/mcp/", nil, http.StatusOK},
+		{"health", http.MethodGet, "/mcp/health", nil, http.StatusOK},
+		{"rpc accepts POST", http.MethodPost, "/mcp/rpc", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping"}`), http.StatusOK},
+		{"message rejects missing session", http.MethodPost, "/mcp/message", strings.NewReader("{}"), http.StatusBadRequest},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req, err := http.NewRequest(c.method, ts.URL+c.path, c.body)
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			if c.body != nil {
+				req.Header.Set("Content-Type", "application/json")
+			}
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("do request: %v", err)
+			}
+			resp.Body.Close()
+			if resp.StatusCode != c.want {
+				t.Fatalf("%s: status = %d, want %d", c.path, resp.StatusCode, c.want)
+			}
+		})
+	}
+}
+
+// TestMCPRoutes_CustomBasePath verifies a custom mount path works end-to-end and
+// that the SSE "endpoint" event reflects that path (regression for the
+// previously hardcoded /mcp/message string).
+func TestMCPRoutes_CustomBasePath(t *testing.T) {
+	srv := mcpserver.New()
+	const basePath = "/api/v2/mcp"
+	ts := httptest.NewServer(newTestEngineWithMCP(t, srv, basePath))
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + basePath + "/health")
+	if err != nil {
+		t.Fatalf("GET health: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("custom base health: status = %d", resp.StatusCode)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+basePath+"/sse", nil)
+	if err != nil {
+		t.Fatalf("new sse request: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	req = req.WithContext(ctx)
+
+	sseResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET sse: %v", err)
+	}
+	defer sseResp.Body.Close()
+	if sseResp.StatusCode != http.StatusOK {
+		t.Fatalf("sse status = %d", sseResp.StatusCode)
+	}
+
+	buf := make([]byte, 1024)
+	n, _ := sseResp.Body.Read(buf)
+	cancel()
+
+	want := basePath + "/message?session_id="
+	if !strings.Contains(string(buf[:n]), want) {
+		t.Fatalf("sse endpoint event did not contain %q; got: %q", want, string(buf[:n]))
+	}
+}
+
+// TestMCPRoutes_RPCPing exercises the full RPC path through Gin and confirms
+// the JSON-RPC envelope is returned.
+func TestMCPRoutes_RPCPing(t *testing.T) {
+	srv := mcpserver.New()
+	ts := httptest.NewServer(newTestEngineWithMCP(t, srv, "/mcp"))
+	defer ts.Close()
+
+	status, out := doRPC(t, ts, "/mcp", map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "abc",
+		"method":  "ping",
+	}, nil)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d", status)
+	}
+	if got := out["jsonrpc"]; got != "2.0" {
+		t.Fatalf("jsonrpc = %v, want 2.0", got)
+	}
+	if got := out["id"]; got != "abc" {
+		t.Fatalf("id = %v, want abc", got)
+	}
+}
+
+// TestMCPRoutes_AuthHeaderForwarded registers a synthetic MCP tool that calls
+// our /api/v1/echo backend and asserts that an Authorization header sent on the
+// MCP RPC request is propagated all the way through APICall.
+func TestMCPRoutes_AuthHeaderForwarded(t *testing.T) {
+	srv := mcpserver.New()
+	srv.RegisterTool(&mcpserver.MCPTool{
+		Name:        "echo_headers",
+		Description: "test tool that hits the loopback echo backend",
+		InputSchema: map[string]any{"type": "object", "properties": map[string]any{}},
+		Handler: func(ctx context.Context, _ json.RawMessage) (any, error) {
+			inReq, _ := mcpserver.HTTPRequestFromContext(ctx)
+			if inReq == nil {
+				return nil, nil
+			}
+			url := "http://" + inReq.Host + "/api/v1/echo"
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+			if err != nil {
+				return nil, err
+			}
+			if v := inReq.Header.Get("Authorization"); v != "" {
+				req.Header.Set("Authorization", v)
+			}
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				return nil, err
+			}
+			defer resp.Body.Close()
+			b, _ := io.ReadAll(resp.Body)
+			var parsed map[string]any
+			_ = json.Unmarshal(b, &parsed)
+			return parsed, nil
+		},
+	})
+
+	ts := httptest.NewServer(newTestEngineWithMCP(t, srv, "/mcp"))
+	defer ts.Close()
+
+	const token = "Bearer test-token-xyz"
+	status, out := doRPC(t, ts, "/mcp", map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params":  map[string]any{"name": "echo_headers", "arguments": map[string]any{}},
+	}, map[string]string{"Authorization": token})
+
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, body = %v", status, out)
+	}
+
+	result, _ := out["result"].(map[string]any)
+	if result == nil {
+		t.Fatalf("missing result: %v", out)
+	}
+	contentSlice, _ := result["content"].([]any)
+	if len(contentSlice) == 0 {
+		t.Fatalf("empty content: %v", result)
+	}
+	first, _ := contentSlice[0].(map[string]any)
+	text, _ := first["text"].(string)
+	if !strings.Contains(text, token) {
+		t.Fatalf("expected Authorization %q to be forwarded; tool result text = %q", token, text)
+	}
+}

--- a/SaFE/apiserver/pkg/mcp/router/router.go
+++ b/SaFE/apiserver/pkg/mcp/router/router.go
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+// Package router wires the MCP server into the apiserver's Gin engine.
+// It exposes SSE, Streamable HTTP, health and index endpoints under the
+// configured base path (defaults to /api/v1/mcp).
+package router
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"k8s.io/klog/v2"
+
+	mcptools "github.com/AMD-AIG-AIMA/SAFE/apiserver/pkg/mcp/tools"
+	"github.com/AMD-AIG-AIMA/SAFE/apiserver/pkg/mcp/unified"
+	commonconfig "github.com/AMD-AIG-AIMA/SAFE/common/pkg/config"
+	mcpserver "github.com/AMD-AIG-AIMA/SAFE/common/pkg/mcp/server"
+)
+
+// defaultBasePath is used when mcp.base_path is unset.
+const defaultBasePath = "/api/v1/mcp"
+
+// InitRoutes builds an MCP server pre-loaded with the unified registry tools
+// plus the built-in tool set, then mounts it on engine under the configured
+// base path. Caller should gate this on commonconfig.IsMCPEnable().
+func InitRoutes(engine *gin.Engine) {
+	srv := mcpserver.New()
+
+	unifiedTools := unified.GetRegistry().GetMCPTools()
+	srv.RegisterTools(unifiedTools)
+	klog.Infof("MCP Server: Registered %d tools from unified registry", len(unifiedTools))
+
+	builtinTools := mcptools.RegisterAllTools()
+	srv.RegisterTools(builtinTools)
+	klog.Infof("MCP Server: Registered %d built-in tools", len(builtinTools))
+
+	if instructions := commonconfig.GetMCPInstructions(); instructions != "" {
+		srv.SetInstructions(instructions)
+	} else {
+		srv.SetInstructions("SaFE API Server - GPU Cluster Management Tools via MCP")
+	}
+
+	MountRoutes(engine, srv, commonconfig.GetMCPBasePath())
+}
+
+// MountRoutes mounts SSE / streamable HTTP / health / index endpoints for the
+// given MCP server under basePath. Exported so tests can verify the routing
+// layer without bringing up a full apiserver.
+func MountRoutes(engine *gin.Engine, srv *mcpserver.Server, basePath string) {
+	if basePath == "" {
+		basePath = defaultBasePath
+	}
+	cleanBase := strings.TrimRight(basePath, "/")
+
+	sseTransport := mcpserver.NewSSETransport(srv)
+	sseTransport.MessageEndpointPath = cleanBase + "/message"
+	streamableTransport := mcpserver.NewStreamableHTTPTransport(srv)
+
+	mcpGroup := engine.Group(basePath)
+	{
+		mcpGroup.GET("/sse", func(c *gin.Context) { sseTransport.HandleSSE(c.Writer, c.Request) })
+		mcpGroup.POST("/message", func(c *gin.Context) { sseTransport.HandleMessage(c.Writer, c.Request) })
+		mcpGroup.POST("/rpc", func(c *gin.Context) { streamableTransport.HandleRPC(c.Writer, c.Request) })
+
+		mcpGroup.GET("/health", func(c *gin.Context) {
+			c.JSON(200, gin.H{
+				"status":      "ok",
+				"server":      "SaFE MCP Server",
+				"version":     mcpserver.MCPVersion,
+				"total_tools": srv.ToolCount(),
+			})
+		})
+
+		mcpGroup.GET("/", func(c *gin.Context) {
+			toolNames := srv.GetToolNames()
+			c.JSON(200, gin.H{
+				"server":       "SaFE MCP Server",
+				"version":      mcpserver.MCPVersion,
+				"sse_endpoint": cleanBase + "/sse",
+				"rpc_endpoint": cleanBase + "/rpc",
+				"total_tools":  len(toolNames),
+				"tools":        toolNames,
+			})
+		})
+	}
+
+	klog.Infof("MCP Server: Routes registered under %s", basePath)
+	klog.Infof("MCP Server: SSE endpoint: %s/sse", cleanBase)
+	klog.Infof("MCP Server: RPC endpoint: %s/rpc (for testing)", cleanBase)
+}

--- a/SaFE/apiserver/pkg/mcp/router/router.go
+++ b/SaFE/apiserver/pkg/mcp/router/router.go
@@ -4,11 +4,25 @@
  */
 
 // Package router wires the MCP server into the apiserver's Gin engine.
-// It exposes SSE, Streamable HTTP, health and index endpoints under the
-// configured base path (defaults to /api/v1/mcp).
+//
+// Two transports are exposed under the configured base path
+// (defaults to /api/v1/mcp), aligned with the MCP specification:
+//
+//   - SSE transport (2024-11-05 spec):
+//       GET  {base}/sse       -> server-sent events stream
+//       POST {base}/messages  -> client-to-server messages (session_id query)
+//
+//   - Streamable HTTP transport (2025-03-26 spec):
+//       POST {base}           -> single request/response (or streamed) JSON-RPC
+//
+// Auxiliary endpoints:
+//
+//       GET  {base}/health    -> liveness check
+//       GET  {base}/info      -> human-readable server info & tool list
 package router
 
 import (
+	"net/http"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -46,9 +60,9 @@ func InitRoutes(engine *gin.Engine) {
 	MountRoutes(engine, srv, commonconfig.GetMCPBasePath())
 }
 
-// MountRoutes mounts SSE / streamable HTTP / health / index endpoints for the
-// given MCP server under basePath. Exported so tests can verify the routing
-// layer without bringing up a full apiserver.
+// MountRoutes mounts the standard MCP transport endpoints (SSE + Streamable
+// HTTP) plus health/info onto engine under basePath. Exported so tests can
+// verify the routing layer without bringing up a full apiserver.
 func MountRoutes(engine *gin.Engine, srv *mcpserver.Server, basePath string) {
 	if basePath == "" {
 		basePath = defaultBasePath
@@ -56,17 +70,27 @@ func MountRoutes(engine *gin.Engine, srv *mcpserver.Server, basePath string) {
 	cleanBase := strings.TrimRight(basePath, "/")
 
 	sseTransport := mcpserver.NewSSETransport(srv)
-	sseTransport.MessageEndpointPath = cleanBase + "/message"
+	sseTransport.MessageEndpointPath = cleanBase + "/messages"
 	streamableTransport := mcpserver.NewStreamableHTTPTransport(srv)
 
-	mcpGroup := engine.Group(basePath)
+	// Streamable HTTP transport: the base path itself is the endpoint per the
+	// 2025-03-26 spec. POST is the JSON-RPC endpoint; GET is reserved for
+	// optional server->client notifications (not implemented yet).
+	engine.POST(cleanBase, func(c *gin.Context) { streamableTransport.HandleRPC(c.Writer, c.Request) })
+	engine.GET(cleanBase, func(c *gin.Context) {
+		c.Header("Allow", "POST")
+		c.AbortWithStatus(http.StatusMethodNotAllowed)
+	})
+
+	mcpGroup := engine.Group(cleanBase)
 	{
+		// SSE transport (2024-11-05 spec): /sse opens the stream, /messages
+		// receives client-to-server JSON-RPC messages.
 		mcpGroup.GET("/sse", func(c *gin.Context) { sseTransport.HandleSSE(c.Writer, c.Request) })
-		mcpGroup.POST("/message", func(c *gin.Context) { sseTransport.HandleMessage(c.Writer, c.Request) })
-		mcpGroup.POST("/rpc", func(c *gin.Context) { streamableTransport.HandleRPC(c.Writer, c.Request) })
+		mcpGroup.POST("/messages", func(c *gin.Context) { sseTransport.HandleMessage(c.Writer, c.Request) })
 
 		mcpGroup.GET("/health", func(c *gin.Context) {
-			c.JSON(200, gin.H{
+			c.JSON(http.StatusOK, gin.H{
 				"status":      "ok",
 				"server":      "SaFE MCP Server",
 				"version":     mcpserver.MCPVersion,
@@ -74,20 +98,20 @@ func MountRoutes(engine *gin.Engine, srv *mcpserver.Server, basePath string) {
 			})
 		})
 
-		mcpGroup.GET("/", func(c *gin.Context) {
+		mcpGroup.GET("/info", func(c *gin.Context) {
 			toolNames := srv.GetToolNames()
-			c.JSON(200, gin.H{
-				"server":       "SaFE MCP Server",
-				"version":      mcpserver.MCPVersion,
-				"sse_endpoint": cleanBase + "/sse",
-				"rpc_endpoint": cleanBase + "/rpc",
-				"total_tools":  len(toolNames),
-				"tools":        toolNames,
+			c.JSON(http.StatusOK, gin.H{
+				"server":                  "SaFE MCP Server",
+				"version":                 mcpserver.MCPVersion,
+				"sse_endpoint":            cleanBase + "/sse",
+				"streamable_http_endpoint": cleanBase,
+				"total_tools":             len(toolNames),
+				"tools":                   toolNames,
 			})
 		})
 	}
 
-	klog.Infof("MCP Server: Routes registered under %s", basePath)
+	klog.Infof("MCP Server: Routes registered under %s", cleanBase)
+	klog.Infof("MCP Server: Streamable HTTP endpoint: %s", cleanBase)
 	klog.Infof("MCP Server: SSE endpoint: %s/sse", cleanBase)
-	klog.Infof("MCP Server: RPC endpoint: %s/rpc (for testing)", cleanBase)
 }

--- a/SaFE/apiserver/pkg/mcp/router/router.go
+++ b/SaFE/apiserver/pkg/mcp/router/router.go
@@ -69,9 +69,18 @@ func MountRoutes(engine *gin.Engine, srv *mcpserver.Server, basePath string) {
 	}
 	cleanBase := strings.TrimRight(basePath, "/")
 
+	allowedOrigins := commonconfig.GetMCPAllowedOrigins()
+
 	sseTransport := mcpserver.NewSSETransport(srv)
 	sseTransport.MessageEndpointPath = cleanBase + "/messages"
+	sseTransport.AllowedOrigins = allowedOrigins
 	streamableTransport := mcpserver.NewStreamableHTTPTransport(srv)
+	streamableTransport.AllowedOrigins = allowedOrigins
+	if len(allowedOrigins) > 0 {
+		klog.Infof("MCP Server: CORS allowed origins: %v", allowedOrigins)
+	} else {
+		klog.Infof("MCP Server: CORS disabled (same-origin only)")
+	}
 
 	// Streamable HTTP transport (2025-03-26): POST on the base path is the
 	// JSON-RPC endpoint.

--- a/SaFE/apiserver/pkg/mcp/router/router.go
+++ b/SaFE/apiserver/pkg/mcp/router/router.go
@@ -73,14 +73,14 @@ func MountRoutes(engine *gin.Engine, srv *mcpserver.Server, basePath string) {
 	sseTransport.MessageEndpointPath = cleanBase + "/messages"
 	streamableTransport := mcpserver.NewStreamableHTTPTransport(srv)
 
-	// Streamable HTTP transport: the base path itself is the endpoint per the
-	// 2025-03-26 spec. POST is the JSON-RPC endpoint; GET is reserved for
-	// optional server->client notifications (not implemented yet).
+	// Streamable HTTP transport (2025-03-26): POST on the base path is the
+	// JSON-RPC endpoint.
 	engine.POST(cleanBase, func(c *gin.Context) { streamableTransport.HandleRPC(c.Writer, c.Request) })
-	engine.GET(cleanBase, func(c *gin.Context) {
-		c.Header("Allow", "POST")
-		c.AbortWithStatus(http.StatusMethodNotAllowed)
-	})
+	// GET on the base path also opens an SSE stream so clients that treat the
+	// base URL as an SSE endpoint (e.g. Cursor's MCP client) work without
+	// pointing at the /sse subpath. This doubles as the "optional server->client
+	// notification stream" slot from the 2025-03-26 spec.
+	engine.GET(cleanBase, func(c *gin.Context) { sseTransport.HandleSSE(c.Writer, c.Request) })
 
 	mcpGroup := engine.Group(cleanBase)
 	{

--- a/SaFE/apiserver/pkg/mcp/router/router.go
+++ b/SaFE/apiserver/pkg/mcp/router/router.go
@@ -84,10 +84,15 @@ func MountRoutes(engine *gin.Engine, srv *mcpserver.Server, basePath string) {
 
 	mcpGroup := engine.Group(cleanBase)
 	{
-		// SSE transport (2024-11-05 spec): /sse opens the stream, /messages
-		// receives client-to-server JSON-RPC messages.
+		// SSE transport (2024-11-05 spec): GET /sse opens the stream,
+		// POST /messages receives client-to-server JSON-RPC messages.
 		mcpGroup.GET("/sse", func(c *gin.Context) { sseTransport.HandleSSE(c.Writer, c.Request) })
 		mcpGroup.POST("/messages", func(c *gin.Context) { sseTransport.HandleMessage(c.Writer, c.Request) })
+
+		// Cursor's MCP client probes Streamable HTTP by POSTing to {base}/sse
+		// before falling back to SSE. Mirror the base POST handler here so
+		// that probe succeeds and Cursor stays on Streamable HTTP.
+		mcpGroup.POST("/sse", func(c *gin.Context) { streamableTransport.HandleRPC(c.Writer, c.Request) })
 
 		mcpGroup.GET("/health", func(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{

--- a/SaFE/apiserver/pkg/mcp/router/router_test.go
+++ b/SaFE/apiserver/pkg/mcp/router/router_test.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
 // See LICENSE for license information.
 
-package handlers
+package router
 
 import (
 	"bytes"
@@ -35,7 +35,7 @@ func newTestEngineWithMCP(t *testing.T, srv *mcpserver.Server, basePath string) 
 		}
 		c.JSON(http.StatusOK, gin.H{"headers": hdrs, "ok": true})
 	})
-	mountMCPRoutes(engine, srv, basePath)
+	MountRoutes(engine, srv, basePath)
 	return engine
 }
 

--- a/SaFE/apiserver/pkg/mcp/router/router_test.go
+++ b/SaFE/apiserver/pkg/mcp/router/router_test.go
@@ -39,14 +39,15 @@ func newTestEngineWithMCP(t *testing.T, srv *mcpserver.Server, basePath string) 
 	return engine
 }
 
-// doRPC issues a JSON-RPC POST against the MCP /rpc endpoint and decodes the response.
+// doRPC issues a JSON-RPC POST against the MCP Streamable HTTP endpoint
+// (the base path itself per the 2025-03-26 spec) and decodes the response.
 func doRPC(t *testing.T, ts *httptest.Server, basePath string, payload any, headers map[string]string) (int, map[string]any) {
 	t.Helper()
 	body, err := json.Marshal(payload)
 	if err != nil {
 		t.Fatalf("marshal payload: %v", err)
 	}
-	req, err := http.NewRequest(http.MethodPost, ts.URL+strings.TrimRight(basePath, "/")+"/rpc", bytes.NewReader(body))
+	req, err := http.NewRequest(http.MethodPost, ts.URL+strings.TrimRight(basePath, "/"), bytes.NewReader(body))
 	if err != nil {
 		t.Fatalf("new request: %v", err)
 	}
@@ -70,8 +71,11 @@ func doRPC(t *testing.T, ts *httptest.Server, basePath string, payload any, head
 	return resp.StatusCode, out
 }
 
-// TestMCPRoutes_DefaultBasePath verifies the four routes are reachable through Gin
-// when mounted under the default /mcp prefix.
+// TestMCPRoutes_DefaultBasePath verifies the standard MCP endpoints are
+// reachable through Gin when mounted under the default /mcp prefix:
+//   - SSE transport: GET /mcp/sse, POST /mcp/messages
+//   - Streamable HTTP transport: POST /mcp (and GET /mcp -> 405)
+//   - Auxiliary: GET /mcp/health, GET /mcp/info
 func TestMCPRoutes_DefaultBasePath(t *testing.T) {
 	srv := mcpserver.New()
 	ts := httptest.NewServer(newTestEngineWithMCP(t, srv, "/mcp"))
@@ -84,10 +88,11 @@ func TestMCPRoutes_DefaultBasePath(t *testing.T) {
 		body   io.Reader
 		want   int
 	}{
-		{"index", http.MethodGet, "/mcp/", nil, http.StatusOK},
+		{"info", http.MethodGet, "/mcp/info", nil, http.StatusOK},
 		{"health", http.MethodGet, "/mcp/health", nil, http.StatusOK},
-		{"rpc accepts POST", http.MethodPost, "/mcp/rpc", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping"}`), http.StatusOK},
-		{"message rejects missing session", http.MethodPost, "/mcp/message", strings.NewReader("{}"), http.StatusBadRequest},
+		{"streamable HTTP accepts POST at base", http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping"}`), http.StatusOK},
+		{"streamable HTTP base rejects GET (no notification stream yet)", http.MethodGet, "/mcp", nil, http.StatusMethodNotAllowed},
+		{"messages rejects missing session", http.MethodPost, "/mcp/messages", strings.NewReader("{}"), http.StatusBadRequest},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -148,7 +153,7 @@ func TestMCPRoutes_CustomBasePath(t *testing.T) {
 	n, _ := sseResp.Body.Read(buf)
 	cancel()
 
-	want := basePath + "/message?session_id="
+	want := basePath + "/messages?session_id="
 	if !strings.Contains(string(buf[:n]), want) {
 		t.Fatalf("sse endpoint event did not contain %q; got: %q", want, string(buf[:n]))
 	}

--- a/SaFE/apiserver/pkg/mcp/router/router_test.go
+++ b/SaFE/apiserver/pkg/mcp/router/router_test.go
@@ -73,9 +73,10 @@ func doRPC(t *testing.T, ts *httptest.Server, basePath string, payload any, head
 
 // TestMCPRoutes_DefaultBasePath verifies the standard MCP endpoints are
 // reachable through Gin when mounted under the default /mcp prefix:
-//   - SSE transport: GET /mcp/sse, POST /mcp/messages
-//   - Streamable HTTP transport: POST /mcp (and GET /mcp -> 405)
-//   - Auxiliary: GET /mcp/health, GET /mcp/info
+//   - SSE transport: GET /mcp/sse and GET /mcp both open SSE streams,
+//     POST /mcp/messages receives client-to-server JSON-RPC.
+//   - Streamable HTTP transport: POST /mcp.
+//   - Auxiliary: GET /mcp/health, GET /mcp/info.
 func TestMCPRoutes_DefaultBasePath(t *testing.T) {
 	srv := mcpserver.New()
 	ts := httptest.NewServer(newTestEngineWithMCP(t, srv, "/mcp"))
@@ -91,7 +92,7 @@ func TestMCPRoutes_DefaultBasePath(t *testing.T) {
 		{"info", http.MethodGet, "/mcp/info", nil, http.StatusOK},
 		{"health", http.MethodGet, "/mcp/health", nil, http.StatusOK},
 		{"streamable HTTP accepts POST at base", http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping"}`), http.StatusOK},
-		{"streamable HTTP base rejects GET (no notification stream yet)", http.MethodGet, "/mcp", nil, http.StatusMethodNotAllowed},
+		{"GET on base opens SSE stream (Cursor compat)", http.MethodGet, "/mcp", nil, http.StatusOK},
 		{"messages rejects missing session", http.MethodPost, "/mcp/messages", strings.NewReader("{}"), http.StatusBadRequest},
 	}
 	for _, c := range cases {
@@ -156,6 +157,47 @@ func TestMCPRoutes_CustomBasePath(t *testing.T) {
 	want := basePath + "/messages?session_id="
 	if !strings.Contains(string(buf[:n]), want) {
 		t.Fatalf("sse endpoint event did not contain %q; got: %q", want, string(buf[:n]))
+	}
+}
+
+// TestMCPRoutes_GETBaseOpensSSE is a regression test for Cursor's MCP client
+// (and any other client that treats the configured base URL as an SSE
+// endpoint). Such clients GET the base path and expect an SSE stream whose
+// first "endpoint" event tells them where to POST messages. Returning 405 on
+// GET base would break those clients with "Session not found" because they'd
+// never get a session_id.
+func TestMCPRoutes_GETBaseOpensSSE(t *testing.T) {
+	srv := mcpserver.New()
+	const basePath = "/mcp"
+	ts := httptest.NewServer(newTestEngineWithMCP(t, srv, basePath))
+	defer ts.Close()
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+basePath, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	req = req.WithContext(ctx)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET base: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET base status = %d, want 200", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Content-Type"); !strings.HasPrefix(got, "text/event-stream") {
+		t.Fatalf("Content-Type = %q, want text/event-stream", got)
+	}
+
+	buf := make([]byte, 1024)
+	n, _ := resp.Body.Read(buf)
+	cancel()
+
+	want := basePath + "/messages?session_id="
+	if !strings.Contains(string(buf[:n]), want) {
+		t.Fatalf("endpoint event missing %q; got: %q", want, string(buf[:n]))
 	}
 }
 

--- a/SaFE/apiserver/pkg/mcp/router/router_test.go
+++ b/SaFE/apiserver/pkg/mcp/router/router_test.go
@@ -93,6 +93,7 @@ func TestMCPRoutes_DefaultBasePath(t *testing.T) {
 		{"health", http.MethodGet, "/mcp/health", nil, http.StatusOK},
 		{"streamable HTTP accepts POST at base", http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping"}`), http.StatusOK},
 		{"GET on base opens SSE stream (Cursor compat)", http.MethodGet, "/mcp", nil, http.StatusOK},
+		{"POST on /sse handled as Streamable HTTP (Cursor compat)", http.MethodPost, "/mcp/sse", strings.NewReader(`{"jsonrpc":"2.0","id":2,"method":"ping"}`), http.StatusOK},
 		{"messages rejects missing session", http.MethodPost, "/mcp/messages", strings.NewReader("{}"), http.StatusBadRequest},
 	}
 	for _, c := range cases {

--- a/SaFE/apiserver/pkg/mcp/tools/register.go
+++ b/SaFE/apiserver/pkg/mcp/tools/register.go
@@ -1,0 +1,278 @@
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+// See LICENSE for license information.
+
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/common"
+	mcpserver "github.com/AMD-AIG-AIMA/SAFE/common/pkg/mcp/server"
+)
+
+// APICall makes an internal HTTP request to the SaFE REST API, forwarding auth headers from the MCP context.
+func APICall(ctx context.Context, method, relPath string, body any) (any, error) {
+	inReq, ok := mcpserver.HTTPRequestFromContext(ctx)
+	if !ok {
+		return nil, fmt.Errorf("tools: incoming HTTP request missing from context; use ContextWithIncomingHTTP")
+	}
+	scheme := "http"
+	if inReq.TLS != nil || strings.EqualFold(inReq.Header.Get("X-Forwarded-Proto"), "https") {
+		scheme = "https"
+	}
+	base := scheme + "://" + inReq.Host
+	apiRoot := strings.TrimSuffix(base, "/") + "/" + strings.TrimPrefix(common.PrimusRouterCustomRootPath, "/")
+	if !strings.HasPrefix(relPath, "/") {
+		relPath = "/" + relPath
+	}
+	fullURL := apiRoot + relPath
+
+	var reader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		reader = bytes.NewReader(b)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, fullURL, reader)
+	if err != nil {
+		return nil, err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", common.JsonContentType)
+	}
+	for _, key := range []string{"Authorization", "Cookie", common.UserId, common.UserName} {
+		if v := inReq.Header.Get(key); v != "" {
+			req.Header.Set(key, v)
+		}
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("api %s %s: %s: %s", method, relPath, resp.Status, strings.TrimSpace(string(respBody)))
+	}
+	if len(respBody) == 0 {
+		return map[string]any{}, nil
+	}
+	var out any
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return out, nil
+}
+
+func parseParams(raw json.RawMessage) (map[string]any, error) {
+	if len(raw) == 0 {
+		return map[string]any{}, nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, err
+	}
+	if m == nil {
+		m = map[string]any{}
+	}
+	return m, nil
+}
+
+func getStr(m map[string]any, key string) string {
+	if m == nil {
+		return ""
+	}
+	v, ok := m[key]
+	if !ok || v == nil {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return fmt.Sprint(v)
+}
+
+func getInt(m map[string]any, key string) (int, bool) {
+	if m == nil {
+		return 0, false
+	}
+	v, ok := m[key]
+	if !ok || v == nil {
+		return 0, false
+	}
+	switch t := v.(type) {
+	case float64:
+		return int(t), true
+	case int:
+		return t, true
+	case int64:
+		return int(t), true
+	case json.Number:
+		i, err := t.Int64()
+		if err != nil {
+			return 0, false
+		}
+		return int(i), true
+	default:
+		return 0, false
+	}
+}
+
+func getBool(m map[string]any, key string) (bool, bool) {
+	if m == nil {
+		return false, false
+	}
+	v, ok := m[key]
+	if !ok || v == nil {
+		return false, false
+	}
+	switch t := v.(type) {
+	case bool:
+		return t, true
+	default:
+		return false, false
+	}
+}
+
+func getFloat(m map[string]any, key string) (float64, bool) {
+	if m == nil {
+		return 0, false
+	}
+	v, ok := m[key]
+	if !ok || v == nil {
+		return 0, false
+	}
+	switch t := v.(type) {
+	case float64:
+		return t, true
+	case int:
+		return float64(t), true
+	case int64:
+		return float64(t), true
+	case json.Number:
+		f, err := t.Float64()
+		if err != nil {
+			return 0, false
+		}
+		return f, true
+	default:
+		return 0, false
+	}
+}
+
+// buildQuery builds ?k=v using the same names as keys in p (for params whose query name matches the MCP argument name).
+func buildQuery(p map[string]any, keys ...string) string {
+	q := url.Values{}
+	for _, k := range keys {
+		if v, ok := p[k]; ok && v != nil {
+			if s, ok := scalarToQuery(v); ok {
+				q.Set(k, s)
+			}
+		}
+	}
+	if len(q) == 0 {
+		return ""
+	}
+	return "?" + q.Encode()
+}
+
+func scalarToQuery(v any) (string, bool) {
+	switch t := v.(type) {
+	case string:
+		return t, true
+	case bool:
+		return strconv.FormatBool(t), true
+	case float64:
+		return strconv.FormatInt(int64(t), 10), true
+	case int:
+		return strconv.Itoa(t), true
+	case int64:
+		return strconv.FormatInt(t, 10), true
+	case json.Number:
+		return t.String(), true
+	default:
+		return fmt.Sprint(t), true
+	}
+}
+
+func setQuery(q url.Values, p map[string]any, paramKey, apiKey string) {
+	if v, ok := p[paramKey]; ok && v != nil {
+		if s, ok := scalarToQuery(v); ok {
+			q.Set(apiKey, s)
+		}
+	}
+}
+
+// RegisterAllTools returns all MCP tools for the SaFE API server.
+func RegisterAllTools() []*mcpserver.MCPTool {
+	var tools []*mcpserver.MCPTool
+	tools = append(tools, clusterTools()...)
+	tools = append(tools, workspaceTools()...)
+	tools = append(tools, flavorTools()...)
+	tools = append(tools, nodeTools()...)
+	tools = append(tools, workloadTools()...)
+	tools = append(tools, opsjobTools()...)
+	tools = append(tools, apikeyTools()...)
+	return tools
+}
+
+func prop(typ, desc string) map[string]any {
+	return map[string]any{"type": typ, "description": desc}
+}
+
+func propEnum(typ, desc string, enum []string) map[string]any {
+	m := prop(typ, desc)
+	m["enum"] = enum
+	return m
+}
+
+// propArray builds an array schema. Call either propArray(items, desc) or propArray(desc, items) for legacy tools.
+func propArray(first any, second any) map[string]any {
+	switch f := first.(type) {
+	case string:
+		items, _ := second.(map[string]any)
+		if items == nil {
+			items = map[string]any{}
+		}
+		return map[string]any{"type": "array", "items": items, "description": f}
+	case map[string]any:
+		desc, _ := second.(string)
+		return map[string]any{"type": "array", "items": f, "description": desc}
+	default:
+		desc, _ := second.(string)
+		return map[string]any{"type": "array", "items": map[string]any{}, "description": desc}
+	}
+}
+
+// propObject builds an object schema. Use propObject(props, desc), or propObject(desc) with a single string for empty properties (legacy).
+func propObject(args ...any) map[string]any {
+	if len(args) == 1 {
+		if desc, ok := args[0].(string); ok {
+			return map[string]any{"type": "object", "properties": map[string]any{}, "description": desc}
+		}
+	}
+	props, _ := args[0].(map[string]any)
+	if props == nil {
+		props = map[string]any{}
+	}
+	desc := ""
+	if len(args) >= 2 {
+		desc, _ = args[1].(string)
+	}
+	return map[string]any{"type": "object", "properties": props, "description": desc}
+}

--- a/SaFE/apiserver/pkg/mcp/tools/register.go
+++ b/SaFE/apiserver/pkg/mcp/tools/register.go
@@ -14,9 +14,27 @@ import (
 	"strconv"
 	"strings"
 
+	"k8s.io/klog/v2"
+
 	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/common"
 	mcpserver "github.com/AMD-AIG-AIMA/SAFE/common/pkg/mcp/server"
 )
+
+// extractErrorCode pulls out the SaFE-style errorCode field from a REST error
+// body, returning "" if the body isn't recognisable JSON. Used by APICall to
+// surface a stable error identifier without echoing the full body to LLMs.
+func extractErrorCode(body []byte) string {
+	if len(body) == 0 {
+		return ""
+	}
+	var probe struct {
+		ErrorCode string `json:"errorCode"`
+	}
+	if err := json.Unmarshal(body, &probe); err != nil {
+		return ""
+	}
+	return probe.ErrorCode
+}
 
 // APICall makes an internal HTTP request to the SaFE REST API, forwarding auth headers from the MCP context.
 func APICall(ctx context.Context, method, relPath string, body any) (any, error) {
@@ -51,7 +69,13 @@ func APICall(ctx context.Context, method, relPath string, body any) (any, error)
 	if body != nil {
 		req.Header.Set("Content-Type", common.JsonContentType)
 	}
-	for _, key := range []string{"Authorization", "Cookie", common.UserId, common.UserName} {
+	// Only forward credential-bearing headers. Identity headers like
+	// common.UserId / common.UserName are NEVER copied from the inbound
+	// request: they are reserved for the apiserver's own auth middleware
+	// to inject server-side, and accepting them from external callers
+	// would let an MCP client impersonate any user when the deployment
+	// runs with user.token_required=false.
+	for _, key := range []string{"Authorization", "Cookie"} {
 		if v := inReq.Header.Get(key); v != "" {
 			req.Header.Set(key, v)
 		}
@@ -67,7 +91,15 @@ func APICall(ctx context.Context, method, relPath string, body any) (any, error)
 		return nil, err
 	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return nil, fmt.Errorf("api %s %s: %s: %s", method, relPath, resp.Status, strings.TrimSpace(string(respBody)))
+		// Don't echo the raw REST body to MCP clients (and therefore to LLM
+		// transcripts/logs): only pass through status + the apiserver's
+		// stable errorCode field. Full body still goes to klog for ops.
+		klog.Warningf("MCP APICall %s %s -> %s body=%s", method, relPath, resp.Status, strings.TrimSpace(string(respBody)))
+		errorCode := extractErrorCode(respBody)
+		if errorCode != "" {
+			return nil, fmt.Errorf("api %s %s: %s (%s)", method, relPath, resp.Status, errorCode)
+		}
+		return nil, fmt.Errorf("api %s %s: %s", method, relPath, resp.Status)
 	}
 	if len(respBody) == 0 {
 		return map[string]any{}, nil

--- a/SaFE/apiserver/pkg/mcp/tools/register.go
+++ b/SaFE/apiserver/pkg/mcp/tools/register.go
@@ -13,12 +13,25 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"k8s.io/klog/v2"
 
 	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/common"
 	mcpserver "github.com/AMD-AIG-AIMA/SAFE/common/pkg/mcp/server"
 )
+
+// apiCallTimeout caps how long a single MCP-driven REST call may take.
+// Without this, a slow downstream handler would let goroutines pile up
+// behind LLM clients that have already given up, eventually exhausting
+// the apiserver's resources. Overridable in tests via APICallClient.
+const apiCallTimeout = 30 * time.Second
+
+// APICallClient is the http.Client used by APICall. Exposed so that tests
+// or callers needing to tune transport behaviour (e.g. shorter timeout in
+// test) can swap it out. Never use http.DefaultClient here: that one has
+// no timeout at all.
+var APICallClient = &http.Client{Timeout: apiCallTimeout}
 
 // extractErrorCode pulls out the SaFE-style errorCode field from a REST error
 // body, returning "" if the body isn't recognisable JSON. Used by APICall to
@@ -81,7 +94,7 @@ func APICall(ctx context.Context, method, relPath string, body any) (any, error)
 		}
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := APICallClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/SaFE/apiserver/pkg/mcp/tools/register_test.go
+++ b/SaFE/apiserver/pkg/mcp/tools/register_test.go
@@ -13,6 +13,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/common"
 	mcpserver "github.com/AMD-AIG-AIMA/SAFE/common/pkg/mcp/server"
@@ -152,6 +153,70 @@ func TestAPICall_ErrorBodySanitised(t *testing.T) {
 	}
 	if strings.Contains(msg, "SELECT") || strings.Contains(msg, "abcd") || strings.Contains(msg, "errorMessage") {
 		t.Fatalf("raw body must NOT leak to caller, got: %v", err)
+	}
+}
+
+// TestAPICall_HonoursClientTimeout verifies that the package-level client
+// has a finite timeout, so a hung downstream handler doesn't leak goroutines
+// behind departed LLM clients.
+//
+// Intentionally NOT t.Parallel: this test mutates the package-level
+// APICallClient and restores it on exit, which would race other parallel
+// APICall tests that share the same global.
+func TestAPICall_HonoursClientTimeout(t *testing.T) {
+	origClient := APICallClient
+	APICallClient = &http.Client{Timeout: 50 * time.Millisecond}
+	defer func() { APICallClient = origClient }()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Sleep longer than the client timeout so the call must abort.
+		time.Sleep(500 * time.Millisecond)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	req := newFakeReq(t, srv.URL)
+	ctx := mcpserver.ContextWithHTTPRequest(context.Background(), req)
+	start := time.Now()
+	_, err := APICall(ctx, http.MethodGet, "/slow", nil)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if elapsed > 400*time.Millisecond {
+		t.Fatalf("call should fail fast around 50ms, took %v", elapsed)
+	}
+}
+
+// TestAPICall_HonoursContextCancel verifies APICall respects the caller's
+// ctx, so a client disconnect aborts the in-flight downstream call.
+func TestAPICall_HonoursContextCancel(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Wait for either the request ctx to die or 5s to pass.
+		select {
+		case <-r.Context().Done():
+		case <-time.After(5 * time.Second):
+		}
+	}))
+	defer srv.Close()
+
+	req := newFakeReq(t, srv.URL)
+	ctx, cancel := context.WithCancel(mcpserver.ContextWithHTTPRequest(context.Background(), req))
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		cancel()
+	}()
+	start := time.Now()
+	_, err := APICall(ctx, http.MethodGet, "/hang", nil)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error from cancelled ctx")
+	}
+	if elapsed > 1*time.Second {
+		t.Fatalf("call should abort with ctx around 30ms, took %v", elapsed)
 	}
 }
 

--- a/SaFE/apiserver/pkg/mcp/tools/register_test.go
+++ b/SaFE/apiserver/pkg/mcp/tools/register_test.go
@@ -1,0 +1,377 @@
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+// See LICENSE for license information.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/common"
+	mcpserver "github.com/AMD-AIG-AIMA/SAFE/common/pkg/mcp/server"
+)
+
+func TestAPICall_MissingHTTPRequest(t *testing.T) {
+	t.Parallel()
+	_, err := APICall(context.Background(), http.MethodGet, "/clusters", nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "incoming HTTP request") {
+		t.Fatalf("error %q should mention incoming HTTP request", err.Error())
+	}
+}
+
+func TestAPICall_SuccessfulGET(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method: got %q want GET", r.Method)
+		}
+		wantPath := "/" + common.PrimusRouterCustomRootPath + "/clusters"
+		if r.URL.Path != wantPath {
+			t.Errorf("path: got %q want %q", r.URL.Path, wantPath)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[1,2],"ok":true}`))
+	}))
+	defer srv.Close()
+
+	req := newFakeReq(t, srv.URL)
+	ctx := mcpserver.ContextWithHTTPRequest(context.Background(), req)
+	got, err := APICall(ctx, http.MethodGet, "/clusters", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]any{
+		"items": []any{float64(1), float64(2)},
+		"ok":    true,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %#v want %#v", got, want)
+	}
+}
+
+func TestAPICall_SuccessfulPOSTWithBody(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method: got %q want POST", r.Method)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != common.JsonContentType {
+			t.Errorf("Content-Type: got %q want %q", ct, common.JsonContentType)
+		}
+		b, _ := io.ReadAll(r.Body)
+		var body map[string]any
+		if err := json.Unmarshal(b, &body); err != nil {
+			t.Fatalf("body json: %v", err)
+		}
+		if body["hello"] != "world" {
+			t.Fatalf("body: %#v", body)
+		}
+		_, _ = w.Write([]byte(`{"created":true}`))
+	}))
+	defer srv.Close()
+
+	req := newFakeReq(t, srv.URL)
+	ctx := mcpserver.ContextWithHTTPRequest(context.Background(), req)
+	got, err := APICall(ctx, http.MethodPost, "/clusters", map[string]any{"hello": "world"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, map[string]any{"created": true}) {
+		t.Fatalf("got %#v", got)
+	}
+}
+
+func TestAPICall_ForwardsAuthorization(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.Header.Get("Authorization"), "Bearer secret-token"; got != want {
+			t.Errorf("Authorization: got %q want %q", got, want)
+		}
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	req := newFakeReq(t, srv.URL)
+	req.Header.Set("Authorization", "Bearer secret-token")
+	ctx := mcpserver.ContextWithHTTPRequest(context.Background(), req)
+	if _, err := APICall(ctx, http.MethodGet, "/x", nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAPICall_Non2xx(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	req := newFakeReq(t, srv.URL)
+	ctx := mcpserver.ContextWithHTTPRequest(context.Background(), req)
+	_, err := APICall(ctx, http.MethodGet, "/clusters", nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "400") {
+		t.Fatalf("error should contain status: %v", err)
+	}
+}
+
+func TestAPICall_Empty2xxBody(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	req := newFakeReq(t, srv.URL)
+	ctx := mcpserver.ContextWithHTTPRequest(context.Background(), req)
+	got, err := APICall(ctx, http.MethodGet, "/clusters", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, ok := got.(map[string]any)
+	if !ok || m == nil {
+		t.Fatalf("want non-nil map[string]any, got %#v", got)
+	}
+	if len(m) != 0 {
+		t.Fatalf("want empty map, got %#v", m)
+	}
+}
+
+func TestAPICall_XForwardedProtoUsesHTTPSURL(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("server should not receive plain request when client speaks TLS to wrong endpoint")
+	}))
+	defer srv.Close()
+
+	req := newFakeReq(t, srv.URL)
+	req.Header.Set("X-Forwarded-Proto", "https")
+	ctx := mcpserver.ContextWithHTTPRequest(context.Background(), req)
+	_, err := APICall(ctx, http.MethodGet, "/clusters", nil)
+	if err == nil {
+		t.Fatal("expected error connecting with https URL to plain HTTP server")
+	}
+	if !strings.Contains(err.Error(), "https://") {
+		t.Fatalf("error should mention https URL for debugging: %v", err)
+	}
+}
+
+func TestGetStr(t *testing.T) {
+	t.Parallel()
+	if got := getStr(nil, "k"); got != "" {
+		t.Fatalf("nil map: got %q", got)
+	}
+	m := map[string]any{"a": "x", "b": nil, "c": 42, "d": true}
+	if getStr(m, "missing") != "" {
+		t.Fatal()
+	}
+	if getStr(m, "b") != "" {
+		t.Fatal()
+	}
+	if getStr(m, "a") != "x" {
+		t.Fatal()
+	}
+	if getStr(m, "c") != "42" {
+		t.Fatalf("got %q", getStr(m, "c"))
+	}
+}
+
+func TestGetInt(t *testing.T) {
+	t.Parallel()
+	if _, ok := getInt(nil, "k"); ok {
+		t.Fatal()
+	}
+	m := map[string]any{
+		"f":     float64(3),
+		"i":     7,
+		"i64":   int64(9),
+		"jn":    json.Number("11"),
+		"jnBad": json.Number("abc"),
+		"jnF":   json.Number("2.5"),
+		"bad":   "x",
+		"nil":   nil,
+	}
+	testOk := func(key string, want int) {
+		t.Helper()
+		got, ok := getInt(m, key)
+		if !ok || got != want {
+			t.Fatalf("%s: got (%d,%v) want (%d,true)", key, got, ok, want)
+		}
+	}
+	testOk("f", 3)
+	testOk("i", 7)
+	testOk("i64", 9)
+	testOk("jn", 11)
+	if _, ok := getInt(m, "jnBad"); ok {
+		t.Fatal("jnBad should fail Int64")
+	}
+	if _, ok := getInt(m, "jnF"); ok {
+		t.Fatal("jnF should not be valid int")
+	}
+	if _, ok := getInt(m, "bad"); ok {
+		t.Fatal()
+	}
+	if _, ok := getInt(m, "nil"); ok {
+		t.Fatal()
+	}
+	if _, ok := getInt(m, "missing"); ok {
+		t.Fatal()
+	}
+}
+
+func TestGetBool(t *testing.T) {
+	t.Parallel()
+	if _, ok := getBool(nil, "k"); ok {
+		t.Fatal()
+	}
+	m := map[string]any{"t": true, "f": false, "s": "x", "nil": nil}
+	if b, ok := getBool(m, "t"); !ok || !b {
+		t.Fatal()
+	}
+	if b, ok := getBool(m, "f"); !ok || b {
+		t.Fatal()
+	}
+	if _, ok := getBool(m, "s"); ok {
+		t.Fatal()
+	}
+	if _, ok := getBool(m, "nil"); ok {
+		t.Fatal()
+	}
+}
+
+func TestGetFloat(t *testing.T) {
+	t.Parallel()
+	if _, ok := getFloat(nil, "k"); ok {
+		t.Fatal()
+	}
+	m := map[string]any{
+		"f":     float64(1.5),
+		"i":     2,
+		"i64":   int64(3),
+		"jn":    json.Number("4.25"),
+		"jnBad": json.Number("abc"),
+		"bad":   "x",
+		"nil":   nil,
+	}
+	testOk := func(key string, want float64) {
+		t.Helper()
+		got, ok := getFloat(m, key)
+		if !ok || got != want {
+			t.Fatalf("%s: got (%v,%v) want (%v,true)", key, got, ok, want)
+		}
+	}
+	testOk("f", 1.5)
+	testOk("i", 2)
+	testOk("i64", 3)
+	testOk("jn", 4.25)
+	if _, ok := getFloat(m, "jnBad"); ok {
+		t.Fatal()
+	}
+	if _, ok := getFloat(m, "bad"); ok {
+		t.Fatal()
+	}
+	if _, ok := getFloat(m, "nil"); ok {
+		t.Fatal()
+	}
+}
+
+func TestBuildQuery(t *testing.T) {
+	t.Parallel()
+	if got := buildQuery(nil, "a"); got != "" {
+		t.Fatalf("nil map: %q", got)
+	}
+	p := map[string]any{
+		"a": nil,
+		"b": "v2",
+		"c": true,
+		"d": float64(3),
+		"e": 4,
+		"f": int64(5),
+		"g": json.Number("6"),
+		"h": "only-this",
+	}
+	// keys b,c,d,e,f,g,h — a skipped (nil). Encode sorts: b,c,d,e,f,g,h
+	want := "?" + url.Values{
+		"b": {"v2"},
+		"c": {"true"},
+		"d": {"3"},
+		"e": {"4"},
+		"f": {"5"},
+		"g": {"6"},
+		"h": {"only-this"},
+	}.Encode()
+	if got := buildQuery(p, "a", "h", "g", "f", "e", "d", "c", "b"); got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+	if buildQuery(p) != "" {
+		t.Fatal()
+	}
+}
+
+func TestScalarToQueryAndSetQuery(t *testing.T) {
+	t.Parallel()
+	q := url.Values{}
+	setQuery(q, nil, "x", "apiX")
+	if len(q) != 0 {
+		t.Fatal()
+	}
+	p := map[string]any{"src": "v", "omit": nil}
+	setQuery(q, p, "missing", "api")
+	setQuery(q, p, "omit", "api")
+	setQuery(q, p, "src", "apiKey")
+	if q.Get("apiKey") != "v" || len(q) != 1 {
+		t.Fatalf("q: %v", q)
+	}
+	if s, ok := scalarToQuery("x"); !ok || s != "x" {
+		t.Fatal()
+	}
+}
+
+func TestParseParams(t *testing.T) {
+	t.Parallel()
+	m, err := parseParams(nil)
+	if err != nil || m == nil || len(m) != 0 {
+		t.Fatalf("nil raw: %#v %v", m, err)
+	}
+	m, err = parseParams(json.RawMessage(""))
+	if err != nil || m == nil || len(m) != 0 {
+		t.Fatalf("empty raw: %#v %v", m, err)
+	}
+	m, err = parseParams(json.RawMessage(`{"a":1}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a, ok := m["a"].(float64); !ok || a != 1 {
+		t.Fatalf("%#v", m)
+	}
+	if _, err := parseParams(json.RawMessage(`not json`)); err == nil {
+		t.Fatal()
+	}
+	m, err = parseParams(json.RawMessage(`null`))
+	if err != nil || m == nil || len(m) != 0 {
+		t.Fatalf("null: %#v %v", m, err)
+	}
+}
+
+func newFakeReq(t *testing.T, serverURL string) *http.Request {
+	t.Helper()
+	u, err := url.Parse(serverURL)
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/mcp/rpc", nil)
+	req.Host = u.Host
+	return req
+}

--- a/SaFE/apiserver/pkg/mcp/tools/register_test.go
+++ b/SaFE/apiserver/pkg/mcp/tools/register_test.go
@@ -127,6 +127,63 @@ func TestAPICall_Non2xx(t *testing.T) {
 	}
 }
 
+// TestAPICall_ErrorBodySanitised verifies that raw REST error bodies are
+// NOT echoed back to MCP/LLM callers. Only HTTP status and the apiserver's
+// errorCode field should reach the caller; secrets/PII in the body must stay
+// in server logs.
+func TestAPICall_ErrorBodySanitised(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"errorCode":"Primus.00007","errorMessage":"sql: SELECT * FROM users WHERE token='abcd'"}`))
+	}))
+	defer srv.Close()
+
+	req := newFakeReq(t, srv.URL)
+	ctx := mcpserver.ContextWithHTTPRequest(context.Background(), req)
+	_, err := APICall(ctx, http.MethodGet, "/secret", nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "403") || !strings.Contains(msg, "Primus.00007") {
+		t.Fatalf("error should expose status + errorCode, got: %v", err)
+	}
+	if strings.Contains(msg, "SELECT") || strings.Contains(msg, "abcd") || strings.Contains(msg, "errorMessage") {
+		t.Fatalf("raw body must NOT leak to caller, got: %v", err)
+	}
+}
+
+// TestAPICall_DropsIdentityHeaders verifies that client-controlled identity
+// headers (UserId/UserName) are NOT forwarded to the downstream REST API,
+// preventing identity spoofing when token validation is optional.
+func TestAPICall_DropsIdentityHeaders(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if v := r.Header.Get(common.UserId); v != "" {
+			t.Errorf("%s should NOT be forwarded, got %q", common.UserId, v)
+		}
+		if v := r.Header.Get(common.UserName); v != "" {
+			t.Errorf("%s should NOT be forwarded, got %q", common.UserName, v)
+		}
+		if v := r.Header.Get("Authorization"); v != "Bearer ok" {
+			t.Errorf("Authorization should be forwarded, got %q", v)
+		}
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	req := newFakeReq(t, srv.URL)
+	req.Header.Set("Authorization", "Bearer ok")
+	req.Header.Set(common.UserId, "attacker-uid")
+	req.Header.Set(common.UserName, "root")
+	ctx := mcpserver.ContextWithHTTPRequest(context.Background(), req)
+	if _, err := APICall(ctx, http.MethodGet, "/x", nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestAPICall_Empty2xxBody(t *testing.T) {
 	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/SaFE/apiserver/pkg/mcp/tools/tools_apikey.go
+++ b/SaFE/apiserver/pkg/mcp/tools/tools_apikey.go
@@ -1,0 +1,130 @@
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+// See LICENSE for license information.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	mcpserver "github.com/AMD-AIG-AIMA/SAFE/common/pkg/mcp/server"
+)
+
+func apikeyTools() []*mcpserver.MCPTool {
+	return []*mcpserver.MCPTool{
+		apikeyCurrent(), apikeyList(), apikeyCreate(), apikeyDelete(),
+	}
+}
+
+func apikeyCurrent() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "apikey_current",
+		Description: "Get information about the API Key currently being used for authentication",
+		InputSchema: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			_, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			return APICall(ctx, http.MethodGet, "/apikeys/current", nil)
+		},
+	}
+}
+
+func apikeyList() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "apikey_list",
+		Description: "List all API Keys for the authenticated user",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"name":  prop("string", "Filter by name (partial match, case-insensitive)"),
+				"limit": prop("integer", "Records per page, default 100"),
+			},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			q := url.Values{}
+			setQuery(q, p, "name", "name")
+			setQuery(q, p, "limit", "limit")
+			suffix := ""
+			if len(q) > 0 {
+				suffix = "?" + q.Encode()
+			}
+			return APICall(ctx, http.MethodGet, "/apikeys"+suffix, nil)
+		},
+	}
+}
+
+func apikeyCreate() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "apikey_create",
+		Description: "Create a new API Key. The key value is only returned once during creation - store it securely!",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"name":      prop("string", "Display name for the API Key (max 100 characters)"),
+				"ttl_days":  prop("integer", "Validity period in days (1-366)"),
+				"whitelist": propArray(prop("string", ""), "List of allowed IP addresses or CIDR ranges (optional)"),
+			},
+			"required": []string{"name", "ttl_days"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			if getStr(p, "name") == "" {
+				return nil, fmt.Errorf("name is required")
+			}
+			ttl, ok := getInt(p, "ttl_days")
+			if !ok {
+				return nil, fmt.Errorf("ttl_days is required")
+			}
+			body := map[string]any{
+				"name":    getStr(p, "name"),
+				"ttlDays": ttl,
+			}
+			if wl, ok := p["whitelist"]; ok && wl != nil {
+				body["whitelist"] = wl
+			}
+			return APICall(ctx, http.MethodPost, "/apikeys", body)
+		},
+	}
+}
+
+func apikeyDelete() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "apikey_delete",
+		Description: "Delete an API Key (soft deletion). The key cannot be recovered after deletion.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"apikey_id": prop("integer", "API Key ID (numeric)"),
+			},
+			"required": []string{"apikey_id"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			id, ok := getInt(p, "apikey_id")
+			if !ok {
+				return nil, fmt.Errorf("apikey_id is required")
+			}
+			path := "/apikeys/" + url.PathEscape(strconv.Itoa(id))
+			return APICall(ctx, http.MethodDelete, path, nil)
+		},
+	}
+}

--- a/SaFE/apiserver/pkg/mcp/tools/tools_cluster.go
+++ b/SaFE/apiserver/pkg/mcp/tools/tools_cluster.go
@@ -1,0 +1,195 @@
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+// See LICENSE for license information.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	mcpserver "github.com/AMD-AIG-AIMA/SAFE/common/pkg/mcp/server"
+)
+
+func clusterTools() []*mcpserver.MCPTool {
+	return []*mcpserver.MCPTool{
+		clusterList(),
+		clusterGet(),
+		clusterCreate(),
+		clusterUpdate(),
+		clusterDelete(),
+		clusterManageNodes(),
+		clusterLogs(),
+	}
+}
+
+func clusterList() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "cluster_list",
+		Description: "List all available clusters. Must call this tool to get cluster_id before creating a workspace.",
+		InputSchema: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			return APICall(ctx, http.MethodGet, "/clusters", nil)
+		},
+	}
+}
+
+func clusterGet() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "cluster_get",
+		Description: "Get detailed information of a specific cluster, including endpoint, node list, Kubernetes version, etc.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"cluster_id": prop("string", "Cluster ID"),
+			},
+			"required": []string{"cluster_id"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			return APICall(ctx, http.MethodGet, fmt.Sprintf("/clusters/%s", getStr(p, "cluster_id")), nil)
+		},
+	}
+}
+
+func clusterCreate() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "cluster_create",
+		Description: "Create a new Kubernetes cluster",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"name":                 prop("string", "Cluster name (unique identifier)"),
+				"nodes":                propArray("Control plane node ID list", map[string]any{"type": "string"}),
+				"ssh_secret_id":        prop("string", "SSH secret ID"),
+				"kube_spray_image":     prop("string", "KubeSpray image address"),
+				"kube_pods_subnet":     prop("string", "Pod subnet, e.g. '10.0.0.0/16'"),
+				"kube_service_address": prop("string", "Service address range, e.g. '10.96.0.0/16'"),
+				"kube_version":         prop("string", "Kubernetes version, e.g. '1.32.5'"),
+				"description":          prop("string", "Cluster description (optional)"),
+				"image_secret_id":      prop("string", "Image registry secret ID (optional)"),
+				"kube_network_plugin":  propEnum("string", "Network plugin, default 'flannel'", []string{"flannel", "calico", "cilium"}),
+				"kube_api_server_args": propObject("API Server extra arguments (optional)"),
+				"labels":               propObject("Cluster labels (optional)"),
+				"is_protected":         prop("boolean", "Whether to protect the cluster, default false"),
+			},
+			"required": []string{"name", "nodes", "ssh_secret_id", "kube_spray_image", "kube_pods_subnet", "kube_service_address", "kube_version"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			return APICall(ctx, http.MethodPost, "/clusters", p)
+		},
+	}
+}
+
+func clusterUpdate() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "cluster_update",
+		Description: "Update cluster configuration (currently only supports modifying protection status)",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"cluster_id":   prop("string", "Cluster ID"),
+				"is_protected": prop("boolean", "Whether to protect the cluster"),
+			},
+			"required": []string{"cluster_id"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			id := getStr(p, "cluster_id")
+			delete(p, "cluster_id")
+			return APICall(ctx, http.MethodPatch, fmt.Sprintf("/clusters/%s", id), p)
+		},
+	}
+}
+
+func clusterDelete() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "cluster_delete",
+		Description: "Delete a cluster. Note: cluster must not be protected and have no running workloads",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"cluster_id": prop("string", "Cluster ID"),
+			},
+			"required": []string{"cluster_id"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			return APICall(ctx, http.MethodDelete, fmt.Sprintf("/clusters/%s", getStr(p, "cluster_id")), nil)
+		},
+	}
+}
+
+func clusterManageNodes() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "cluster_manage_nodes",
+		Description: "Manage cluster nodes (add or remove nodes)",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"cluster_id": prop("string", "Cluster ID"),
+				"node_ids":   propArray("Node ID list", map[string]any{"type": "string"}),
+				"action":     propEnum("string", "Action type", []string{"add", "remove"}),
+			},
+			"required": []string{"cluster_id", "node_ids", "action"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			id := getStr(p, "cluster_id")
+			delete(p, "cluster_id")
+			return APICall(ctx, http.MethodPost, fmt.Sprintf("/clusters/%s/nodes", id), p)
+		},
+	}
+}
+
+func clusterLogs() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "cluster_logs",
+		Description: "Get cluster creation/operation logs",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"cluster_id":    prop("string", "Cluster ID"),
+				"tail_lines":    prop("integer", "Return last N lines of logs, default 1000"),
+				"since_seconds": prop("integer", "Return logs from last N seconds (optional)"),
+			},
+			"required": []string{"cluster_id"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			id := getStr(p, "cluster_id")
+			q := url.Values{}
+			setQuery(q, p, "tail_lines", "tailLines")
+			setQuery(q, p, "since_seconds", "sinceSeconds")
+			qs := ""
+			if len(q) > 0 {
+				qs = "?" + q.Encode()
+			}
+			return APICall(ctx, http.MethodGet, fmt.Sprintf("/clusters/%s/logs%s", id, qs), nil)
+		},
+	}
+}

--- a/SaFE/apiserver/pkg/mcp/tools/tools_flavor.go
+++ b/SaFE/apiserver/pkg/mcp/tools/tools_flavor.go
@@ -1,0 +1,55 @@
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+// See LICENSE for license information.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	mcpserver "github.com/AMD-AIG-AIMA/SAFE/common/pkg/mcp/server"
+)
+
+func flavorTools() []*mcpserver.MCPTool {
+	return []*mcpserver.MCPTool{
+		flavorList(),
+		flavorGet(),
+	}
+}
+
+func flavorList() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "flavor_list",
+		Description: "List all available node flavors. Must call this tool to get flavor_id before creating a workspace.",
+		InputSchema: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			return APICall(ctx, http.MethodGet, "/nodeflavors", nil)
+		},
+	}
+}
+
+func flavorGet() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "flavor_get",
+		Description: "Get detailed information of a specific node flavor",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"flavor_id": prop("string", "Node flavor ID"),
+			},
+			"required": []string{"flavor_id"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			return APICall(ctx, http.MethodGet, fmt.Sprintf("/nodeflavors/%s", getStr(p, "flavor_id")), nil)
+		},
+	}
+}

--- a/SaFE/apiserver/pkg/mcp/tools/tools_node.go
+++ b/SaFE/apiserver/pkg/mcp/tools/tools_node.go
@@ -194,13 +194,12 @@ func nodeUpdate() *mcpserver.MCPTool {
 func nodeDelete() *mcpserver.MCPTool {
 	return &mcpserver.MCPTool{
 		Name:        "node_delete",
-		Description: "Delete a node",
+		Description: "Delete a node. Set force=true to bypass safety checks. Drain/grace-period are not supported by the SaFE REST API and are intentionally not exposed here.",
 		InputSchema: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
-				"node_id":      prop("string", "Node ID/name"),
-				"drain":        prop("boolean", "Whether to drain workloads first, default true"),
-				"grace_period": prop("integer", "Grace period in seconds"),
+				"node_id": prop("string", "Node ID/name"),
+				"force":   prop("boolean", "Bypass safety checks (default false). Maps to ?force= on the REST call."),
 			},
 			"required": []string{"node_id"},
 		},
@@ -214,11 +213,8 @@ func nodeDelete() *mcpserver.MCPTool {
 				return nil, fmt.Errorf("node_id is required")
 			}
 			q := url.Values{}
-			if drain, ok := getBool(p, "drain"); ok {
-				q.Set("force", strconv.FormatBool(drain))
-			}
-			if gp, ok := getInt(p, "grace_period"); ok {
-				q.Set("gracePeriod", strconv.Itoa(gp))
+			if force, ok := getBool(p, "force"); ok {
+				q.Set("force", strconv.FormatBool(force))
 			}
 			suffix := ""
 			if len(q) > 0 {

--- a/SaFE/apiserver/pkg/mcp/tools/tools_node.go
+++ b/SaFE/apiserver/pkg/mcp/tools/tools_node.go
@@ -1,0 +1,454 @@
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+// See LICENSE for license information.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	mcpserver "github.com/AMD-AIG-AIMA/SAFE/common/pkg/mcp/server"
+)
+
+func nodeTools() []*mcpserver.MCPTool {
+	return []*mcpserver.MCPTool{
+		nodeList(), nodeGet(), nodeCreate(), nodeUpdate(), nodeDelete(),
+		nodeStatus(), nodeCordon(), nodeUncordon(), nodeDrain(),
+		nodeReboot(), nodeRebootLogs(), nodeExport(),
+	}
+}
+
+func nodeList() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "node_list",
+		Description: "List nodes with multiple filter options",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"cluster_id":   prop("string", "Filter by cluster ID (empty string for unbound nodes)"),
+				"workspace_id": prop("string", "Filter by workspace ID"),
+				"flavor_id":    prop("string", "Filter by node flavor"),
+				"node_id":      prop("string", "Filter by node ID"),
+				"available":    prop("boolean", "Filter by availability"),
+				"phase":        prop("string", "Filter by phase (Ready/SSHFailed/Managing/etc.)"),
+				"brief":        prop("boolean", "Brief mode, return basic info only"),
+				"limit":        prop("integer", "Items per page, default 100, -1 for all"),
+			},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			q := url.Values{}
+			setQuery(q, p, "cluster_id", "clusterId")
+			setQuery(q, p, "workspace_id", "workspaceId")
+			setQuery(q, p, "flavor_id", "flavorId")
+			setQuery(q, p, "node_id", "nodeId")
+			setQuery(q, p, "available", "available")
+			setQuery(q, p, "phase", "phase")
+			setQuery(q, p, "brief", "brief")
+			setQuery(q, p, "limit", "limit")
+			suffix := ""
+			if len(q) > 0 {
+				suffix = "?" + q.Encode()
+			}
+			return APICall(ctx, http.MethodGet, "/nodes"+suffix, nil)
+		},
+	}
+}
+
+func nodeGet() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "node_get",
+		Description: "Get detailed information of a specific node",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"node_id": prop("string", "Node ID/name"),
+			},
+			"required": []string{"node_id"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			id := getStr(p, "node_id")
+			if id == "" {
+				return nil, fmt.Errorf("node_id is required")
+			}
+			return APICall(ctx, http.MethodGet, "/nodes/"+url.PathEscape(id), nil)
+		},
+	}
+}
+
+func nodeCreate() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "node_create",
+		Description: "Register a new node to the system",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"private_ip":    prop("string", "Node private IP (required)"),
+				"flavor_id":     prop("string", "Node flavor ID (required, get from flavor_list)"),
+				"template_id":   prop("string", "Node template ID (required)"),
+				"ssh_secret_id": prop("string", "SSH secret ID (required)"),
+				"hostname":      prop("string", "Node hostname (optional, defaults to private_ip)"),
+				"public_ip":     prop("string", "Node public IP (optional)"),
+				"port":          prop("integer", "SSH port, default 22"),
+				"labels":        propObject(map[string]any{}, "Node labels (optional)"),
+			},
+			"required": []string{"private_ip", "flavor_id", "template_id", "ssh_secret_id"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			if getStr(p, "private_ip") == "" || getStr(p, "flavor_id") == "" || getStr(p, "template_id") == "" || getStr(p, "ssh_secret_id") == "" {
+				return nil, fmt.Errorf("private_ip, flavor_id, template_id, and ssh_secret_id are required")
+			}
+			body := map[string]any{
+				"privateIP":   getStr(p, "private_ip"),
+				"flavorId":    getStr(p, "flavor_id"),
+				"templateId":  getStr(p, "template_id"),
+				"sshSecretId": getStr(p, "ssh_secret_id"),
+			}
+			if pub := getStr(p, "public_ip"); pub != "" {
+				body["publicIP"] = pub
+			}
+			if h := getStr(p, "hostname"); h != "" {
+				body["hostname"] = h
+			}
+			if port, ok := getInt(p, "port"); ok {
+				body["port"] = int32(port)
+			}
+			if labels, ok := p["labels"]; ok && labels != nil {
+				body["labels"] = labels
+			}
+			return APICall(ctx, http.MethodPost, "/nodes", body)
+		},
+	}
+}
+
+func nodeUpdate() *mcpserver.MCPTool {
+	taintsItem := propObject(map[string]any{
+		"key":    prop("string", ""),
+		"value":  prop("string", ""),
+		"effect": propEnum("string", "", []string{"NoSchedule", "PreferNoSchedule", "NoExecute"}),
+	}, "")
+	return &mcpserver.MCPTool{
+		Name:        "node_update",
+		Description: "Update node configuration (labels, taints, flavor, etc.)",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"node_id":     prop("string", "Node ID"),
+				"labels":      propObject(map[string]any{}, "Node labels dictionary"),
+				"taints":      propArray(taintsItem, "Taints list"),
+				"flavor_id":   prop("string", "New node flavor ID"),
+				"template_id": prop("string", "New node template ID"),
+				"private_ip":  prop("string", "New private IP"),
+				"port":        prop("integer", "New SSH port"),
+			},
+			"required": []string{"node_id"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			id := getStr(p, "node_id")
+			if id == "" {
+				return nil, fmt.Errorf("node_id is required")
+			}
+			body := map[string]any{}
+			if _, ok := p["labels"]; ok {
+				body["labels"] = p["labels"]
+			}
+			if _, ok := p["taints"]; ok {
+				body["taints"] = p["taints"]
+			}
+			if v := getStr(p, "flavor_id"); v != "" {
+				body["flavorId"] = v
+			}
+			if v := getStr(p, "template_id"); v != "" {
+				body["templateId"] = v
+			}
+			if v := getStr(p, "private_ip"); v != "" {
+				body["privateIP"] = v
+			}
+			if port, ok := getInt(p, "port"); ok {
+				body["port"] = int32(port)
+			}
+			return APICall(ctx, http.MethodPatch, "/nodes/"+url.PathEscape(id), body)
+		},
+	}
+}
+
+func nodeDelete() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "node_delete",
+		Description: "Delete a node",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"node_id":      prop("string", "Node ID/name"),
+				"drain":        prop("boolean", "Whether to drain workloads first, default true"),
+				"grace_period": prop("integer", "Grace period in seconds"),
+			},
+			"required": []string{"node_id"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			id := getStr(p, "node_id")
+			if id == "" {
+				return nil, fmt.Errorf("node_id is required")
+			}
+			q := url.Values{}
+			if drain, ok := getBool(p, "drain"); ok {
+				q.Set("force", strconv.FormatBool(drain))
+			}
+			if gp, ok := getInt(p, "grace_period"); ok {
+				q.Set("gracePeriod", strconv.Itoa(gp))
+			}
+			suffix := ""
+			if len(q) > 0 {
+				suffix = "?" + q.Encode()
+			}
+			return APICall(ctx, http.MethodDelete, "/nodes/"+url.PathEscape(id)+suffix, nil)
+		},
+	}
+}
+
+func nodeStatus() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "node_status",
+		Description: "Get node status information (ready status, capacity, conditions, etc.)",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"node_id": prop("string", "Node ID/name"),
+			},
+			"required": []string{"node_id"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			id := getStr(p, "node_id")
+			if id == "" {
+				return nil, fmt.Errorf("node_id is required")
+			}
+			return APICall(ctx, http.MethodGet, "/nodes/"+url.PathEscape(id), nil)
+		},
+	}
+}
+
+func nodeCordon() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "node_cordon",
+		Description: "Mark node as unschedulable (cordon), prevent new Pods from being scheduled to this node",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"node_id": prop("string", "Node ID/name"),
+			},
+			"required": []string{"node_id"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			id := getStr(p, "node_id")
+			if id == "" {
+				return nil, fmt.Errorf("node_id is required")
+			}
+			return APICall(ctx, http.MethodPatch, "/nodes/"+url.PathEscape(id), map[string]any{"unschedulable": true})
+		},
+	}
+}
+
+func nodeUncordon() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "node_uncordon",
+		Description: "Remove unschedulable mark from node (uncordon), allow new Pods to be scheduled to this node",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"node_id": prop("string", "Node ID/name"),
+			},
+			"required": []string{"node_id"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			id := getStr(p, "node_id")
+			if id == "" {
+				return nil, fmt.Errorf("node_id is required")
+			}
+			return APICall(ctx, http.MethodPatch, "/nodes/"+url.PathEscape(id), map[string]any{"unschedulable": false})
+		},
+	}
+}
+
+func nodeDrain() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "node_drain",
+		Description: "Drain all workloads from a node",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"node_id":             prop("string", "Node ID/name"),
+				"force":               prop("boolean", "Whether to force drain, default false"),
+				"ignore_daemonsets":   prop("boolean", "Whether to ignore DaemonSets, default true"),
+				"timeout":             prop("integer", "Timeout in seconds"),
+			},
+			"required": []string{"node_id"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			id := getStr(p, "node_id")
+			if id == "" {
+				return nil, fmt.Errorf("node_id is required")
+			}
+			body := map[string]any{"drain": true}
+			if b, ok := getBool(p, "force"); ok {
+				body["force"] = b
+			}
+			if b, ok := getBool(p, "ignore_daemonsets"); ok {
+				body["ignoreDaemonsets"] = b
+			}
+			if n, ok := getInt(p, "timeout"); ok {
+				body["timeout"] = n
+			}
+			return APICall(ctx, http.MethodPatch, "/nodes/"+url.PathEscape(id), body)
+		},
+	}
+}
+
+func nodeReboot() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "node_reboot",
+		Description: "Reboot a node (via OpsJob)",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"node_id":  prop("string", "Node ID"),
+				"job_name": prop("string", "Job name, default 'reboot-node'"),
+			},
+			"required": []string{"node_id"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			id := getStr(p, "node_id")
+			if id == "" {
+				return nil, fmt.Errorf("node_id is required")
+			}
+			jobName := getStr(p, "job_name")
+			if jobName == "" {
+				jobName = "reboot-node"
+			}
+			body := map[string]any{
+				"name": jobName,
+				"type": "reboot",
+				"inputs": []map[string]any{
+					{"name": "node", "value": id},
+				},
+			}
+			return APICall(ctx, http.MethodPost, "/opsjobs", body)
+		},
+	}
+}
+
+func nodeRebootLogs() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "node_reboot_logs",
+		Description: "Get node reboot history logs",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"node_id":    prop("string", "Node ID"),
+				"since_time": prop("string", "Start time filter (RFC3339 format)"),
+				"until_time": prop("string", "End time filter (RFC3339 format)"),
+				"limit":      prop("integer", "Items per page, default 100"),
+			},
+			"required": []string{"node_id"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			id := getStr(p, "node_id")
+			if id == "" {
+				return nil, fmt.Errorf("node_id is required")
+			}
+			q := url.Values{}
+			setQuery(q, p, "since_time", "sinceTime")
+			setQuery(q, p, "until_time", "untilTime")
+			setQuery(q, p, "limit", "limit")
+			suffix := ""
+			if len(q) > 0 {
+				suffix = "?" + q.Encode()
+			}
+			return APICall(ctx, http.MethodGet, "/nodes/"+url.PathEscape(id)+"/reboot/logs"+suffix, nil)
+		},
+	}
+}
+
+func nodeExport() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "node_export",
+		Description: "Export nodes list with multiple filtering options",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"cluster_id":          prop("string", "Filter by cluster ID"),
+				"workspace_id":        prop("string", "Filter by workspace ID"),
+				"flavor_id":           prop("string", "Filter by node flavor ID"),
+				"node_id":             prop("string", "Filter by node ID"),
+				"available":           prop("boolean", "Filter by availability: true (available) / false (unavailable)"),
+				"phase":               prop("string", "Filter by status (comma-separated, e.g. Ready,SSHFailed,Managing)"),
+				"is_addons_installed": prop("boolean", "Filter by addon installation status"),
+			},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			q := url.Values{}
+			setQuery(q, p, "cluster_id", "clusterId")
+			setQuery(q, p, "workspace_id", "workspaceId")
+			setQuery(q, p, "flavor_id", "flavorId")
+			setQuery(q, p, "node_id", "nodeId")
+			setQuery(q, p, "available", "available")
+			setQuery(q, p, "phase", "phase")
+			setQuery(q, p, "is_addons_installed", "isAddonsInstalled")
+			suffix := ""
+			if len(q) > 0 {
+				suffix = "?" + q.Encode()
+			}
+			return APICall(ctx, http.MethodGet, "/nodes/export"+suffix, nil)
+		},
+	}
+}

--- a/SaFE/apiserver/pkg/mcp/tools/tools_opsjob.go
+++ b/SaFE/apiserver/pkg/mcp/tools/tools_opsjob.go
@@ -1,0 +1,271 @@
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+// See LICENSE for license information.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	mcpserver "github.com/AMD-AIG-AIMA/SAFE/common/pkg/mcp/server"
+)
+
+func opsjobTools() []*mcpserver.MCPTool {
+	return []*mcpserver.MCPTool{
+		opsjobList(), opsjobGet(), opsjobCreate(), opsjobStop(), opsjobDelete(),
+	}
+}
+
+func opsjobInputItemSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"name":  prop("string", "Selector name: node, addon.template, workload, workspace, cluster, node.template, node.host, image, script, secret, endpoint, dest.path, label"),
+			"value": prop("string", "Selector value (e.g. nodeId, workloadId, workspaceId)"),
+		},
+		"required": []string{"name", "value"},
+	}
+}
+
+func opsjobResourceSchema() map[string]any {
+	return propObject(map[string]any{
+		"cpu":               prop("string", "CPU cores, e.g. '8'"),
+		"memory":            prop("string", "Memory size, e.g. '32Gi'"),
+		"gpu":               prop("string", "Number of GPUs"),
+		"ephemeralStorage":  prop("string", "Ephemeral storage size"),
+		"sharedMemory":      prop("string", "Shared memory size"),
+	}, "Container resources (preflight only)")
+}
+
+func opsjobCreateSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"name":    prop("string", "Job name, used to generate ops job ID"),
+			"type":    propEnum("string", "Ops job type", []string{"addon", "preflight", "dumplog", "reboot", "exportimage", "prewarm", "download"}),
+			"inputs":  propArray(opsjobInputItemSchema(), "Input selectors specifying targets and parameters"),
+			"timeout_second": prop("integer", "Timeout in seconds, 0 or negative means no timeout"),
+			"ttl_seconds_after_finished": prop("integer", "Job TTL after completion in seconds"),
+			"excluded_nodes":             propArray(prop("string", ""), "Node IDs to exclude from execution"),
+			"is_tolerate_all":            prop("boolean", "Whether to tolerate all node taints, default true"),
+			"image":                      prop("string", "Container image (preflight only)"),
+			"entry_point":                prop("string", "Startup command, Base64 encoded (preflight only)"),
+			"resource":                   opsjobResourceSchema(),
+			"env":                        propObject(map[string]any{}, "Environment variables as key-value pairs (preflight only)"),
+			"hostpath":                   propArray(prop("string", ""), "Host paths to mount (preflight only)"),
+			"workspace_id":               prop("string", "Workspace ID (preflight only, required for non-admin users)"),
+			"batch_count":                prop("integer", "Parallel nodes per batch (addon only, default 1)"),
+			"available_ratio":            prop("number", "Success ratio threshold (addon only, default 1.0)"),
+			"security_upgrade":           prop("boolean", "Wait until node idle before upgrade (addon only)"),
+		},
+		"required": []string{"name", "type", "inputs"},
+	}
+}
+
+func buildOpsjobCreateBody(p map[string]any) map[string]any {
+	body := map[string]any{
+		"name":   getStr(p, "name"),
+		"type":   getStr(p, "type"),
+		"inputs": p["inputs"],
+	}
+	if _, ok := p["timeout_second"]; ok {
+		if n, ok := getInt(p, "timeout_second"); ok {
+			body["timeoutSecond"] = n
+		}
+	}
+	if _, ok := p["ttl_seconds_after_finished"]; ok {
+		if n, ok := getInt(p, "ttl_seconds_after_finished"); ok {
+			body["ttlSecondsAfterFinished"] = n
+		}
+	}
+	if en, ok := p["excluded_nodes"]; ok && en != nil {
+		body["excludedNodes"] = en
+	}
+	if b, ok := getBool(p, "is_tolerate_all"); ok {
+		body["isTolerateAll"] = b
+	}
+	if v := getStr(p, "image"); v != "" {
+		body["image"] = v
+	}
+	if v := getStr(p, "entry_point"); v != "" {
+		body["entryPoint"] = v
+	}
+	if r, ok := p["resource"]; ok && r != nil {
+		body["resource"] = r
+	}
+	if env, ok := p["env"]; ok && env != nil {
+		body["env"] = env
+	}
+	if hp, ok := p["hostpath"]; ok && hp != nil {
+		body["hostpath"] = hp
+	}
+	if v := getStr(p, "workspace_id"); v != "" {
+		body["workspaceId"] = v
+	}
+	if _, ok := p["batch_count"]; ok {
+		if n, ok := getInt(p, "batch_count"); ok {
+			body["batchCount"] = n
+		}
+	}
+	if _, ok := p["available_ratio"]; ok {
+		if f, ok := getFloat(p, "available_ratio"); ok {
+			body["availableRatio"] = f
+		}
+	}
+	if b, ok := getBool(p, "security_upgrade"); ok {
+		body["securityOperation"] = b
+	}
+	return body
+}
+
+func opsjobList() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "opsjob_list",
+		Description: "List ops jobs with optional filters by cluster, workspace, status, type, user, time range, etc.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"offset":   prop("integer", "Pagination offset, default 0"),
+				"limit":    prop("integer", "Records per page, default 100"),
+				"sort_by":  prop("string", "Sort field, default 'creationTime'"),
+				"order":    propEnum("string", "Sort order, default 'desc'", []string{"desc", "asc"}),
+				"cluster_id":   prop("string", "Filter by cluster ID"),
+				"workspace_id": prop("string", "Filter by workspace ID"),
+				"user_name":    prop("string", "Filter by submitter username (fuzzy match)"),
+				"phase": propEnum("string", "Filter by job status", []string{
+					"Succeeded", "Failed", "Running", "Pending",
+				}),
+				"type": propEnum("string", "Filter by job type", []string{
+					"addon", "preflight", "dumplog", "reboot", "exportimage", "prewarm", "download",
+				}),
+				"job_name": prop("string", "Filter by job name (fuzzy match)"),
+				"since":    prop("string", "Start time filter (RFC3339), default until-720h"),
+				"until":    prop("string", "End time filter (RFC3339), default now"),
+			},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			q := url.Values{}
+			setQuery(q, p, "offset", "offset")
+			setQuery(q, p, "limit", "limit")
+			setQuery(q, p, "sort_by", "sortBy")
+			setQuery(q, p, "order", "order")
+			setQuery(q, p, "cluster_id", "clusterId")
+			setQuery(q, p, "workspace_id", "workspaceId")
+			setQuery(q, p, "user_name", "userName")
+			setQuery(q, p, "phase", "phase")
+			setQuery(q, p, "type", "type")
+			setQuery(q, p, "job_name", "jobName")
+			setQuery(q, p, "since", "since")
+			setQuery(q, p, "until", "until")
+			suffix := ""
+			if len(q) > 0 {
+				suffix = "?" + q.Encode()
+			}
+			return APICall(ctx, http.MethodGet, "/opsjobs"+suffix, nil)
+		},
+	}
+}
+
+func opsjobGet() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "opsjob_get",
+		Description: "Get detailed information of a specific ops job, including conditions, inputs, outputs, and resource config",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"job_id": prop("string", "Ops job ID"),
+			},
+			"required": []string{"job_id"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			id := getStr(p, "job_id")
+			if id == "" {
+				return nil, fmt.Errorf("job_id is required")
+			}
+			return APICall(ctx, http.MethodGet, "/opsjobs/"+url.PathEscape(id), nil)
+		},
+	}
+}
+
+func opsjobCreate() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "opsjob_create",
+		Description: "Create an OpsJob (operations job) to perform administrative tasks. Supported types: addon (install/upgrade addons on nodes), preflight (run preflight checks on nodes/cluster), dumplog (dump workload logs to S3), reboot (reboot a node), exportimage (export workload image to registry), prewarm (pre-pull image to all nodes in workspace), download (download files from S3 to nodes). At least one scope selector must be provided via inputs: node/workspace/cluster/workload.",
+		InputSchema: opsjobCreateSchema(),
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			if getStr(p, "name") == "" || getStr(p, "type") == "" {
+				return nil, fmt.Errorf("name and type are required")
+			}
+			if inputs, ok := p["inputs"].([]any); !ok || len(inputs) == 0 {
+				return nil, fmt.Errorf("inputs is required")
+			}
+			body := buildOpsjobCreateBody(p)
+			return APICall(ctx, http.MethodPost, "/opsjobs", body)
+		},
+	}
+}
+
+func opsjobStop() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "opsjob_stop",
+		Description: "Stop a running ops job",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"job_id": prop("string", "Ops job ID to stop"),
+			},
+			"required": []string{"job_id"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			id := getStr(p, "job_id")
+			if id == "" {
+				return nil, fmt.Errorf("job_id is required")
+			}
+			return APICall(ctx, http.MethodPost, "/opsjobs/"+url.PathEscape(id)+"/stop", nil)
+		},
+	}
+}
+
+func opsjobDelete() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "opsjob_delete",
+		Description: "Delete an ops job",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"job_id": prop("string", "Ops job ID to delete"),
+			},
+			"required": []string{"job_id"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			id := getStr(p, "job_id")
+			if id == "" {
+				return nil, fmt.Errorf("job_id is required")
+			}
+			return APICall(ctx, http.MethodDelete, "/opsjobs/"+url.PathEscape(id), nil)
+		},
+	}
+}

--- a/SaFE/apiserver/pkg/mcp/tools/tools_test.go
+++ b/SaFE/apiserver/pkg/mcp/tools/tools_test.go
@@ -1,0 +1,362 @@
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+// See LICENSE for license information.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/common"
+	mcpserver "github.com/AMD-AIG-AIMA/SAFE/common/pkg/mcp/server"
+)
+
+var toolNameRegexp = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+
+func findTool(t *testing.T, name string) *mcpserver.MCPTool {
+	t.Helper()
+	for _, tl := range RegisterAllTools() {
+		if tl.Name == name {
+			return tl
+		}
+	}
+	t.Fatalf("tool %q not found", name)
+	return nil
+}
+
+func TestRegisterAllTools_Count(t *testing.T) {
+	t.Parallel()
+	if n := len(RegisterAllTools()); n != 47 {
+		t.Fatalf("RegisterAllTools: got %d tools want 47", n)
+	}
+}
+
+func TestRegisterAllTools_NamesUnique(t *testing.T) {
+	t.Parallel()
+	seen := make(map[string]int)
+	for _, tl := range RegisterAllTools() {
+		seen[tl.Name]++
+	}
+	for name, c := range seen {
+		if c != 1 {
+			t.Fatalf("duplicate tool name %q count %d", name, c)
+		}
+	}
+}
+
+func TestRegisterAllTools_SchemaValid(t *testing.T) {
+	t.Parallel()
+	for _, tl := range RegisterAllTools() {
+		if tl.Name == "" {
+			t.Fatal("empty name")
+		}
+		if !toolNameRegexp.MatchString(tl.Name) {
+			t.Errorf("tool %q name does not match ^[a-z][a-z0-9_]*$", tl.Name)
+		}
+		if strings.TrimSpace(tl.Description) == "" {
+			t.Errorf("tool %q: empty description", tl.Name)
+		}
+		if tl.Handler == nil {
+			t.Errorf("tool %q: nil handler", tl.Name)
+		}
+		schema := tl.InputSchema
+		if schema == nil {
+			t.Fatalf("tool %q: nil InputSchema", tl.Name)
+		}
+		typ, _ := schema["type"].(string)
+		if typ != "object" {
+			t.Errorf("tool %q: InputSchema type=%q want object", tl.Name, typ)
+		}
+		propsAny, ok := schema["properties"]
+		if !ok {
+			t.Errorf("tool %q: missing properties", tl.Name)
+			continue
+		}
+		props, ok := propsAny.(map[string]any)
+		if !ok {
+			t.Errorf("tool %q: properties not map[string]any", tl.Name)
+			continue
+		}
+		if reqAny, has := schema["required"]; has {
+			reqNames := extractRequiredStrings(reqAny)
+			if reqNames == nil {
+				t.Errorf("tool %q: required has wrong type %T", tl.Name, reqAny)
+				continue
+			}
+			for _, r := range reqNames {
+				if _, ok := props[r]; !ok {
+					t.Errorf("tool %q: required field %q not in properties", tl.Name, r)
+				}
+			}
+		}
+		_ = props
+	}
+}
+
+func extractRequiredStrings(v any) []string {
+	switch x := v.(type) {
+	case []string:
+		return x
+	case []any:
+		out := make([]string, 0, len(x))
+		for _, e := range x {
+			s, ok := e.(string)
+			if !ok {
+				return nil
+			}
+			out = append(out, s)
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func TestRegisterAllTools_GroupCounts(t *testing.T) {
+	t.Parallel()
+	counts := map[string]int{
+		"cluster_":   0,
+		"workspace_": 0,
+		"flavor_":    0,
+		"node_":      0,
+		"workload_":  0,
+		"opsjob_":    0,
+		"apikey_":    0,
+	}
+	want := map[string]int{
+		"cluster_":   7,
+		"workspace_": 7,
+		"flavor_":    2,
+		"node_":      12,
+		"workload_":  10,
+		"opsjob_":    5,
+		"apikey_":    4,
+	}
+	for _, tl := range RegisterAllTools() {
+		for prefix := range counts {
+			if strings.HasPrefix(tl.Name, prefix) {
+				counts[prefix]++
+				break
+			}
+		}
+	}
+	for prefix, w := range want {
+		if got := counts[prefix]; got != w {
+			t.Errorf("prefix %s: got %d want %d", prefix, got, w)
+		}
+	}
+}
+
+func TestTool_HappyPath_GET(t *testing.T) {
+	t.Parallel()
+	sample := `{"clusters":[{"id":"c1"}]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method %s", r.Method)
+		}
+		if want := "/" + common.PrimusRouterCustomRootPath + "/clusters"; r.URL.Path != want {
+			t.Errorf("path got %q want %q", r.URL.Path, want)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(sample))
+	}))
+	defer srv.Close()
+
+	req := newFakeReq(t, srv.URL)
+	ctx := mcpserver.ContextWithHTTPRequest(context.Background(), req)
+	tool := findTool(t, "cluster_list")
+	got, err := tool.Handler(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var exp any
+	if err := json.Unmarshal([]byte(sample), &exp); err != nil {
+		t.Fatal(err)
+	}
+	if !fmtDeepEqualJSON(got, exp) {
+		t.Fatalf("got %#v want %#v", got, exp)
+	}
+}
+
+func fmtDeepEqualJSON(a, b any) bool {
+	// Normalize via JSON round-trip for stable comparison.
+	ja, err1 := json.Marshal(a)
+	jb, err2 := json.Marshal(b)
+	if err1 != nil || err2 != nil {
+		return false
+	}
+	return string(ja) == string(jb)
+}
+
+func TestTool_HappyPath_GETWithPath(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method %s", r.Method)
+		}
+		want := "/" + common.PrimusRouterCustomRootPath + "/clusters/test-cluster"
+		if r.URL.Path != want {
+			t.Errorf("path got %q want %q", r.URL.Path, want)
+		}
+		_, _ = w.Write([]byte(`{"id":"test-cluster"}`))
+	}))
+	defer srv.Close()
+
+	raw := json.RawMessage(`{"cluster_id":"test-cluster"}`)
+	req := newFakeReq(t, srv.URL)
+	ctx := mcpserver.ContextWithHTTPRequest(context.Background(), req)
+	tool := findTool(t, "cluster_get")
+	got, err := tool.Handler(ctx, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	exp := map[string]any{"id": "test-cluster"}
+	if !fmtDeepEqualJSON(got, exp) {
+		t.Fatalf("got %#v", got)
+	}
+}
+
+func TestTool_HappyPath_POSTWithBody(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method %s", r.Method)
+		}
+		if want := "/" + common.PrimusRouterCustomRootPath + "/workspaces"; r.URL.Path != want {
+			t.Errorf("path got %q want %q", r.URL.Path, want)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		for _, k := range []string{"name", "cluster_id", "flavor_id"} {
+			if _, ok := body[k]; !ok {
+				t.Errorf("body missing %q: %#v", k, body)
+			}
+		}
+		_, _ = w.Write([]byte(`{"workspace_id":"ws-1"}`))
+	}))
+	defer srv.Close()
+
+	raw := json.RawMessage(`{"name":"w1","cluster_id":"c1","flavor_id":"f1"}`)
+	req := newFakeReq(t, srv.URL)
+	ctx := mcpserver.ContextWithHTTPRequest(context.Background(), req)
+	tool := findTool(t, "workspace_create")
+	got, err := tool.Handler(ctx, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	exp := map[string]any{"workspace_id": "ws-1"}
+	if !fmtDeepEqualJSON(got, exp) {
+		t.Fatalf("got %#v", got)
+	}
+}
+
+func TestTool_QueryParamMapping(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method %s", r.Method)
+		}
+		q := r.URL.Query()
+		if got := q.Get("clusterId"); got != "my-cluster" {
+			t.Fatalf("query clusterId=%q full %q", got, r.URL.RawQuery)
+		}
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer srv.Close()
+
+	raw := json.RawMessage(`{"cluster_id":"my-cluster"}`)
+	req := newFakeReq(t, srv.URL)
+	ctx := mcpserver.ContextWithHTTPRequest(context.Background(), req)
+	tool := findTool(t, "node_list")
+	if _, err := tool.Handler(ctx, raw); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// minimalArgsForTool returns minimum required JSON args for a tool name so the
+// Handler can be exercised end-to-end. Empty raw is fine for tools without
+// required fields.
+func minimalArgsForTool(name string) json.RawMessage {
+	args := map[string]any{}
+	// Cover every "required" field referenced by InputSchema across the 47 tools.
+	defaults := map[string]any{
+		"cluster_id":   "test-cluster",
+		"workspace_id": "ws-1",
+		"node_id":      "node-1",
+		"workload_id":  "wl-1",
+		"job_id":       "job-1",
+		"flavor_id":    "flavor-1",
+		"pod_id":       "pod-1",
+		"name":         "name-1",
+		"action":       "add",
+		"node_ids":     []string{"node-1"},
+		"workload_ids": []string{"wl-1"},
+		"images":       []string{"img:latest"},
+		"resources":    []map[string]any{{"cpu": "1", "memory": "1Gi", "replica": 1}},
+		"kind":         "Deployment",
+		"display_name": "wl-display",
+		"replica":      1,
+		"ttl_days":     7,
+		"apikey_id":    1,
+		"type":         "preflight",
+		"inputs":       []map[string]any{{"name": "node", "value": "node-1"}},
+		"ssh_secret_id":         "ssh-1",
+		"kube_spray_image":      "spray:1",
+		"kube_pods_subnet":      "10.0.0.0/16",
+		"kube_service_address":  "10.96.0.0/16",
+		"kube_version":          "1.32.5",
+		"nodes":                 []string{"node-1"},
+		"private_ip":            "10.0.0.1",
+		"template_id":           "tmpl-1",
+	}
+	for k, v := range defaults {
+		args[k] = v
+	}
+	raw, _ := json.Marshal(args)
+	return raw
+}
+
+// TestAllTools_ReachableViaHandler runs every registered tool's Handler against
+// a permissive loopback server. The goal is coverage and a basic smoke-check
+// that no Handler panics, mis-builds a URL, or fails to parse params, NOT to
+// validate per-tool behavior. Per-tool semantics are covered elsewhere.
+func TestAllTools_ReachableViaHandler(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	req := newFakeReq(t, srv.URL)
+	ctx := mcpserver.ContextWithHTTPRequest(context.Background(), req)
+
+	for _, tl := range RegisterAllTools() {
+		tl := tl
+		t.Run(tl.Name, func(t *testing.T) {
+			args := minimalArgsForTool(tl.Name)
+			if _, err := tl.Handler(ctx, args); err != nil {
+				t.Fatalf("tool %q handler error: %v", tl.Name, err)
+			}
+		})
+	}
+}
+
+func TestTool_RequiresContext(t *testing.T) {
+	t.Parallel()
+	tool := findTool(t, "cluster_list")
+	_, err := tool.Handler(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error without HTTP request in context")
+	}
+	if !strings.Contains(err.Error(), "incoming HTTP request") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/SaFE/apiserver/pkg/mcp/tools/tools_workload.go
+++ b/SaFE/apiserver/pkg/mcp/tools/tools_workload.go
@@ -1,0 +1,497 @@
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+// See LICENSE for license information.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	mcpserver "github.com/AMD-AIG-AIMA/SAFE/common/pkg/mcp/server"
+)
+
+func workloadTools() []*mcpserver.MCPTool {
+	return []*mcpserver.MCPTool{
+		workloadList(), workloadGet(), workloadCreate(), workloadUpdate(), workloadStop(),
+		workloadBatchStop(), workloadDelete(), workloadBatchDelete(), workloadPodLogs(), workloadLogsDownload(),
+	}
+}
+
+func workloadResourceItemSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"cpu":               prop("string", "CPU cores, e.g. '4'"),
+			"memory":            prop("string", "Memory size, e.g. '256Gi'"),
+			"gpu":               prop("string", "Number of GPUs"),
+			"replica":           prop("integer", "Number of replicas"),
+			"ephemeralStorage":  prop("string", "Ephemeral storage size, e.g. '50Gi'"),
+			"sharedMemory":      prop("string", "Shared memory size, e.g. '64Gi'"),
+		},
+		"required": []string{"cpu", "memory", "replica"},
+	}
+}
+
+func workloadCreateSchema() map[string]any {
+	secretsItem := propObject(map[string]any{
+		"id":   prop("string", ""),
+		"type": propEnum("string", "", []string{"image", "general"}),
+	}, "")
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"display_name": prop("string", "Workload display name"),
+			"workspace_id": prop("string", "Workspace ID"),
+			"kind": propEnum("string", "Workload type", []string{
+				"PyTorchJob", "Deployment", "StatefulSet", "Authoring", "TorchFT", "RayJob", "AutoscalingRunnerSet",
+			}),
+			"images":    propArray(prop("string", ""), "Container image URLs array. Length should match resources array."),
+			"resources": propArray(workloadResourceItemSchema(), "Resources array. For PyTorchJob: [master, worker]. For TorchFT: [lighthouse, worker]. For RayJob: [head, worker_group_1, worker_group_2(optional)], head replica must be 1."),
+			"entry_points": propArray(prop("string", ""), "Startup commands (Base64 encoded) array. Length should match resources array. Not required for Authoring type. For RayJob: these are node initialization scripts (e.g. init-head.sh, init-worker.sh), NOT the training entrypoint (use env.RAY_JOB_ENTRYPOINT for that)."),
+			"description":  prop("string", "Workload description"),
+			"priority":     prop("integer", "Priority level (0-2), default 0"),
+			"timeout":      prop("integer", "Timeout in seconds, default 0 (no timeout)"),
+			"max_retry":    prop("integer", "Maximum retry count, default 0"),
+			"env":          propObject(map[string]any{}, "Environment variables as key-value pairs. For RayJob: RAY_JOB_ENTRYPOINT is required (the main training command submitted to Ray cluster, e.g. 'bash my-train-job.sh')."),
+			"specified_nodes": propArray(prop("string", ""), "List of node IDs to run on"),
+			"excluded_nodes":  propArray(prop("string", ""), "List of node IDs to exclude"),
+			"is_supervised":   prop("boolean", "Enable monitoring, default false"),
+			"ttl_seconds_after_finished": prop("integer", "TTL after completion in seconds, default 60"),
+			"customer_labels":            propObject(map[string]any{}, "Custom labels as key-value pairs"),
+			"secrets":                    propArray(secretsItem, "List of secrets"),
+			"is_tolerate_all":            prop("boolean", "Tolerate all node taints, default false"),
+			"preheat":                    prop("boolean", "Pre-pull image, default false"),
+			"sticky_nodes":               prop("boolean", "Use same nodes during retries/failovers, default false"),
+			"liveness":                   propObject(map[string]any{}, "Liveness probe configuration (Deployment/StatefulSet only)"),
+			"readiness":                  propObject(map[string]any{}, "Readiness probe configuration (Deployment/StatefulSet only)"),
+			"service":                    propObject(map[string]any{}, "Service configuration (Deployment/StatefulSet only)"),
+		},
+		"required": []string{"display_name", "workspace_id", "kind", "images", "resources"},
+	}
+}
+
+func buildWorkloadCreateBody(p map[string]any) (map[string]any, error) {
+	if getStr(p, "display_name") == "" || getStr(p, "workspace_id") == "" || getStr(p, "kind") == "" {
+		return nil, fmt.Errorf("display_name, workspace_id, and kind are required")
+	}
+	imgs, ok := p["images"].([]any)
+	if !ok || len(imgs) == 0 {
+		return nil, fmt.Errorf("images is required")
+	}
+	res, ok := p["resources"].([]any)
+	if !ok || len(res) == 0 {
+		return nil, fmt.Errorf("resources is required")
+	}
+	kind := getStr(p, "kind")
+	body := map[string]any{
+		"displayName":   getStr(p, "display_name"),
+		"workspaceId":   getStr(p, "workspace_id"),
+		"groupVersionKind": map[string]any{
+			"group":   "",
+			"version": "v1",
+			"kind":    kind,
+		},
+		"images":    p["images"],
+		"resources": p["resources"],
+	}
+	if v := getStr(p, "description"); v != "" {
+		body["description"] = v
+	}
+	if _, ok := p["priority"]; ok {
+		if n, ok := getInt(p, "priority"); ok {
+			body["priority"] = n
+		}
+	}
+	if _, ok := p["timeout"]; ok {
+		if n, ok := getInt(p, "timeout"); ok {
+			body["timeout"] = n
+		}
+	}
+	if _, ok := p["max_retry"]; ok {
+		if n, ok := getInt(p, "max_retry"); ok {
+			body["maxRetry"] = n
+		}
+	}
+	if env, ok := p["env"]; ok && env != nil {
+		body["env"] = env
+	}
+	if sn, ok := p["specified_nodes"]; ok && sn != nil {
+		body["specifiedNodes"] = sn
+	}
+	if en, ok := p["excluded_nodes"]; ok && en != nil {
+		body["excludedNodes"] = en
+	}
+	if b, ok := getBool(p, "is_supervised"); ok {
+		body["isSupervised"] = b
+	}
+	if _, ok := p["ttl_seconds_after_finished"]; ok {
+		if n, ok := getInt(p, "ttl_seconds_after_finished"); ok {
+			body["ttlSecondsAfterFinished"] = n
+		}
+	}
+	if cl, ok := p["customer_labels"]; ok && cl != nil {
+		body["customerLabels"] = cl
+	}
+	if sec, ok := p["secrets"]; ok && sec != nil {
+		body["secrets"] = sec
+	}
+	if b, ok := getBool(p, "is_tolerate_all"); ok {
+		body["isTolerateAll"] = b
+	}
+	if b, ok := getBool(p, "preheat"); ok {
+		body["preheat"] = b
+	}
+	if b, ok := getBool(p, "sticky_nodes"); ok && b {
+		body["annotations"] = map[string]any{"primus-safe.retry.on.original.nodes": "true"}
+	}
+	if ep, ok := p["entry_points"]; ok && ep != nil {
+		body["entryPoints"] = ep
+	}
+	if lv, ok := p["liveness"]; ok && lv != nil {
+		body["liveness"] = lv
+	}
+	if rd, ok := p["readiness"]; ok && rd != nil {
+		body["readiness"] = rd
+	}
+	if svc, ok := p["service"]; ok && svc != nil {
+		body["service"] = svc
+	}
+	return body, nil
+}
+
+func workloadList() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "workload_list",
+		Description: "List workloads with optional filters. Use this to query workloads by workspace, cluster, user, status, or type.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"workspace_id": prop("string", "Filter by workspace ID"),
+				"cluster_id":   prop("string", "Filter by cluster ID"),
+				"user_id":      prop("string", "Filter by user ID"),
+				"phase": propEnum("string", "Filter by status phase", []string{
+					"Succeeded", "Failed", "Pending", "Running", "Stopped", "Updating", "NotReady",
+				}),
+				"kind": propEnum("string", "Filter by workload type", []string{
+					"PyTorchJob", "Deployment", "StatefulSet", "Authoring", "AutoscalingRunnerSet", "TorchFT", "RayJob",
+				}),
+				"workload_id": prop("string", "Fuzzy match by workload ID"),
+				"offset":      prop("integer", "Pagination offset, default 0"),
+				"limit":       prop("integer", "Number of items per page, default 100"),
+				"sort_by":     prop("string", "Sort field, default 'creationTime'"),
+				"order":       propEnum("string", "Sort order", []string{"desc", "asc"}),
+			},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			q := url.Values{}
+			setQuery(q, p, "workspace_id", "workspaceId")
+			setQuery(q, p, "cluster_id", "clusterId")
+			setQuery(q, p, "user_id", "userId")
+			setQuery(q, p, "phase", "phase")
+			setQuery(q, p, "kind", "kind")
+			setQuery(q, p, "workload_id", "workloadId")
+			setQuery(q, p, "offset", "offset")
+			setQuery(q, p, "limit", "limit")
+			setQuery(q, p, "sort_by", "sortBy")
+			setQuery(q, p, "order", "order")
+			suffix := ""
+			if len(q) > 0 {
+				suffix = "?" + q.Encode()
+			}
+			return APICall(ctx, http.MethodGet, "/workloads"+suffix, nil)
+		},
+	}
+}
+
+func workloadGet() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "workload_get",
+		Description: "Get detailed information of a specific workload by its ID",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"workload_id": prop("string", "Workload ID"),
+			},
+			"required": []string{"workload_id"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			id := getStr(p, "workload_id")
+			if id == "" {
+				return nil, fmt.Errorf("workload_id is required")
+			}
+			return APICall(ctx, http.MethodGet, "/workloads/"+url.PathEscape(id), nil)
+		},
+	}
+}
+
+func workloadCreate() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "workload_create",
+		Description: "Create a new workload. Supports PyTorchJob (distributed training), Deployment (inference), StatefulSet (stateful service), Authoring (development), TorchFT (fault-tolerant training), RayJob (Ray distributed training), and AutoscalingRunnerSet (CI/CD).",
+		InputSchema: workloadCreateSchema(),
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			body, err := buildWorkloadCreateBody(p)
+			if err != nil {
+				return nil, err
+			}
+			return APICall(ctx, http.MethodPost, "/workloads", body)
+		},
+	}
+}
+
+func workloadUpdate() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "workload_update",
+		Description: "Update an existing workload. Only specified fields will be updated. Note: array/object fields require complete values.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"workload_id":   prop("string", "Workload ID to update"),
+				"priority":      prop("integer", "New priority level (0-2)"),
+				"images":        propArray(prop("string", ""), "New container image URLs array (must provide complete array)"),
+				"entry_points":  propArray(prop("string", ""), "New startup commands (Base64 encoded) array (must provide complete array)"),
+				"description":   prop("string", "New description"),
+				"timeout":       prop("integer", "New timeout in seconds"),
+				"max_retry":     prop("integer", "New maximum retry count"),
+				"env":           propObject(map[string]any{}, "New environment variables (must provide complete object)"),
+				"service":       propObject(map[string]any{}, "New service configuration"),
+				"resources": propArray(map[string]any{
+					"type": "object",
+				}, "New resources array (must provide complete array)"),
+			},
+			"required": []string{"workload_id"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			id := getStr(p, "workload_id")
+			if id == "" {
+				return nil, fmt.Errorf("workload_id is required")
+			}
+			body := map[string]any{}
+			if _, ok := p["priority"]; ok {
+				if n, ok := getInt(p, "priority"); ok {
+					body["priority"] = n
+				}
+			}
+			if _, ok := p["images"]; ok {
+				body["images"] = p["images"]
+			}
+			if _, ok := p["entry_points"]; ok {
+				body["entryPoints"] = p["entry_points"]
+			}
+			if v := getStr(p, "description"); v != "" {
+				body["description"] = v
+			}
+			if _, ok := p["timeout"]; ok {
+				if n, ok := getInt(p, "timeout"); ok {
+					body["timeout"] = n
+				}
+			}
+			if _, ok := p["max_retry"]; ok {
+				if n, ok := getInt(p, "max_retry"); ok {
+					body["maxRetry"] = n
+				}
+			}
+			if _, ok := p["env"]; ok {
+				body["env"] = p["env"]
+			}
+			if _, ok := p["service"]; ok {
+				body["service"] = p["service"]
+			}
+			if _, ok := p["resources"]; ok {
+				body["resources"] = p["resources"]
+			}
+			return APICall(ctx, http.MethodPatch, "/workloads/"+url.PathEscape(id), body)
+		},
+	}
+}
+
+func workloadStop() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "workload_stop",
+		Description: "Stop a running workload",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"workload_id": prop("string", "Workload ID to stop"),
+			},
+			"required": []string{"workload_id"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			id := getStr(p, "workload_id")
+			if id == "" {
+				return nil, fmt.Errorf("workload_id is required")
+			}
+			return APICall(ctx, http.MethodPost, "/workloads/"+url.PathEscape(id)+"/stop", nil)
+		},
+	}
+}
+
+func workloadBatchStop() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "workload_batch_stop",
+		Description: "Stop multiple running workloads at once",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"workload_ids": propArray(prop("string", ""), "List of workload IDs to stop"),
+			},
+			"required": []string{"workload_ids"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			ids, ok := p["workload_ids"].([]any)
+			if !ok || len(ids) == 0 {
+				return nil, fmt.Errorf("workload_ids is required")
+			}
+			body := map[string]any{"workloadIds": p["workload_ids"]}
+			return APICall(ctx, http.MethodPost, "/workloads/stop", body)
+		},
+	}
+}
+
+func workloadDelete() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "workload_delete",
+		Description: "Delete a workload by its ID",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"workload_id": prop("string", "Workload ID to delete"),
+			},
+			"required": []string{"workload_id"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			id := getStr(p, "workload_id")
+			if id == "" {
+				return nil, fmt.Errorf("workload_id is required")
+			}
+			return APICall(ctx, http.MethodDelete, "/workloads/"+url.PathEscape(id), nil)
+		},
+	}
+}
+
+func workloadBatchDelete() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "workload_batch_delete",
+		Description: "Delete multiple workloads at once",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"workload_ids": propArray(prop("string", ""), "List of workload IDs to delete"),
+			},
+			"required": []string{"workload_ids"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			if _, ok := p["workload_ids"].([]any); !ok {
+				return nil, fmt.Errorf("workload_ids is required")
+			}
+			body := map[string]any{"workloadIds": p["workload_ids"]}
+			return APICall(ctx, http.MethodPost, "/workloads/delete", body)
+		},
+	}
+}
+
+func workloadPodLogs() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "workload_pod_logs",
+		Description: "Get logs from a specific pod of a workload",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"workload_id":    prop("string", "Workload ID"),
+				"pod_id":         prop("string", "Pod ID"),
+				"tail_lines":     prop("integer", "Number of lines to return from the end, default 1000"),
+				"container":      prop("string", "Container name (optional, for multi-container pods)"),
+				"since_seconds":  prop("integer", "Return logs from last N seconds (optional)"),
+			},
+			"required": []string{"workload_id", "pod_id"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			wid := getStr(p, "workload_id")
+			pid := getStr(p, "pod_id")
+			if wid == "" || pid == "" {
+				return nil, fmt.Errorf("workload_id and pod_id are required")
+			}
+			q := url.Values{}
+			setQuery(q, p, "tail_lines", "tailLines")
+			setQuery(q, p, "container", "container")
+			setQuery(q, p, "since_seconds", "sinceSeconds")
+			suffix := ""
+			if len(q) > 0 {
+				suffix = "?" + q.Encode()
+			}
+			path := "/workloads/" + url.PathEscape(wid) + "/pods/" + url.PathEscape(pid) + "/logs" + suffix
+			return APICall(ctx, http.MethodGet, path, nil)
+		},
+	}
+}
+
+func workloadLogsDownload() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name: "workload_logs_download",
+		Description: "Download workload logs to a local file.\n\nHOW TO USE:\n1. Run this curl command directly (recommended):\n   curl -L -o <output_file> \"<api_base_url>/api/v1/workloads/<workload_id>/logs/download\" \\\n     -H \"Content-Type: application/json\" -H \"Authorization: Bearer <token>\" -d '{}'\n   \n   The -L flag follows the HTTP 303 redirect to download the log file directly.\n\n2. Or call this tool to get the presigned S3 URL, then download separately:\n   curl -o <output_file> \"<presigned_url_from_this_tool>\"\n\nNOTES:\n- The download may take several minutes (DumpLog job runs internally)\n- Requires OpenSearch and S3 enabled on the cluster\n- api_base_url is the SaFE API server address (e.g., https://example.primus-safe.amd.com)\n",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"workload_id":     prop("string", "Workload ID to download logs for"),
+				"timeout_second":  prop("integer", "Timeout in seconds for waiting DumpLog job completion (default: 900 = 15 minutes). Set to 0 or omit to use server default."),
+			},
+			"required": []string{"workload_id"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			id := getStr(p, "workload_id")
+			if id == "" {
+				return nil, fmt.Errorf("workload_id is required")
+			}
+			body := map[string]any{}
+			if _, ok := p["timeout_second"]; ok {
+				if n, ok := getInt(p, "timeout_second"); ok {
+					body["timeoutSecond"] = n
+				}
+			}
+			return APICall(ctx, http.MethodPost, "/workloads/"+url.PathEscape(id)+"/logs/download", body)
+		},
+	}
+}

--- a/SaFE/apiserver/pkg/mcp/tools/tools_workspace.go
+++ b/SaFE/apiserver/pkg/mcp/tools/tools_workspace.go
@@ -1,0 +1,204 @@
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+// See LICENSE for license information.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	mcpserver "github.com/AMD-AIG-AIMA/SAFE/common/pkg/mcp/server"
+)
+
+func workspaceTools() []*mcpserver.MCPTool {
+	return []*mcpserver.MCPTool{
+		workspaceList(),
+		workspaceGet(),
+		workspaceCreate(),
+		workspaceUpdate(),
+		workspaceScale(),
+		workspaceManageNodes(),
+		workspaceDelete(),
+	}
+}
+
+func workspaceList() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "workspace_list",
+		Description: "List all workspaces, supports filtering by cluster",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"cluster_id": prop("string", "Filter by cluster ID (optional)"),
+			},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, _ := parseParams(raw)
+			q := url.Values{}
+			setQuery(q, p, "cluster_id", "clusterId")
+			qs := ""
+			if len(q) > 0 {
+				qs = "?" + q.Encode()
+			}
+			return APICall(ctx, http.MethodGet, "/workspaces"+qs, nil)
+		},
+	}
+}
+
+func workspaceGet() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "workspace_get",
+		Description: "Get detailed information of a specific workspace",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"workspace_id": prop("string", "Workspace ID (format: clusterId-workspaceName)"),
+			},
+			"required": []string{"workspace_id"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			return APICall(ctx, http.MethodGet, fmt.Sprintf("/workspaces/%s", getStr(p, "workspace_id")), nil)
+		},
+	}
+}
+
+func workspaceCreate() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "workspace_create",
+		Description: "Create a new workspace. Note: must call cluster_list and flavor_list first to get available clusters and node flavors.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"name":               prop("string", "Workspace name"),
+				"cluster_id":         prop("string", "Cluster ID (required, get from cluster_list)"),
+				"flavor_id":          prop("string", "Node flavor ID (required, get from flavor_list)"),
+				"replica":            prop("integer", "Expected node count (optional)"),
+				"description":        prop("string", "Description (optional)"),
+				"queue_policy":       propEnum("string", "Queue policy", []string{"fifo", "balance"}),
+				"scopes":             propArray("Supported service modules: Train, Infer, Authoring, CICD", map[string]any{"type": "string"}),
+				"volumes":            propArray("Volume configuration list", map[string]any{"type": "object"}),
+				"enable_preempt":     prop("boolean", "Whether to enable preemption, default false"),
+				"is_default":         prop("boolean", "Whether to set as default workspace, default false"),
+				"image_secret_ids":   propArray("Image pull secret ID list", map[string]any{"type": "string"}),
+			},
+			"required": []string{"name", "cluster_id", "flavor_id"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			return APICall(ctx, http.MethodPost, "/workspaces", p)
+		},
+	}
+}
+
+func workspaceUpdate() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "workspace_update",
+		Description: "Update workspace configuration",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"workspace_id":     prop("string", "Workspace ID (format: clusterId-workspaceName)"),
+				"description":      prop("string", "New description"),
+				"flavor_id":        prop("string", "New node flavor ID"),
+				"replica":          prop("integer", "New replica count (node count)"),
+				"queue_policy":     propEnum("string", "New queue policy", []string{"fifo", "balance"}),
+				"scopes":           propArray("New service module list", map[string]any{"type": "string"}),
+				"volumes":          propArray("New volume configuration list", map[string]any{"type": "object"}),
+				"enable_preempt":   prop("boolean", "Whether to enable preemption"),
+				"managers":         propArray("Manager user ID list", map[string]any{"type": "string"}),
+				"is_default":       prop("boolean", "Whether to set as default workspace"),
+				"image_secret_ids": propArray("Image pull secret ID list", map[string]any{"type": "string"}),
+			},
+			"required": []string{"workspace_id"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			id := getStr(p, "workspace_id")
+			delete(p, "workspace_id")
+			return APICall(ctx, http.MethodPatch, fmt.Sprintf("/workspaces/%s", id), p)
+		},
+	}
+}
+
+func workspaceScale() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "workspace_scale",
+		Description: "Scale workspace (shortcut, equivalent to workspace_update with only replica)",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"workspace_id": prop("string", "Workspace ID (format: clusterId-workspaceName)"),
+				"replica":      prop("integer", "New node count"),
+			},
+			"required": []string{"workspace_id", "replica"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			id := getStr(p, "workspace_id")
+			body := map[string]any{"replica": p["replica"]}
+			return APICall(ctx, http.MethodPatch, fmt.Sprintf("/workspaces/%s", id), body)
+		},
+	}
+}
+
+func workspaceManageNodes() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "workspace_manage_nodes",
+		Description: "Manage workspace nodes (add or remove nodes)",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"workspace_id": prop("string", "Workspace ID (format: clusterId-workspaceName)"),
+				"node_ids":     propArray("Node ID list", map[string]any{"type": "string"}),
+				"action":       propEnum("string", "Action type", []string{"add", "remove"}),
+			},
+			"required": []string{"workspace_id", "node_ids", "action"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			id := getStr(p, "workspace_id")
+			delete(p, "workspace_id")
+			return APICall(ctx, http.MethodPost, fmt.Sprintf("/workspaces/%s/nodes", id), p)
+		},
+	}
+}
+
+func workspaceDelete() *mcpserver.MCPTool {
+	return &mcpserver.MCPTool{
+		Name:        "workspace_delete",
+		Description: "Delete a workspace. Note: workspace must have no running workloads",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"workspace_id": prop("string", "Workspace ID (format: clusterId-workspaceName)"),
+			},
+			"required": []string{"workspace_id"},
+		},
+		Handler: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			p, err := parseParams(raw)
+			if err != nil {
+				return nil, err
+			}
+			return APICall(ctx, http.MethodDelete, fmt.Sprintf("/workspaces/%s", getStr(p, "workspace_id")), nil)
+		},
+	}
+}

--- a/SaFE/apiserver/pkg/mcp/unified/adapter_test.go
+++ b/SaFE/apiserver/pkg/mcp/unified/adapter_test.go
@@ -1,0 +1,313 @@
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+// See LICENSE for license information.
+
+package unified
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToMCPTool_Success(t *testing.T) {
+	type Req struct {
+		N int `json:"n"`
+	}
+	type Resp struct {
+		Double int `json:"double"`
+	}
+	def := &EndpointDef[Req, Resp]{
+		Name:        "calc",
+		Description: "doubles",
+		Handler: func(ctx context.Context, req *Req) (*Resp, error) {
+			return &Resp{Double: req.N * 2}, nil
+		},
+	}
+	tool := ToMCPTool(def)
+	require.NotNil(t, tool)
+	out, err := tool.Handler(context.Background(), json.RawMessage(`{"n":21}`))
+	require.NoError(t, err)
+	resp, ok := out.(*Resp)
+	require.True(t, ok)
+	assert.Equal(t, 42, resp.Double)
+}
+
+func TestToMCPTool_BindError(t *testing.T) {
+	type Req struct{ X int `json:"x"` }
+	type Resp struct{}
+
+	var calls atomic.Int32
+	def := &EndpointDef[Req, Resp]{
+		Name: "t",
+		Handler: func(ctx context.Context, req *Req) (*Resp, error) {
+			calls.Add(1)
+			return &Resp{}, nil
+		},
+	}
+	tool := ToMCPTool(def)
+	_, err := tool.Handler(context.Background(), json.RawMessage(`not json`))
+	require.Error(t, err)
+	assert.Zero(t, calls.Load())
+}
+
+func TestToMCPTool_HandlerError(t *testing.T) {
+	type Req struct{}
+	type Resp struct{}
+	want := errors.New("boom")
+	def := &EndpointDef[Req, Resp]{
+		Name: "t",
+		Handler: func(ctx context.Context, req *Req) (*Resp, error) {
+			return nil, want
+		},
+	}
+	tool := ToMCPTool(def)
+	_, err := tool.Handler(context.Background(), json.RawMessage(`{}`))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, want)
+}
+
+func TestToMCPTool_NameDefault(t *testing.T) {
+	type Req struct{}
+	type Resp struct{}
+	def := &EndpointDef[Req, Resp]{
+		Name: "default-name",
+		Handler: func(ctx context.Context, req *Req) (*Resp, error) {
+			return &Resp{}, nil
+		},
+	}
+	tool := ToMCPTool(def)
+	assert.Equal(t, "default-name", tool.Name)
+}
+
+func TestToMCPTool_NameOverride(t *testing.T) {
+	type Req struct{}
+	type Resp struct{}
+	def := &EndpointDef[Req, Resp]{
+		Name:        "default-name",
+		MCPToolName: "override",
+		Handler: func(ctx context.Context, req *Req) (*Resp, error) {
+			return &Resp{}, nil
+		},
+	}
+	tool := ToMCPTool(def)
+	assert.Equal(t, "override", tool.Name)
+}
+
+func TestToMCPToolFromRaw_NilSchema(t *testing.T) {
+	tool := ToMCPToolFromRaw("raw", "d", nil, func(ctx context.Context, params map[string]any) (any, error) {
+		return "ok", nil
+	})
+	exp := map[string]any{"type": "object", "properties": map[string]any{}}
+	assert.Equal(t, exp, tool.InputSchema)
+}
+
+func TestToMCPToolFromRaw_CustomSchema(t *testing.T) {
+	custom := map[string]any{"type": "object", "title": "T"}
+	tool := ToMCPToolFromRaw("raw", "d", custom, func(ctx context.Context, params map[string]any) (any, error) {
+		return nil, nil
+	})
+	assert.Equal(t, custom, tool.InputSchema)
+}
+
+func TestToMCPToolFromRaw_NilParams(t *testing.T) {
+	var got map[string]any
+	tool := ToMCPToolFromRaw("raw", "d", map[string]any{}, func(ctx context.Context, params map[string]any) (any, error) {
+		got = params
+		return nil, nil
+	})
+	_, err := tool.Handler(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	_, err = tool.Handler(context.Background(), json.RawMessage{})
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestToMCPToolFromRaw_InvalidJSON(t *testing.T) {
+	tool := ToMCPToolFromRaw("raw", "d", map[string]any{}, func(ctx context.Context, params map[string]any) (any, error) {
+		t.Fatal("handler should not run")
+		return nil, nil
+	})
+	_, err := tool.Handler(context.Background(), json.RawMessage(`{`))
+	require.Error(t, err)
+}
+
+func TestGetMCPTool_HTTPOnly(t *testing.T) {
+	type Req struct{}
+	type Resp struct{}
+	def := &EndpointDef[Req, Resp]{
+		Name:     "h",
+		HTTPOnly: true,
+		Handler: func(ctx context.Context, req *Req) (*Resp, error) {
+			return &Resp{}, nil
+		},
+	}
+	assert.Nil(t, def.GetMCPTool())
+}
+
+func TestGetMCPTool_RawMCPHandlerPriority(t *testing.T) {
+	type Req struct{}
+	type Resp struct{}
+	def := &EndpointDef[Req, Resp]{
+		Name:        "n",
+		MCPToolName: "from-raw",
+		Handler: func(ctx context.Context, req *Req) (*Resp, error) {
+			t.Fatal("typed handler should not be used")
+			return nil, nil
+		},
+		RawMCPHandler: func(ctx context.Context, params map[string]any) (any, error) {
+			return "raw-out", nil
+		},
+	}
+	tool := def.GetMCPTool()
+	require.NotNil(t, tool)
+	assert.Equal(t, "from-raw", tool.Name)
+	out, err := tool.Handler(context.Background(), json.RawMessage(`{"a":1}`))
+	require.NoError(t, err)
+	assert.Equal(t, "raw-out", out)
+}
+
+func TestGetMCPTool_HandlerOnly(t *testing.T) {
+	type Req struct{}
+	type Resp struct{ OK bool `json:"ok"` }
+	def := &EndpointDef[Req, Resp]{
+		Name: "only-handler",
+		Handler: func(ctx context.Context, req *Req) (*Resp, error) {
+			return &Resp{OK: true}, nil
+		},
+	}
+	tool := def.GetMCPTool()
+	require.NotNil(t, tool)
+	assert.Equal(t, "only-handler", tool.Name)
+}
+
+func TestGetMCPTool_NoHandler(t *testing.T) {
+	type Req struct{}
+	type Resp struct{}
+	def := &EndpointDef[Req, Resp]{Name: "empty"}
+	assert.Nil(t, def.GetMCPTool())
+}
+
+func TestToGinHandler_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	type Req struct {
+		Q string `query:"q"`
+	}
+	type Resp struct {
+		Echo string `json:"echo"`
+	}
+	h := ToGinHandler(func(ctx context.Context, req *Req) (*Resp, error) {
+		return &Resp{Echo: req.Q}, nil
+	})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/x?q=hi", nil)
+	h(c)
+	assert.Equal(t, http.StatusOK, w.Code)
+	var body Resp
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, "hi", body.Echo)
+}
+
+func TestToGinHandler_BindError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	type Req struct {
+		N int `query:"n"`
+	}
+	type Resp struct{}
+	h := ToGinHandler(func(ctx context.Context, req *Req) (*Resp, error) {
+		return &Resp{}, nil
+	})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/x?n=bad", nil)
+	h(c)
+	assert.Greater(t, len(c.Errors), 0)
+}
+
+func TestToGinHandler_HandlerError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	type Req struct{}
+	type Resp struct{}
+	want := errors.New("http-err")
+	h := ToGinHandler(func(ctx context.Context, req *Req) (*Resp, error) {
+		return nil, want
+	})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/x", nil)
+	h(c)
+	assert.Greater(t, len(c.Errors), 0)
+	assert.ErrorIs(t, c.Errors.Last().Err, want)
+}
+
+func TestGetGinHandler_MCPOnly(t *testing.T) {
+	type Req struct{}
+	type Resp struct{}
+	def := &EndpointDef[Req, Resp]{
+		MCPOnly: true,
+		Handler: func(ctx context.Context, req *Req) (*Resp, error) {
+			return &Resp{}, nil
+		},
+	}
+	assert.Nil(t, def.GetGinHandler())
+}
+
+func TestGetGinHandler_RawHTTPHandlerPriority(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	type Req struct{}
+	type Resp struct{}
+	var rawHits atomic.Int32
+	def := &EndpointDef[Req, Resp]{
+		Handler: func(ctx context.Context, req *Req) (*Resp, error) {
+			t.Fatal("Handler must not run when RawHTTP is set")
+			return nil, nil
+		},
+		RawHTTPHandler: func(c *gin.Context) {
+			rawHits.Add(1)
+			c.Status(http.StatusTeapot)
+		},
+	}
+	g := def.GetGinHandler()
+	require.NotNil(t, g)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+	g(c)
+	assert.Equal(t, 1, int(rawHits.Load()))
+	assert.Equal(t, http.StatusTeapot, c.Writer.Status(), "httptest recorder Code=%d (Gin may defer WriteHeader)", w.Code)
+}
+
+func TestGetGinHandler_HandlerOnly(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	type Req struct{}
+	type Resp struct{ OK bool `json:"ok"` }
+	def := &EndpointDef[Req, Resp]{
+		Handler: func(ctx context.Context, req *Req) (*Resp, error) {
+			return &Resp{OK: true}, nil
+		},
+	}
+	g := def.GetGinHandler()
+	require.NotNil(t, g)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/x", nil)
+	g(c)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestGetGinHandler_NoHandler(t *testing.T) {
+	type Req struct{}
+	type Resp struct{}
+	def := &EndpointDef[Req, Resp]{Name: "x"}
+	assert.Nil(t, def.GetGinHandler())
+}

--- a/SaFE/apiserver/pkg/mcp/unified/binding.go
+++ b/SaFE/apiserver/pkg/mcp/unified/binding.go
@@ -1,0 +1,229 @@
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+// See LICENSE for license information.
+
+package unified
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	tagQuery  = "query"
+	tagParam  = "param"
+	tagJSON   = "json"
+	tagHeader = "header"
+	tagMCP    = "mcp"
+)
+
+// BindGinRequest binds request parameters from gin.Context to a struct.
+// Supports tags: query, param, json (body), header.
+func BindGinRequest[Req any](c *gin.Context, req *Req) error {
+	v := reflect.ValueOf(req)
+	if v.Kind() != reflect.Ptr || v.IsNil() {
+		return fmt.Errorf("req must be a non-nil pointer")
+	}
+	v = v.Elem()
+	if v.Kind() != reflect.Struct {
+		return fmt.Errorf("req must be a pointer to struct")
+	}
+
+	method := c.Request.Method
+	if method == "POST" || method == "PUT" || method == "PATCH" {
+		if c.ContentType() == "application/json" {
+			if err := c.ShouldBindJSON(req); err != nil {
+				if c.Request.ContentLength > 0 {
+					return fmt.Errorf("failed to parse JSON body: %w", err)
+				}
+			}
+		}
+	}
+
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		fieldValue := v.Field(i)
+
+		if field.Anonymous && field.Type.Kind() == reflect.Struct {
+			if err := bindStructFields(c, v, i); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if !fieldValue.CanSet() {
+			continue
+		}
+
+		if queryTag := field.Tag.Get(tagQuery); queryTag != "" {
+			queryTag = parseTagName(queryTag)
+			if value := c.Query(queryTag); value != "" {
+				if err := setFieldValue(fieldValue, value); err != nil {
+					return fmt.Errorf("failed to set query param %s: %w", queryTag, err)
+				}
+			}
+		}
+
+		if paramTag := field.Tag.Get(tagParam); paramTag != "" {
+			paramTag = parseTagName(paramTag)
+			if value := c.Param(paramTag); value != "" {
+				if err := setFieldValue(fieldValue, value); err != nil {
+					return fmt.Errorf("failed to set path param %s: %w", paramTag, err)
+				}
+			}
+		}
+
+		if headerTag := field.Tag.Get(tagHeader); headerTag != "" {
+			headerTag = parseTagName(headerTag)
+			if value := c.GetHeader(headerTag); value != "" {
+				if err := setFieldValue(fieldValue, value); err != nil {
+					return fmt.Errorf("failed to set header %s: %w", headerTag, err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func bindStructFields(c *gin.Context, parent reflect.Value, embeddedIdx int) error {
+	embedded := parent.Field(embeddedIdx)
+	if embedded.Kind() != reflect.Struct {
+		return nil
+	}
+
+	t := embedded.Type()
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		fieldValue := embedded.Field(i)
+		if !fieldValue.CanSet() {
+			continue
+		}
+
+		if queryTag := field.Tag.Get(tagQuery); queryTag != "" {
+			queryTag = parseTagName(queryTag)
+			if value := c.Query(queryTag); value != "" {
+				if err := setFieldValue(fieldValue, value); err != nil {
+					return err
+				}
+			}
+		}
+
+		if paramTag := field.Tag.Get(tagParam); paramTag != "" {
+			paramTag = parseTagName(paramTag)
+			if value := c.Param(paramTag); value != "" {
+				if err := setFieldValue(fieldValue, value); err != nil {
+					return err
+				}
+			}
+		}
+
+		if headerTag := field.Tag.Get(tagHeader); headerTag != "" {
+			headerTag = parseTagName(headerTag)
+			if value := c.GetHeader(headerTag); value != "" {
+				if err := setFieldValue(fieldValue, value); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// BindMCPRequest binds MCP request parameters (JSON) to a struct.
+func BindMCPRequest[Req any](params json.RawMessage, req *Req) error {
+	if len(params) == 0 {
+		return nil
+	}
+	return json.Unmarshal(params, req)
+}
+
+func parseTagName(tag string) string {
+	if idx := strings.Index(tag, ","); idx != -1 {
+		return tag[:idx]
+	}
+	return tag
+}
+
+func setFieldValue(field reflect.Value, value string) error {
+	switch field.Kind() {
+	case reflect.String:
+		field.SetString(value)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		intVal, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return err
+		}
+		field.SetInt(intVal)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		uintVal, err := strconv.ParseUint(value, 10, 64)
+		if err != nil {
+			return err
+		}
+		field.SetUint(uintVal)
+	case reflect.Float32, reflect.Float64:
+		floatVal, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return err
+		}
+		field.SetFloat(floatVal)
+	case reflect.Bool:
+		boolVal, err := strconv.ParseBool(value)
+		if err != nil {
+			return err
+		}
+		field.SetBool(boolVal)
+	case reflect.Slice:
+		if field.Type().Elem().Kind() == reflect.String {
+			parts := strings.Split(value, ",")
+			slice := reflect.MakeSlice(field.Type(), len(parts), len(parts))
+			for i, part := range parts {
+				slice.Index(i).SetString(strings.TrimSpace(part))
+			}
+			field.Set(slice)
+		} else {
+			return fmt.Errorf("unsupported slice element type: %s", field.Type().Elem().Kind())
+		}
+	case reflect.Ptr:
+		if field.IsNil() {
+			field.Set(reflect.New(field.Type().Elem()))
+		}
+		return setFieldValue(field.Elem(), value)
+	default:
+		return fmt.Errorf("unsupported field type: %s", field.Kind())
+	}
+	return nil
+}
+
+// MCPTagOptions holds parsed mcp tag options.
+type MCPTagOptions struct {
+	Name        string
+	Description string
+	Required    bool
+}
+
+// ParseMCPTag parses the mcp struct tag.
+// Format: mcp:"name,description=xxx,required"
+func ParseMCPTag(tag string) MCPTagOptions {
+	opts := MCPTagOptions{}
+	parts := strings.Split(tag, ",")
+	for i, part := range parts {
+		part = strings.TrimSpace(part)
+		if i == 0 {
+			opts.Name = part
+			continue
+		}
+		if part == "required" {
+			opts.Required = true
+			continue
+		}
+		if strings.HasPrefix(part, "description=") {
+			opts.Description = strings.TrimPrefix(part, "description=")
+		}
+	}
+	return opts
+}

--- a/SaFE/apiserver/pkg/mcp/unified/binding_test.go
+++ b/SaFE/apiserver/pkg/mcp/unified/binding_test.go
@@ -1,0 +1,217 @@
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+// See LICENSE for license information.
+
+package unified
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func ginCtxFromReq(req *http.Request) (*gin.Context, *httptest.ResponseRecorder) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+	return c, w
+}
+
+func TestBindGinRequest_Query(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	type R struct {
+		Name string `query:"name"`
+	}
+	req := httptest.NewRequest(http.MethodGet, "/?name=value", nil)
+	c, _ := ginCtxFromReq(req)
+	var got R
+	require.NoError(t, BindGinRequest(c, &got))
+	assert.Equal(t, "value", got.Name)
+}
+
+func TestBindGinRequest_Param(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	type R struct {
+		ID string `param:"id"`
+	}
+	req := httptest.NewRequest(http.MethodGet, "/x/abc", nil)
+	c, _ := ginCtxFromReq(req)
+	c.Params = []gin.Param{{Key: "id", Value: "abc"}}
+	var got R
+	require.NoError(t, BindGinRequest(c, &got))
+	assert.Equal(t, "abc", got.ID)
+}
+
+func TestBindGinRequest_Header(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	type R struct {
+		Token string `header:"X-Token"`
+	}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Token", "secret")
+	c, _ := ginCtxFromReq(req)
+	var got R
+	require.NoError(t, BindGinRequest(c, &got))
+	assert.Equal(t, "secret", got.Token)
+}
+
+func TestBindGinRequest_JSONBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	type R struct {
+		Foo string `json:"foo"`
+	}
+	body := bytes.NewBufferString(`{"foo":"bar"}`)
+	req := httptest.NewRequest(http.MethodPost, "/", body)
+	req.Header.Set("Content-Type", "application/json")
+	c, _ := ginCtxFromReq(req)
+	var got R
+	require.NoError(t, BindGinRequest(c, &got))
+	assert.Equal(t, "bar", got.Foo)
+}
+
+func TestBindGinRequest_PtrError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	type R struct{ X int }
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	c, _ := ginCtxFromReq(req)
+
+	var n int
+	err := BindGinRequest(c, &n)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pointer to struct")
+
+	var nilPtr *R
+	err = BindGinRequest(c, nilPtr)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-nil pointer")
+}
+
+func TestBindGinRequest_AllTypesViaQuery(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	type R struct {
+		I   int      `query:"i"`
+		U   uint     `query:"u"`
+		F   float64  `query:"f"`
+		B   bool     `query:"b"`
+		S   string   `query:"s"`
+		Sl  []string `query:"sl"`
+		Pi  *int     `query:"pi"`
+	}
+	raw := "/?i=-3&u=42&f=1.5&b=true&s=hi&sl=a,b,%20c&pi=7"
+	req := httptest.NewRequest(http.MethodGet, raw, nil)
+	c, _ := ginCtxFromReq(req)
+	var got R
+	require.NoError(t, BindGinRequest(c, &got))
+	assert.Equal(t, -3, got.I)
+	assert.Equal(t, uint(42), got.U)
+	assert.InEpsilon(t, 1.5, got.F, 1e-9)
+	assert.True(t, got.B)
+	assert.Equal(t, "hi", got.S)
+	assert.Equal(t, []string{"a", "b", "c"}, got.Sl)
+	require.NotNil(t, got.Pi)
+	assert.Equal(t, 7, *got.Pi)
+}
+
+func TestBindGinRequest_ParseError_Int(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	type R struct {
+		Count int `query:"count"`
+	}
+	req := httptest.NewRequest(http.MethodGet, "/?count=not-a-number", nil)
+	c, _ := ginCtxFromReq(req)
+	var got R
+	err := BindGinRequest(c, &got)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to set")
+}
+
+func TestBindGinRequest_EmbeddedStruct(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	type Inner struct {
+		A string `query:"a"`
+		B int    `query:"b"`
+	}
+	type Outer struct {
+		Inner
+	}
+	req := httptest.NewRequest(http.MethodGet, "/?a=embed&b=99", nil)
+	c, _ := ginCtxFromReq(req)
+	var got Outer
+	require.NoError(t, BindGinRequest(c, &got))
+	assert.Equal(t, "embed", got.A)
+	assert.Equal(t, 99, got.B)
+}
+
+func TestBindMCPRequest(t *testing.T) {
+	type R struct {
+		X int    `json:"x"`
+		Y string `json:"y"`
+	}
+	raw := json.RawMessage(`{"x":3,"y":"z"}`)
+	var got R
+	require.NoError(t, BindMCPRequest(raw, &got))
+	assert.Equal(t, 3, got.X)
+	assert.Equal(t, "z", got.Y)
+}
+
+func TestBindMCPRequest_Empty(t *testing.T) {
+	type R struct {
+		X int `json:"x"`
+	}
+	var got R
+	require.NoError(t, BindMCPRequest(nil, &got))
+	assert.Zero(t, got.X)
+	require.NoError(t, BindMCPRequest(json.RawMessage{}, &got))
+	assert.Zero(t, got.X)
+}
+
+func TestParseMCPTag(t *testing.T) {
+	cases := []struct {
+		tag  string
+		name string
+		desc string
+		req  bool
+	}{
+		{"name", "name", "", false},
+		{"name,description=hello,required", "name", "hello", true},
+		{"name,required", "name", "", true},
+		{"name,description=multi word", "name", "multi word", false},
+	}
+	for _, tc := range cases {
+		opts := ParseMCPTag(tc.tag)
+		assert.Equal(t, tc.name, opts.Name, "tag=%q", tc.tag)
+		assert.Equal(t, tc.desc, opts.Description, "tag=%q", tc.tag)
+		assert.Equal(t, tc.req, opts.Required, "tag=%q", tc.tag)
+	}
+}
+
+func TestParseTagName(t *testing.T) {
+	assert.Equal(t, "name", parseTagName("name,omitempty"))
+	assert.Equal(t, "name", parseTagName("name"))
+}
+
+func TestSetFieldValue_Errors(t *testing.T) {
+	vBool := reflect.ValueOf(new(bool)).Elem()
+	err := setFieldValue(vBool, "notbool")
+	require.Error(t, err)
+
+	vFloat := reflect.ValueOf(new(float64)).Elem()
+	err = setFieldValue(vFloat, "xyz")
+	require.Error(t, err)
+
+	vIntSlice := reflect.ValueOf(new([]int)).Elem()
+	err = setFieldValue(vIntSlice, "1,2")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported slice")
+
+	vMap := reflect.ValueOf(new(map[string]int)).Elem()
+	err = setFieldValue(vMap, "anything")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported field type")
+}

--- a/SaFE/apiserver/pkg/mcp/unified/gin_adapter.go
+++ b/SaFE/apiserver/pkg/mcp/unified/gin_adapter.go
@@ -1,0 +1,41 @@
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+// See LICENSE for license information.
+
+package unified
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// ToGinHandler converts a unified Handler to gin.HandlerFunc.
+func ToGinHandler[Req, Resp any](h Handler[Req, Resp]) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var req Req
+		if err := BindGinRequest(c, &req); err != nil {
+			_ = c.Error(err)
+			return
+		}
+		resp, err := h(c.Request.Context(), &req)
+		if err != nil {
+			_ = c.Error(err)
+			return
+		}
+		c.JSON(http.StatusOK, resp)
+	}
+}
+
+// GetGinHandler returns the appropriate gin.HandlerFunc for the endpoint.
+func (def *EndpointDef[Req, Resp]) GetGinHandler() gin.HandlerFunc {
+	if def.MCPOnly {
+		return nil
+	}
+	if def.RawHTTPHandler != nil {
+		return gin.HandlerFunc(def.RawHTTPHandler)
+	}
+	if def.Handler != nil {
+		return ToGinHandler(def.Handler)
+	}
+	return nil
+}

--- a/SaFE/apiserver/pkg/mcp/unified/mcp_adapter.go
+++ b/SaFE/apiserver/pkg/mcp/unified/mcp_adapter.go
@@ -1,0 +1,64 @@
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+// See LICENSE for license information.
+
+package unified
+
+import (
+	"context"
+	"encoding/json"
+
+	mcpserver "github.com/AMD-AIG-AIMA/SAFE/common/pkg/mcp/server"
+)
+
+// ToMCPTool converts a unified Handler to an MCPTool.
+func ToMCPTool[Req, Resp any](def *EndpointDef[Req, Resp]) *mcpserver.MCPTool {
+	toolName := def.GetMCPToolName()
+	return &mcpserver.MCPTool{
+		Name:        toolName,
+		Description: def.Description,
+		InputSchema: GenerateJSONSchema[Req](),
+		Handler: func(ctx context.Context, params json.RawMessage) (any, error) {
+			var req Req
+			if err := BindMCPRequest(params, &req); err != nil {
+				return nil, err
+			}
+			return def.Handler(ctx, &req)
+		},
+	}
+}
+
+// ToMCPToolFromRaw creates an MCPTool from a RawMCPHandler.
+// If inputSchema is nil, an empty object schema is used.
+func ToMCPToolFromRaw(name, description string, inputSchema map[string]any, handler RawMCPHandler) *mcpserver.MCPTool {
+	if inputSchema == nil {
+		inputSchema = map[string]any{"type": "object", "properties": map[string]any{}}
+	}
+	return &mcpserver.MCPTool{
+		Name:        name,
+		Description: description,
+		InputSchema: inputSchema,
+		Handler: func(ctx context.Context, params json.RawMessage) (any, error) {
+			var paramsMap map[string]any
+			if len(params) > 0 {
+				if err := json.Unmarshal(params, &paramsMap); err != nil {
+					return nil, err
+				}
+			}
+			return handler(ctx, paramsMap)
+		},
+	}
+}
+
+// GetMCPTool returns an MCPTool for MCP registration, or nil if HTTP-only.
+func (def *EndpointDef[Req, Resp]) GetMCPTool() *mcpserver.MCPTool {
+	if def.HTTPOnly {
+		return nil
+	}
+	if def.RawMCPHandler != nil {
+		return ToMCPToolFromRaw(def.GetMCPToolName(), def.Description, def.MCPInputSchema, def.RawMCPHandler)
+	}
+	if def.Handler != nil {
+		return ToMCPTool(def)
+	}
+	return nil
+}

--- a/SaFE/apiserver/pkg/mcp/unified/registry.go
+++ b/SaFE/apiserver/pkg/mcp/unified/registry.go
@@ -70,6 +70,7 @@ func (r *Registry) InitGinRoutes(group *gin.RouterGroup) error {
 		method := ep.GetHTTPMethod()
 		path := ep.GetHTTPPath()
 
+		registered := true
 		switch method {
 		case "GET":
 			group.GET(path, handler)
@@ -88,9 +89,12 @@ func (r *Registry) InitGinRoutes(group *gin.RouterGroup) error {
 		case "Any", "ANY", "any":
 			group.Any(path, handler)
 		default:
+			registered = false
 			klog.Warningf("Unknown HTTP method %s for endpoint %s", method, ep.GetName())
 		}
-		klog.Infof("Registered HTTP route: %s %s -> %s", method, path, ep.GetName())
+		if registered {
+			klog.Infof("Registered HTTP route: %s %s -> %s", method, path, ep.GetName())
+		}
 	}
 	return nil
 }

--- a/SaFE/apiserver/pkg/mcp/unified/registry.go
+++ b/SaFE/apiserver/pkg/mcp/unified/registry.go
@@ -1,0 +1,195 @@
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+// See LICENSE for license information.
+
+package unified
+
+import (
+	"sync"
+
+	mcpserver "github.com/AMD-AIG-AIMA/SAFE/common/pkg/mcp/server"
+	"github.com/gin-gonic/gin"
+	"k8s.io/klog/v2"
+)
+
+// Registry holds all endpoint definitions for HTTP and MCP registration.
+type Registry struct {
+	mu        sync.RWMutex
+	endpoints []EndpointRegistration
+	mcpTools  []*mcpserver.MCPTool
+}
+
+var (
+	globalRegistry     *Registry
+	globalRegistryOnce sync.Once
+)
+
+func GetRegistry() *Registry {
+	globalRegistryOnce.Do(func() {
+		globalRegistry = &Registry{
+			endpoints: make([]EndpointRegistration, 0),
+			mcpTools:  make([]*mcpserver.MCPTool, 0),
+		}
+	})
+	return globalRegistry
+}
+
+// Register registers an endpoint definition to the global registry.
+func Register[Req, Resp any](def *EndpointDef[Req, Resp]) {
+	GetRegistry().RegisterEndpoint(def)
+}
+
+func (r *Registry) RegisterEndpoint(ep EndpointRegistration) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.endpoints = append(r.endpoints, ep)
+
+	if tool := ep.GetMCPTool(); tool != nil {
+		r.mcpTools = append(r.mcpTools, tool)
+	}
+
+	klog.Infof("Registered endpoint: %s (HTTP: %s %s, MCP: %s)",
+		ep.GetName(), ep.GetHTTPMethod(), ep.GetHTTPPath(), ep.GetMCPToolName())
+}
+
+// InitGinRoutes registers all unified endpoints to a Gin router group.
+func (r *Registry) InitGinRoutes(group *gin.RouterGroup) error {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, ep := range r.endpoints {
+		if ep.IsMCPOnly() {
+			continue
+		}
+		handler := ep.GetGinHandler()
+		if handler == nil {
+			klog.Warningf("Endpoint %s has no HTTP handler, skipping", ep.GetName())
+			continue
+		}
+
+		method := ep.GetHTTPMethod()
+		path := ep.GetHTTPPath()
+
+		switch method {
+		case "GET":
+			group.GET(path, handler)
+		case "POST":
+			group.POST(path, handler)
+		case "PUT":
+			group.PUT(path, handler)
+		case "DELETE":
+			group.DELETE(path, handler)
+		case "PATCH":
+			group.PATCH(path, handler)
+		case "HEAD":
+			group.HEAD(path, handler)
+		case "OPTIONS":
+			group.OPTIONS(path, handler)
+		case "Any", "ANY", "any":
+			group.Any(path, handler)
+		default:
+			klog.Warningf("Unknown HTTP method %s for endpoint %s", method, ep.GetName())
+		}
+		klog.Infof("Registered HTTP route: %s %s -> %s", method, path, ep.GetName())
+	}
+	return nil
+}
+
+func (r *Registry) GetMCPTools() []*mcpserver.MCPTool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	tools := make([]*mcpserver.MCPTool, len(r.mcpTools))
+	copy(tools, r.mcpTools)
+	return tools
+}
+
+func (r *Registry) GetMCPToolsByGroup(group string) []*mcpserver.MCPTool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var filtered []*mcpserver.MCPTool
+	for _, ep := range r.endpoints {
+		if ep.GetGroup() == group {
+			if tool := ep.GetMCPTool(); tool != nil {
+				filtered = append(filtered, tool)
+			}
+		}
+	}
+	return filtered
+}
+
+func (r *Registry) GetEndpoints() []EndpointRegistration {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	eps := make([]EndpointRegistration, len(r.endpoints))
+	copy(eps, r.endpoints)
+	return eps
+}
+
+func (r *Registry) GetEndpointByName(name string) EndpointRegistration {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, ep := range r.endpoints {
+		if ep.GetName() == name {
+			return ep
+		}
+	}
+	return nil
+}
+
+func (r *Registry) GetMCPToolByName(name string) *mcpserver.MCPTool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, tool := range r.mcpTools {
+		if tool.Name == name {
+			return tool
+		}
+	}
+	return nil
+}
+
+func (r *Registry) Clear() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.endpoints = make([]EndpointRegistration, 0)
+	r.mcpTools = make([]*mcpserver.MCPTool, 0)
+}
+
+func (r *Registry) Count() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.endpoints)
+}
+
+func (r *Registry) MCPToolCount() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.mcpTools)
+}
+
+func (r *Registry) GetEndpointByPath(path string) EndpointRegistration {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, ep := range r.endpoints {
+		if ep.GetHTTPPath() == path {
+			return ep
+		}
+	}
+	return nil
+}
+
+func (r *Registry) GetEndpointByMethodAndPath(method, path string) EndpointRegistration {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, ep := range r.endpoints {
+		if ep.GetHTTPPath() == path && ep.GetHTTPMethod() == method {
+			return ep
+		}
+	}
+	for _, ep := range r.endpoints {
+		if ep.GetHTTPPath() == path {
+			return ep
+		}
+	}
+	return nil
+}

--- a/SaFE/apiserver/pkg/mcp/unified/registry_test.go
+++ b/SaFE/apiserver/pkg/mcp/unified/registry_test.go
@@ -1,0 +1,225 @@
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+// See LICENSE for license information.
+
+package unified
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type emptyReq struct{}
+type emptyResp struct{ OK bool `json:"ok"` }
+
+func makeEndpoint(name, method, path string, mcpOnly, httpOnly bool) *EndpointDef[emptyReq, emptyResp] {
+	return &EndpointDef[emptyReq, emptyResp]{
+		Name: name, HTTPMethod: method, HTTPPath: path,
+		MCPOnly: mcpOnly, HTTPOnly: httpOnly,
+		Handler: func(ctx context.Context, req *emptyReq) (*emptyResp, error) {
+			return &emptyResp{OK: true}, nil
+		},
+	}
+}
+
+func TestRegistry_RegisterAndCount(t *testing.T) {
+	GetRegistry().Clear()
+	defer GetRegistry().Clear()
+
+	Register(makeEndpoint("a", "GET", "/a", false, false))
+	Register(makeEndpoint("b", "GET", "/b", false, false))
+	Register(makeEndpoint("c", "GET", "/c", false, false))
+
+	assert.Equal(t, 3, GetRegistry().Count())
+}
+
+func TestRegistry_GetMCPTools(t *testing.T) {
+	GetRegistry().Clear()
+	defer GetRegistry().Clear()
+
+	Register(makeEndpoint("with-http-mcp", "GET", "/h1", false, false))
+	Register(makeEndpoint("http-only-skip", "GET", "/h2", false, true))
+	Register(makeEndpoint("mcp-only", "GET", "/h3", true, false))
+
+	assert.Equal(t, 3, GetRegistry().Count())
+	assert.Equal(t, 2, GetRegistry().MCPToolCount())
+
+	tools := GetRegistry().GetMCPTools()
+	require.Len(t, tools, 2)
+	names := make(map[string]bool)
+	for _, tool := range tools {
+		require.NotNil(t, tool)
+		names[tool.Name] = true
+	}
+	assert.True(t, names["with-http-mcp"])
+	assert.True(t, names["mcp-only"])
+	assert.False(t, names["http-only-skip"])
+}
+
+func TestRegistry_GetMCPToolsByGroup(t *testing.T) {
+	GetRegistry().Clear()
+	defer GetRegistry().Clear()
+
+	d1 := makeEndpoint("d1", "GET", "/d1", false, false)
+	d1.Group = "diagnostic"
+	Register(d1)
+
+	d2 := makeEndpoint("d2", "GET", "/d2", true, false)
+	d2.Group = "diagnostic"
+	Register(d2)
+
+	other := makeEndpoint("other", "GET", "/o", false, false)
+	other.Group = "ops"
+	Register(other)
+
+	diag := GetRegistry().GetMCPToolsByGroup("diagnostic")
+	require.Len(t, diag, 2)
+	got := map[string]struct{}{}
+	for _, tool := range diag {
+		got[tool.Name] = struct{}{}
+	}
+	assert.Contains(t, got, "d1")
+	assert.Contains(t, got, "d2")
+
+	ops := GetRegistry().GetMCPToolsByGroup("ops")
+	require.Len(t, ops, 1)
+	assert.Equal(t, "other", ops[0].Name)
+}
+
+func TestRegistry_GetEndpointByName(t *testing.T) {
+	GetRegistry().Clear()
+	defer GetRegistry().Clear()
+
+	Register(makeEndpoint("lookup-me", "GET", "/x", false, false))
+
+	ep := GetRegistry().GetEndpointByName("lookup-me")
+	require.NotNil(t, ep)
+	assert.Equal(t, "lookup-me", ep.GetName())
+
+	assert.Nil(t, GetRegistry().GetEndpointByName("missing"))
+}
+
+func TestRegistry_GetEndpointByMethodAndPath(t *testing.T) {
+	GetRegistry().Clear()
+	defer GetRegistry().Clear()
+
+	getEp := makeEndpoint("get-same", "GET", "/resource", false, false)
+	postEp := makeEndpoint("post-same", "POST", "/resource", false, false)
+	Register(getEp)
+	Register(postEp)
+
+	g := GetRegistry().GetEndpointByMethodAndPath("GET", "/resource")
+	require.NotNil(t, g)
+	assert.Equal(t, "get-same", g.GetName())
+
+	p := GetRegistry().GetEndpointByMethodAndPath("POST", "/resource")
+	require.NotNil(t, p)
+	assert.Equal(t, "post-same", p.GetName())
+
+	// Fallback: method mismatch → first registration with same path
+	fallback := GetRegistry().GetEndpointByMethodAndPath("PUT", "/resource")
+	require.NotNil(t, fallback)
+	assert.Equal(t, "get-same", fallback.GetName())
+}
+
+func TestRegistry_GetEndpointByPath(t *testing.T) {
+	GetRegistry().Clear()
+	defer GetRegistry().Clear()
+
+	Register(makeEndpoint("p1", "GET", "/only-path", false, false))
+
+	ep := GetRegistry().GetEndpointByPath("/only-path")
+	require.NotNil(t, ep)
+	assert.Equal(t, "p1", ep.GetName())
+	assert.Nil(t, GetRegistry().GetEndpointByPath("/nope"))
+}
+
+func TestRegistry_GetMCPToolByName(t *testing.T) {
+	GetRegistry().Clear()
+	defer GetRegistry().Clear()
+
+	custom := makeEndpoint("base-name", "GET", "/m", false, false)
+	custom.MCPToolName = "override-tool"
+	Register(custom)
+
+	tool := GetRegistry().GetMCPToolByName("override-tool")
+	require.NotNil(t, tool)
+	assert.Equal(t, "override-tool", tool.Name)
+
+	assert.Nil(t, GetRegistry().GetMCPToolByName("nope"))
+}
+
+func TestRegistry_Clear(t *testing.T) {
+	GetRegistry().Clear()
+	defer GetRegistry().Clear()
+
+	Register(makeEndpoint("x", "GET", "/x", false, false))
+	Register(makeEndpoint("y", "GET", "/y", true, false))
+	require.NotZero(t, GetRegistry().Count())
+	require.NotZero(t, GetRegistry().MCPToolCount())
+
+	GetRegistry().Clear()
+	assert.Zero(t, GetRegistry().Count())
+	assert.Zero(t, GetRegistry().MCPToolCount())
+}
+
+func TestRegistry_InitGinRoutes_Methods(t *testing.T) {
+	GetRegistry().Clear()
+	defer GetRegistry().Clear()
+
+	gin.SetMode(gin.TestMode)
+
+	type row struct {
+		method   string
+		path     string
+		httpTest string // method for httptest (HEAD/OPTIONS need exact match)
+	}
+	tests := []row{
+		{"GET", "/tm/get", "GET"},
+		{"POST", "/tm/post", "POST"},
+		{"PUT", "/tm/put", "PUT"},
+		{"DELETE", "/tm/delete", "DELETE"},
+		{"PATCH", "/tm/patch", "PATCH"},
+		{"HEAD", "/tm/head", "HEAD"},
+		{"OPTIONS", "/tm/options", "OPTIONS"},
+		{"Any", "/tm/any", "GET"},      // Any registers all methods; probe with GET
+		{"ANY", "/tm/any_upper", "GET"},
+		{"any", "/tm/any_lower", "GET"},
+		{"UNKNOWN", "/tm/unknown", ""}, // no route expected
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		name := tc.method + "_" + tc.path
+		t.Run(name, func(t *testing.T) {
+			GetRegistry().Clear()
+			defer GetRegistry().Clear()
+
+			ep := makeEndpoint("ep-"+tc.method, tc.method, tc.path, false, false)
+			Register(ep)
+
+			r := gin.New()
+			grp := r.Group("/api")
+			err := GetRegistry().InitGinRoutes(grp)
+			require.NoError(t, err)
+
+			if tc.httpTest == "" {
+				req := httptest.NewRequest(http.MethodGet, "/api"+tc.path, nil)
+				w := httptest.NewRecorder()
+				r.ServeHTTP(w, req)
+				assert.Equal(t, http.StatusNotFound, w.Code)
+				return
+			}
+
+			req := httptest.NewRequest(tc.httpTest, "/api"+tc.path, nil)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		})
+	}
+}

--- a/SaFE/apiserver/pkg/mcp/unified/schema.go
+++ b/SaFE/apiserver/pkg/mcp/unified/schema.go
@@ -1,0 +1,165 @@
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+// See LICENSE for license information.
+
+package unified
+
+import (
+	"reflect"
+	"strings"
+)
+
+type JSONSchema struct {
+	Type        string                `json:"type"`
+	Description string                `json:"description,omitempty"`
+	Properties  map[string]JSONSchema `json:"properties,omitempty"`
+	Required    []string              `json:"required,omitempty"`
+	Items       *JSONSchema           `json:"items,omitempty"`
+	Enum        []any                 `json:"enum,omitempty"`
+	Default     any                   `json:"default,omitempty"`
+}
+
+// GenerateJSONSchema generates a JSON Schema from a struct type using tags.
+func GenerateJSONSchema[Req any]() map[string]any {
+	var req Req
+	t := reflect.TypeOf(req)
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return map[string]any{"type": "object"}
+	}
+	schema := generateSchemaFromType(t)
+	return schemaToMap(schema)
+}
+
+func generateSchemaFromType(t reflect.Type) JSONSchema {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	schema := JSONSchema{
+		Type:       "object",
+		Properties: make(map[string]JSONSchema),
+		Required:   []string{},
+	}
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+
+		if field.Anonymous {
+			embeddedSchema := generateSchemaFromType(field.Type)
+			for name, prop := range embeddedSchema.Properties {
+				schema.Properties[name] = prop
+			}
+			schema.Required = append(schema.Required, embeddedSchema.Required...)
+			continue
+		}
+
+		fieldName := getFieldName(field)
+		if fieldName == "-" {
+			continue
+		}
+
+		fieldSchema := typeToSchema(field.Type)
+
+		if mcpTag := field.Tag.Get(tagMCP); mcpTag != "" {
+			mcpOpts := ParseMCPTag(mcpTag)
+			if mcpOpts.Description != "" {
+				fieldSchema.Description = mcpOpts.Description
+			}
+			if mcpOpts.Required {
+				schema.Required = append(schema.Required, fieldName)
+			}
+			if mcpOpts.Name != "" {
+				fieldName = mcpOpts.Name
+			}
+		}
+		schema.Properties[fieldName] = fieldSchema
+	}
+	return schema
+}
+
+func typeToSchema(t reflect.Type) JSONSchema {
+	if t.Kind() == reflect.Ptr {
+		return typeToSchema(t.Elem())
+	}
+
+	switch t.Kind() {
+	case reflect.String:
+		return JSONSchema{Type: "string"}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return JSONSchema{Type: "integer"}
+	case reflect.Float32, reflect.Float64:
+		return JSONSchema{Type: "number"}
+	case reflect.Bool:
+		return JSONSchema{Type: "boolean"}
+	case reflect.Slice, reflect.Array:
+		itemSchema := typeToSchema(t.Elem())
+		return JSONSchema{Type: "array", Items: &itemSchema}
+	case reflect.Map:
+		return JSONSchema{Type: "object"}
+	case reflect.Struct:
+		if t.String() == "time.Time" {
+			return JSONSchema{Type: "string", Description: "ISO 8601 datetime"}
+		}
+		return generateSchemaFromType(t)
+	case reflect.Interface:
+		return JSONSchema{Type: "object"}
+	default:
+		return JSONSchema{Type: "string"}
+	}
+}
+
+func getFieldName(field reflect.StructField) string {
+	if jsonTag := field.Tag.Get("json"); jsonTag != "" {
+		name := parseTagName(jsonTag)
+		if name != "" {
+			return name
+		}
+	}
+	if queryTag := field.Tag.Get("query"); queryTag != "" {
+		name := parseTagName(queryTag)
+		if name != "" {
+			return name
+		}
+	}
+	if paramTag := field.Tag.Get("param"); paramTag != "" {
+		name := parseTagName(paramTag)
+		if name != "" {
+			return name
+		}
+	}
+	return strings.ToLower(field.Name)
+}
+
+func schemaToMap(schema JSONSchema) map[string]any {
+	result := map[string]any{"type": schema.Type}
+
+	if schema.Description != "" {
+		result["description"] = schema.Description
+	}
+	if len(schema.Properties) > 0 {
+		props := make(map[string]any)
+		for name, prop := range schema.Properties {
+			props[name] = schemaToMap(prop)
+		}
+		result["properties"] = props
+	}
+	if len(schema.Required) > 0 {
+		result["required"] = schema.Required
+	}
+	if schema.Items != nil {
+		result["items"] = schemaToMap(*schema.Items)
+	}
+	if len(schema.Enum) > 0 {
+		result["enum"] = schema.Enum
+	}
+	if schema.Default != nil {
+		result["default"] = schema.Default
+	}
+	return result
+}

--- a/SaFE/apiserver/pkg/mcp/unified/schema_test.go
+++ b/SaFE/apiserver/pkg/mcp/unified/schema_test.go
@@ -1,0 +1,211 @@
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+// See LICENSE for license information.
+
+package unified
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func getProp(t *testing.T, m map[string]any, key string) map[string]any {
+	t.Helper()
+	props, ok := m["properties"].(map[string]any)
+	require.True(t, ok)
+	p, ok := props[key].(map[string]any)
+	require.True(t, ok, "missing property %q", key)
+	return p
+}
+
+func TestGenerateJSONSchema_Primitives(t *testing.T) {
+	type T struct {
+		S string  `json:"s"`
+		I int     `json:"i"`
+		B bool    `json:"b"`
+		F float64 `json:"f"`
+	}
+	s := GenerateJSONSchema[T]()
+	assert.Equal(t, "object", s["type"])
+	assert.Equal(t, "string", getProp(t, s, "s")["type"])
+	assert.Equal(t, "integer", getProp(t, s, "i")["type"])
+	assert.Equal(t, "boolean", getProp(t, s, "b")["type"])
+	assert.Equal(t, "number", getProp(t, s, "f")["type"])
+}
+
+func TestGenerateJSONSchema_Slice(t *testing.T) {
+	type T struct {
+		Strs []string `json:"strs"`
+		Nums []int    `json:"nums"`
+	}
+	s := GenerateJSONSchema[T]()
+	arrS := getProp(t, s, "strs")
+	assert.Equal(t, "array", arrS["type"])
+	itemsS, ok := arrS["items"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "string", itemsS["type"])
+
+	arrN := getProp(t, s, "nums")
+	assert.Equal(t, "array", arrN["type"])
+	itemsN, ok := arrN["items"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "integer", itemsN["type"])
+}
+
+func TestGenerateJSONSchema_Pointer(t *testing.T) {
+	type T struct {
+		P *string `json:"p"`
+	}
+	s := GenerateJSONSchema[T]()
+	assert.Equal(t, "string", getProp(t, s, "p")["type"])
+}
+
+func TestGenerateJSONSchema_Struct(t *testing.T) {
+	type Inner struct {
+		Z int `json:"z"`
+	}
+	type T struct {
+		N Inner `json:"n"`
+	}
+	s := GenerateJSONSchema[T]()
+	nested := getProp(t, s, "n")
+	assert.Equal(t, "object", nested["type"])
+	zProp, ok := nested["properties"].(map[string]any)["z"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "integer", zProp["type"])
+}
+
+func TestGenerateJSONSchema_TimeField(t *testing.T) {
+	type T struct {
+		When time.Time `json:"when"`
+	}
+	s := GenerateJSONSchema[T]()
+	p := getProp(t, s, "when")
+	assert.Equal(t, "string", p["type"])
+	assert.Equal(t, "ISO 8601 datetime", p["description"])
+}
+
+func TestGenerateJSONSchema_Map(t *testing.T) {
+	type T struct {
+		M map[string]int `json:"m"`
+	}
+	s := GenerateJSONSchema[T]()
+	assert.Equal(t, "object", getProp(t, s, "m")["type"])
+}
+
+func TestGenerateJSONSchema_FieldNameJSON(t *testing.T) {
+	type T struct {
+		X string `json:"my_name,omitempty"`
+	}
+	s := GenerateJSONSchema[T]()
+	props, ok := s["properties"].(map[string]any)
+	require.True(t, ok)
+	_, ok = props["my_name"]
+	assert.True(t, ok)
+}
+
+func TestGenerateJSONSchema_FieldNameQuery(t *testing.T) {
+	type T struct {
+		X string `query:"q_name"`
+	}
+	s := GenerateJSONSchema[T]()
+	_, ok := s["properties"].(map[string]any)["q_name"]
+	assert.True(t, ok)
+}
+
+func TestGenerateJSONSchema_FieldNameParam(t *testing.T) {
+	type T struct {
+		X string `param:"id"`
+	}
+	s := GenerateJSONSchema[T]()
+	_, ok := s["properties"].(map[string]any)["id"]
+	assert.True(t, ok)
+}
+
+func TestGenerateJSONSchema_FieldNameDash(t *testing.T) {
+	type T struct {
+		Secret string `json:"-"`
+		Public string `json:"pub"`
+	}
+	s := GenerateJSONSchema[T]()
+	props := s["properties"].(map[string]any)
+	_, bad := props["-"]
+	assert.False(t, bad)
+	_, ok := props["pub"]
+	assert.True(t, ok)
+}
+
+func TestGenerateJSONSchema_MCPTag_DescriptionAndRequired(t *testing.T) {
+	type T struct {
+		Foo string `mcp:"foo,description=hello,required"`
+	}
+	m := GenerateJSONSchema[T]()
+	p := getProp(t, m, "foo")
+	assert.Equal(t, "hello", p["description"])
+	req, ok := m["required"].([]string)
+	require.True(t, ok)
+	assert.Contains(t, req, "foo", "required should name the property key used in schema (see generateSchemaFromType ordering)")
+}
+
+func TestGenerateJSONSchema_MCPTagRenames(t *testing.T) {
+	type T struct {
+		X string `mcp:"renamed"`
+	}
+	m := GenerateJSONSchema[T]()
+	props := m["properties"].(map[string]any)
+	_, hasRenamed := props["renamed"]
+	assert.True(t, hasRenamed)
+}
+
+func TestGenerateJSONSchema_NonStruct(t *testing.T) {
+	m := GenerateJSONSchema[int]()
+	assert.Equal(t, "object", m["type"])
+}
+
+func TestGenerateJSONSchema_UnexportedSkipped(t *testing.T) {
+	type T struct {
+		Public  string `json:"public"`
+		private string
+	}
+	m := GenerateJSONSchema[T]()
+	props := m["properties"].(map[string]any)
+	assert.Contains(t, props, "public")
+	assert.NotContains(t, props, "private")
+}
+
+func TestGenerateJSONSchema_EmbeddedStruct(t *testing.T) {
+	type Base struct {
+		A int `json:"a"`
+	}
+	type T struct {
+		Base
+		B string `json:"b"`
+	}
+	m := GenerateJSONSchema[T]()
+	props := m["properties"].(map[string]any)
+	assert.Contains(t, props, "a")
+	assert.Contains(t, props, "b")
+}
+
+func TestTypeToSchemaReflect(t *testing.T) {
+	st := typeToSchema(reflect.TypeFor[string]())
+	assert.Equal(t, "string", st.Type)
+}
+
+func TestGetFieldNameReflect(t *testing.T) {
+	type S struct {
+		Z int `json:"zeta"`
+	}
+	f, _ := reflect.TypeOf(S{}).FieldByName("Z")
+	assert.Equal(t, "zeta", getFieldName(f))
+}
+
+func TestSchemaToMapEmpty(t *testing.T) {
+	m := schemaToMap(JSONSchema{Type: "object"})
+	assert.Equal(t, "object", m["type"])
+	_, hasProps := m["properties"]
+	assert.False(t, hasProps)
+}

--- a/SaFE/apiserver/pkg/mcp/unified/types.go
+++ b/SaFE/apiserver/pkg/mcp/unified/types.go
@@ -1,0 +1,71 @@
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+// See LICENSE for license information.
+
+// Package unified provides a unified endpoint abstraction that allows defining
+// handlers once and exposing them via both HTTP (Gin) and MCP (Model Context Protocol).
+package unified
+
+import (
+	"context"
+
+	mcpserver "github.com/AMD-AIG-AIMA/SAFE/common/pkg/mcp/server"
+	"github.com/gin-gonic/gin"
+)
+
+// Handler is a generic handler function for standard request/response APIs.
+type Handler[Req, Resp any] func(ctx context.Context, req *Req) (*Resp, error)
+
+// RawHTTPHandler is for special cases that need direct HTTP access
+// (WebSocket, SSE streaming, file downloads, proxy requests).
+type RawHTTPHandler func(c *gin.Context)
+
+// RawMCPHandler is for MCP-specific complex operations.
+type RawMCPHandler func(ctx context.Context, params map[string]any) (any, error)
+
+// EndpointDef defines a unified endpoint registered as both HTTP and MCP.
+type EndpointDef[Req, Resp any] struct {
+	Name        string
+	Description string
+	Group       string // Tool group for MCP server isolation (e.g. "diagnostic")
+
+	Handler        Handler[Req, Resp]
+	RawHTTPHandler RawHTTPHandler
+	RawMCPHandler  RawMCPHandler
+
+	HTTPMethod string // GET, POST, PUT, DELETE, Any
+	HTTPPath   string
+
+	MCPToolName    string
+	MCPInputSchema map[string]any // Custom input schema for RawMCPHandler (optional)
+	MCPOnly        bool
+	HTTPOnly       bool
+}
+
+// EndpointRegistration is a non-generic interface for the registry.
+type EndpointRegistration interface {
+	GetName() string
+	GetDescription() string
+	GetHTTPMethod() string
+	GetHTTPPath() string
+	GetMCPToolName() string
+	IsHTTPOnly() bool
+	IsMCPOnly() bool
+	GetGinHandler() gin.HandlerFunc
+	GetMCPTool() *mcpserver.MCPTool
+	GetGroup() string
+}
+
+func (def *EndpointDef[Req, Resp]) GetName() string        { return def.Name }
+func (def *EndpointDef[Req, Resp]) GetDescription() string { return def.Description }
+func (def *EndpointDef[Req, Resp]) GetHTTPMethod() string  { return def.HTTPMethod }
+func (def *EndpointDef[Req, Resp]) GetHTTPPath() string    { return def.HTTPPath }
+func (def *EndpointDef[Req, Resp]) IsHTTPOnly() bool       { return def.HTTPOnly }
+func (def *EndpointDef[Req, Resp]) IsMCPOnly() bool        { return def.MCPOnly }
+func (def *EndpointDef[Req, Resp]) GetGroup() string       { return def.Group }
+
+func (def *EndpointDef[Req, Resp]) GetMCPToolName() string {
+	if def.MCPToolName != "" {
+		return def.MCPToolName
+	}
+	return def.Name
+}

--- a/SaFE/charts/primus-safe/templates/apiserver/config.yaml
+++ b/SaFE/charts/primus-safe/templates/apiserver/config.yaml
@@ -150,7 +150,7 @@ data:
       secret_path: {{ default "/etc/secrets/llm-gateway" (default dict .Values.llm_gateway).secret_path }}
     mcp:
       # Whether to enable MCP (Model Context Protocol) server for AI assistant integration
-      enabled: {{ default false (default dict .Values.mcp).enabled }}
+      enabled: {{ default true (default dict .Values.mcp).enabled }}
       base_path: {{ default "/mcp" (default dict .Values.mcp).base_path }}
       instructions: {{ default "SaFE API Server - GPU Cluster Management Tools via MCP" (default dict .Values.mcp).instructions | quote }}
 kind: ConfigMap

--- a/SaFE/charts/primus-safe/templates/apiserver/config.yaml
+++ b/SaFE/charts/primus-safe/templates/apiserver/config.yaml
@@ -151,7 +151,7 @@ data:
     mcp:
       # Whether to enable MCP (Model Context Protocol) server for AI assistant integration
       enabled: {{ default true (default dict .Values.mcp).enabled }}
-      base_path: {{ default "/mcp" (default dict .Values.mcp).base_path }}
+      base_path: {{ default "/api/v1/mcp" (default dict .Values.mcp).base_path }}
       instructions: {{ default "SaFE API Server - GPU Cluster Management Tools via MCP" (default dict .Values.mcp).instructions | quote }}
 kind: ConfigMap
 metadata:

--- a/SaFE/charts/primus-safe/templates/apiserver/config.yaml
+++ b/SaFE/charts/primus-safe/templates/apiserver/config.yaml
@@ -148,6 +148,11 @@ data:
       enabled: {{ default true (default dict .Values.llm_gateway).enabled }}
       # Path to the secret directory containing litellm_admin_key, litellm_endpoint, litellm_team_id
       secret_path: {{ default "/etc/secrets/llm-gateway" (default dict .Values.llm_gateway).secret_path }}
+    mcp:
+      # Whether to enable MCP (Model Context Protocol) server for AI assistant integration
+      enabled: {{ default false (default dict .Values.mcp).enabled }}
+      base_path: {{ default "/mcp" (default dict .Values.mcp).base_path }}
+      instructions: {{ default "SaFE API Server - GPU Cluster Management Tools via MCP" (default dict .Values.mcp).instructions | quote }}
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-apiserver

--- a/SaFE/charts/primus-safe/templates/apiserver/config.yaml
+++ b/SaFE/charts/primus-safe/templates/apiserver/config.yaml
@@ -153,6 +153,11 @@ data:
       enabled: {{ default true (default dict .Values.mcp).enabled }}
       base_path: {{ default "/api/v1/mcp" (default dict .Values.mcp).base_path }}
       instructions: {{ default "SaFE API Server - GPU Cluster Management Tools via MCP" (default dict .Values.mcp).instructions | quote }}
+      # CORS allowlist; empty = same-origin only.
+      allowed_origins:
+{{- range default (list) (default dict .Values.mcp).allowed_origins }}
+        - {{ . | quote }}
+{{- end }}
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-apiserver

--- a/SaFE/charts/primus-safe/values.yaml
+++ b/SaFE/charts/primus-safe/values.yaml
@@ -259,3 +259,9 @@ mcp:
   enabled: true
   base_path: "/api/v1/mcp"
   instructions: "SaFE API Server - GPU Cluster Management Tools via MCP"
+  # CORS allowlist for browser-based MCP clients. Empty (default) means
+  # same-origin only: no Access-Control-Allow-Origin header is emitted, so
+  # cross-origin fetch from arbitrary sites is blocked. Add explicit origins
+  # (e.g. "https://safe-ui.example.com") to opt in. Wildcard "*" supported
+  # but discouraged.
+  allowed_origins: []

--- a/SaFE/charts/primus-safe/values.yaml
+++ b/SaFE/charts/primus-safe/values.yaml
@@ -257,5 +257,5 @@ llm_gateway:
   secret_path: "/etc/secrets/llm-gateway"
 mcp:
   enabled: true
-  base_path: "/mcp"
+  base_path: "/api/v1/mcp"
   instructions: "SaFE API Server - GPU Cluster Management Tools via MCP"

--- a/SaFE/charts/primus-safe/values.yaml
+++ b/SaFE/charts/primus-safe/values.yaml
@@ -255,3 +255,7 @@ a2a_gateway:
 llm_gateway:
   enabled: true
   secret_path: "/etc/secrets/llm-gateway"
+mcp:
+  enabled: false
+  base_path: "/mcp"
+  instructions: "SaFE API Server - GPU Cluster Management Tools via MCP"

--- a/SaFE/charts/primus-safe/values.yaml
+++ b/SaFE/charts/primus-safe/values.yaml
@@ -256,6 +256,6 @@ llm_gateway:
   enabled: true
   secret_path: "/etc/secrets/llm-gateway"
 mcp:
-  enabled: false
+  enabled: true
   base_path: "/mcp"
   instructions: "SaFE API Server - GPU Cluster Management Tools via MCP"

--- a/SaFE/common/pkg/config/config.go
+++ b/SaFE/common/pkg/config/config.go
@@ -569,3 +569,17 @@ func IsMonarchEnable() bool {
 func GetMonarchClientRole() string {
 	return getString(monarchClientRole, "")
 }
+
+// ── MCP (Model Context Protocol) ────────────────────────────────────────
+
+func IsMCPEnable() bool {
+	return getBool(mcpEnable, false)
+}
+
+func GetMCPBasePath() string {
+	return getString(mcpBasePath, "/mcp")
+}
+
+func GetMCPInstructions() string {
+	return getString(mcpInstructions, "")
+}

--- a/SaFE/common/pkg/config/config.go
+++ b/SaFE/common/pkg/config/config.go
@@ -583,3 +583,13 @@ func GetMCPBasePath() string {
 func GetMCPInstructions() string {
 	return getString(mcpInstructions, "")
 }
+
+// GetMCPAllowedOrigins returns the CORS allowlist for the MCP HTTP transports.
+// Empty (default) means same-origin only: no Access-Control-Allow-Origin
+// header is set, so cross-origin browser requests are blocked. Add explicit
+// origins (e.g. "https://safe-ui.example.com") to opt in. Use "*" only if
+// you really mean it; bearer-token clients work but cookie-based browser
+// clients won't be able to call the API anyway.
+func GetMCPAllowedOrigins() []string {
+	return viper.GetStringSlice(mcpAllowedOrigins)
+}

--- a/SaFE/common/pkg/config/config.go
+++ b/SaFE/common/pkg/config/config.go
@@ -577,7 +577,7 @@ func IsMCPEnable() bool {
 }
 
 func GetMCPBasePath() string {
-	return getString(mcpBasePath, "/mcp")
+	return getString(mcpBasePath, "/api/v1/mcp")
 }
 
 func GetMCPInstructions() string {

--- a/SaFE/common/pkg/config/define.go
+++ b/SaFE/common/pkg/config/define.go
@@ -172,4 +172,10 @@ const (
 	monarchPrefix     = "monarch."
 	monarchEnable     = monarchPrefix + "enable"
 	monarchClientRole = monarchPrefix + "client_role"
+
+	// mcp (Model Context Protocol)
+	mcpPrefix       = "mcp."
+	mcpEnable       = mcpPrefix + "enabled"
+	mcpBasePath     = mcpPrefix + "base_path"
+	mcpInstructions = mcpPrefix + "instructions"
 )

--- a/SaFE/common/pkg/config/define.go
+++ b/SaFE/common/pkg/config/define.go
@@ -174,8 +174,9 @@ const (
 	monarchClientRole = monarchPrefix + "client_role"
 
 	// mcp (Model Context Protocol)
-	mcpPrefix       = "mcp."
-	mcpEnable       = mcpPrefix + "enabled"
-	mcpBasePath     = mcpPrefix + "base_path"
-	mcpInstructions = mcpPrefix + "instructions"
+	mcpPrefix         = "mcp."
+	mcpEnable         = mcpPrefix + "enabled"
+	mcpBasePath       = mcpPrefix + "base_path"
+	mcpInstructions   = mcpPrefix + "instructions"
+	mcpAllowedOrigins = mcpPrefix + "allowed_origins"
 )

--- a/SaFE/common/pkg/mcp/server/protocol.go
+++ b/SaFE/common/pkg/mcp/server/protocol.go
@@ -41,6 +41,10 @@ const (
 	ErrorCodeToolNotFound      = -32001
 	ErrorCodeToolExecutionFail = -32002
 	ErrorCodeResourceNotFound  = -32003
+	// ErrorCodeUnauthorized is returned by tools/call when the request is
+	// missing credentials. Discovery methods (initialize, tools/list, ping)
+	// stay anonymous so clients can advertise capabilities.
+	ErrorCodeUnauthorized = -32004
 )
 
 type JSONRPCRequest struct {

--- a/SaFE/common/pkg/mcp/server/protocol.go
+++ b/SaFE/common/pkg/mcp/server/protocol.go
@@ -1,0 +1,271 @@
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+// See LICENSE for license information.
+
+// Package server implements the MCP (Model Context Protocol) server.
+// It supports both SSE (Server-Sent Events) and STDIO transports.
+package server
+
+import (
+	"encoding/json"
+)
+
+const (
+	JSONRPCVersion = "2.0"
+)
+
+const (
+	MCPProtocolVersion = "2024-11-05"
+	MCPVersion         = "1.0.0"
+)
+
+const (
+	MethodInitialize      = "initialize"
+	MethodInitialized     = "notifications/initialized"
+	MethodToolsList       = "tools/list"
+	MethodToolsCall       = "tools/call"
+	MethodPing            = "ping"
+	MethodResourcesList   = "resources/list"
+	MethodResourcesRead   = "resources/read"
+	MethodPromptsList     = "prompts/list"
+	MethodPromptsGet      = "prompts/get"
+	MethodLoggingSetLevel = "logging/setLevel"
+)
+
+const (
+	ErrorCodeParseError     = -32700
+	ErrorCodeInvalidRequest = -32600
+	ErrorCodeMethodNotFound = -32601
+	ErrorCodeInvalidParams  = -32602
+	ErrorCodeInternalError  = -32603
+
+	ErrorCodeToolNotFound      = -32001
+	ErrorCodeToolExecutionFail = -32002
+	ErrorCodeResourceNotFound  = -32003
+)
+
+type JSONRPCRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type JSONRPCResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Result  any             `json:"result,omitempty"`
+	Error   *JSONRPCError   `json:"error,omitempty"`
+}
+
+type JSONRPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    any    `json:"data,omitempty"`
+}
+
+type JSONRPCNotification struct {
+	JSONRPC string          `json:"jsonrpc"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+func NewResponse(id json.RawMessage, result any) *JSONRPCResponse {
+	return &JSONRPCResponse{
+		JSONRPC: JSONRPCVersion,
+		ID:      id,
+		Result:  result,
+	}
+}
+
+func NewErrorResponse(id json.RawMessage, code int, message string, data any) *JSONRPCResponse {
+	return &JSONRPCResponse{
+		JSONRPC: JSONRPCVersion,
+		ID:      id,
+		Error: &JSONRPCError{
+			Code:    code,
+			Message: message,
+			Data:    data,
+		},
+	}
+}
+
+// ===== MCP Initialize =====
+
+type InitializeParams struct {
+	ProtocolVersion string           `json:"protocolVersion"`
+	Capabilities    ClientCapability `json:"capabilities"`
+	ClientInfo      Implementation   `json:"clientInfo"`
+}
+
+type InitializeResult struct {
+	ProtocolVersion string           `json:"protocolVersion"`
+	Capabilities    ServerCapability `json:"capabilities"`
+	ServerInfo      Implementation   `json:"serverInfo"`
+	Instructions    string           `json:"instructions,omitempty"`
+}
+
+type Implementation struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type ClientCapability struct {
+	Roots    *RootsCapability    `json:"roots,omitempty"`
+	Sampling *SamplingCapability `json:"sampling,omitempty"`
+}
+
+type ServerCapability struct {
+	Tools     *ToolsCapability     `json:"tools,omitempty"`
+	Resources *ResourcesCapability `json:"resources,omitempty"`
+	Prompts   *PromptsCapability   `json:"prompts,omitempty"`
+	Logging   *LoggingCapability   `json:"logging,omitempty"`
+}
+
+type RootsCapability struct {
+	ListChanged bool `json:"listChanged,omitempty"`
+}
+
+type SamplingCapability struct{}
+
+type ToolsCapability struct {
+	ListChanged bool `json:"listChanged,omitempty"`
+}
+
+type ResourcesCapability struct {
+	Subscribe   bool `json:"subscribe,omitempty"`
+	ListChanged bool `json:"listChanged,omitempty"`
+}
+
+type PromptsCapability struct {
+	ListChanged bool `json:"listChanged,omitempty"`
+}
+
+type LoggingCapability struct{}
+
+// ===== MCP Tools =====
+
+type ToolsListResult struct {
+	Tools []ToolDefinition `json:"tools"`
+}
+
+type ToolDefinition struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	InputSchema map[string]any `json:"inputSchema"`
+}
+
+type ToolsCallParams struct {
+	Name      string         `json:"name"`
+	Arguments map[string]any `json:"arguments,omitempty"`
+}
+
+type ToolsCallResult struct {
+	Content []ContentBlock `json:"content"`
+	IsError bool           `json:"isError,omitempty"`
+}
+
+type ContentBlock struct {
+	Type     string `json:"type"`
+	Text     string `json:"text,omitempty"`
+	MimeType string `json:"mimeType,omitempty"`
+	Data     string `json:"data,omitempty"`
+	URI      string `json:"uri,omitempty"`
+}
+
+func NewTextContent(text string) ContentBlock {
+	return ContentBlock{Type: "text", Text: text}
+}
+
+func NewJSONContent(data any) (ContentBlock, error) {
+	jsonBytes, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return ContentBlock{}, err
+	}
+	return ContentBlock{Type: "text", Text: string(jsonBytes)}, nil
+}
+
+// ===== MCP Ping =====
+
+type PingResult struct{}
+
+// ===== MCP Resources =====
+
+type ResourcesListResult struct {
+	Resources []ResourceDefinition `json:"resources"`
+}
+
+type ResourceDefinition struct {
+	URI         string `json:"uri"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	MimeType    string `json:"mimeType,omitempty"`
+}
+
+type ResourcesReadParams struct {
+	URI string `json:"uri"`
+}
+
+type ResourcesReadResult struct {
+	Contents []ResourceContent `json:"contents"`
+}
+
+type ResourceContent struct {
+	URI      string `json:"uri"`
+	MimeType string `json:"mimeType,omitempty"`
+	Text     string `json:"text,omitempty"`
+	Blob     string `json:"blob,omitempty"`
+}
+
+// ===== MCP Prompts =====
+
+type PromptsListResult struct {
+	Prompts []PromptDefinition `json:"prompts"`
+}
+
+type PromptDefinition struct {
+	Name        string           `json:"name"`
+	Description string           `json:"description,omitempty"`
+	Arguments   []PromptArgument `json:"arguments,omitempty"`
+}
+
+type PromptArgument struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Required    bool   `json:"required,omitempty"`
+}
+
+type PromptsGetParams struct {
+	Name      string         `json:"name"`
+	Arguments map[string]any `json:"arguments,omitempty"`
+}
+
+type PromptsGetResult struct {
+	Description string          `json:"description,omitempty"`
+	Messages    []PromptMessage `json:"messages"`
+}
+
+type PromptMessage struct {
+	Role    string       `json:"role"`
+	Content ContentBlock `json:"content"`
+}
+
+// ===== Helpers =====
+
+func ParseRequest(data []byte) (*JSONRPCRequest, error) {
+	var req JSONRPCRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return nil, err
+	}
+	return &req, nil
+}
+
+func (r *JSONRPCRequest) IsNotification() bool {
+	return len(r.ID) == 0 || string(r.ID) == "null"
+}
+
+func (r *JSONRPCRequest) GetIDString() string {
+	if r.ID == nil {
+		return "<nil>"
+	}
+	return string(r.ID)
+}

--- a/SaFE/common/pkg/mcp/server/server.go
+++ b/SaFE/common/pkg/mcp/server/server.go
@@ -1,0 +1,242 @@
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+// See LICENSE for license information.
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"k8s.io/klog/v2"
+)
+
+type httpRequestKey struct{}
+
+// ContextWithHTTPRequest attaches an HTTP request to a context so tool handlers can access auth headers, host, etc.
+func ContextWithHTTPRequest(ctx context.Context, r *http.Request) context.Context {
+	return context.WithValue(ctx, httpRequestKey{}, r)
+}
+
+// HTTPRequestFromContext retrieves the HTTP request stored in ctx, if any.
+func HTTPRequestFromContext(ctx context.Context) (*http.Request, bool) {
+	r, ok := ctx.Value(httpRequestKey{}).(*http.Request)
+	return r, ok && r != nil
+}
+
+var ServerInfo = Implementation{
+	Name:    "SaFE MCP Server",
+	Version: "1.0.0",
+}
+
+// MCPTool represents an MCP tool definition that can be registered with the server.
+type MCPTool struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	InputSchema map[string]any `json:"inputSchema"`
+	Handler     MCPToolHandler `json:"-"`
+}
+
+// MCPToolHandler is the function signature for MCP tool handlers.
+type MCPToolHandler func(ctx context.Context, params json.RawMessage) (any, error)
+
+// Server represents an MCP server that handles JSON-RPC requests.
+type Server struct {
+	mu          sync.RWMutex
+	tools       map[string]*MCPTool
+	initialized bool
+	clientInfo  *Implementation
+	Instructions string
+}
+
+func New() *Server {
+	return &Server{
+		tools: make(map[string]*MCPTool),
+	}
+}
+
+func (s *Server) RegisterTools(tools []*MCPTool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, tool := range tools {
+		s.tools[tool.Name] = tool
+		klog.Infof("MCP Server: Registered tool %s", tool.Name)
+	}
+}
+
+func (s *Server) RegisterTool(tool *MCPTool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.tools[tool.Name] = tool
+	klog.Infof("MCP Server: Registered tool %s", tool.Name)
+}
+
+func (s *Server) SetInstructions(instructions string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Instructions = instructions
+}
+
+func (s *Server) HandleRequest(ctx context.Context, req *JSONRPCRequest) *JSONRPCResponse {
+	klog.V(4).Infof("MCP Server: Handling request method=%s id=%s", req.Method, req.GetIDString())
+
+	switch req.Method {
+	case MethodInitialize:
+		return s.handleInitialize(ctx, req)
+	case MethodInitialized:
+		return nil
+	case MethodToolsList:
+		return s.handleToolsList(ctx, req)
+	case MethodToolsCall:
+		return s.handleToolsCall(ctx, req)
+	case MethodPing:
+		return s.handlePing(ctx, req)
+	case MethodResourcesList:
+		return s.handleResourcesList(ctx, req)
+	case MethodPromptsList:
+		return s.handlePromptsList(ctx, req)
+	default:
+		return NewErrorResponse(req.ID, ErrorCodeMethodNotFound,
+			fmt.Sprintf("Method not found: %s", req.Method), nil)
+	}
+}
+
+func (s *Server) handleInitialize(_ context.Context, req *JSONRPCRequest) *JSONRPCResponse {
+	var params InitializeParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return NewErrorResponse(req.ID, ErrorCodeInvalidParams, "Invalid initialize params", err.Error())
+	}
+
+	s.mu.Lock()
+	s.initialized = true
+	s.clientInfo = &params.ClientInfo
+	s.mu.Unlock()
+
+	klog.Infof("MCP Server: Initialized by client %s v%s (protocol: %s)",
+		params.ClientInfo.Name, params.ClientInfo.Version, params.ProtocolVersion)
+
+	result := InitializeResult{
+		ProtocolVersion: MCPProtocolVersion,
+		Capabilities: ServerCapability{
+			Tools: &ToolsCapability{ListChanged: false},
+		},
+		ServerInfo:   ServerInfo,
+		Instructions: s.Instructions,
+	}
+	return NewResponse(req.ID, result)
+}
+
+func (s *Server) handleToolsList(_ context.Context, req *JSONRPCRequest) *JSONRPCResponse {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	tools := make([]ToolDefinition, 0, len(s.tools))
+	for _, tool := range s.tools {
+		tools = append(tools, ToolDefinition{
+			Name:        tool.Name,
+			Description: tool.Description,
+			InputSchema: tool.InputSchema,
+		})
+	}
+	klog.V(4).Infof("MCP Server: Listed %d tools", len(tools))
+	return NewResponse(req.ID, ToolsListResult{Tools: tools})
+}
+
+func (s *Server) handleToolsCall(ctx context.Context, req *JSONRPCRequest) *JSONRPCResponse {
+	var params ToolsCallParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return NewErrorResponse(req.ID, ErrorCodeInvalidParams, "Invalid tools/call params", err.Error())
+	}
+
+	klog.Infof("MCP Server: Calling tool %s", params.Name)
+
+	s.mu.RLock()
+	tool, exists := s.tools[params.Name]
+	s.mu.RUnlock()
+
+	if !exists {
+		return NewErrorResponse(req.ID, ErrorCodeToolNotFound,
+			fmt.Sprintf("Tool not found: %s", params.Name), nil)
+	}
+
+	argsJSON, err := json.Marshal(params.Arguments)
+	if err != nil {
+		return NewErrorResponse(req.ID, ErrorCodeInvalidParams, "Failed to marshal arguments", err.Error())
+	}
+
+	result, err := tool.Handler(ctx, argsJSON)
+	if err != nil {
+		klog.Errorf("MCP Server: Tool %s execution failed: %v", params.Name, err)
+		return NewResponse(req.ID, ToolsCallResult{
+			Content: []ContentBlock{NewTextContent(err.Error())},
+			IsError: true,
+		})
+	}
+
+	content, err := NewJSONContent(result)
+	if err != nil {
+		return NewErrorResponse(req.ID, ErrorCodeInternalError, "Failed to marshal result", err.Error())
+	}
+	klog.V(4).Infof("MCP Server: Tool %s executed successfully", params.Name)
+	return NewResponse(req.ID, ToolsCallResult{Content: []ContentBlock{content}})
+}
+
+func (s *Server) handlePing(_ context.Context, req *JSONRPCRequest) *JSONRPCResponse {
+	return NewResponse(req.ID, PingResult{})
+}
+
+func (s *Server) handleResourcesList(_ context.Context, req *JSONRPCRequest) *JSONRPCResponse {
+	return NewResponse(req.ID, ResourcesListResult{Resources: []ResourceDefinition{}})
+}
+
+func (s *Server) handlePromptsList(_ context.Context, req *JSONRPCRequest) *JSONRPCResponse {
+	return NewResponse(req.ID, PromptsListResult{Prompts: []PromptDefinition{}})
+}
+
+// HandleMessage processes a raw JSON message and returns the response bytes.
+func (s *Server) HandleMessage(ctx context.Context, data []byte) ([]byte, error) {
+	req, err := ParseRequest(data)
+	if err != nil {
+		resp := NewErrorResponse(nil, ErrorCodeParseError, "Parse error", err.Error())
+		return json.Marshal(resp)
+	}
+	if req.JSONRPC != JSONRPCVersion {
+		resp := NewErrorResponse(req.ID, ErrorCodeInvalidRequest, "Invalid JSON-RPC version", nil)
+		return json.Marshal(resp)
+	}
+	resp := s.HandleRequest(ctx, req)
+	if resp == nil {
+		return nil, nil
+	}
+	return json.Marshal(resp)
+}
+
+func (s *Server) IsInitialized() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.initialized
+}
+
+func (s *Server) GetClientInfo() *Implementation {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.clientInfo
+}
+
+func (s *Server) ToolCount() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.tools)
+}
+
+func (s *Server) GetToolNames() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	names := make([]string, 0, len(s.tools))
+	for name := range s.tools {
+		names = append(names, name)
+	}
+	return names
+}

--- a/SaFE/common/pkg/mcp/server/server.go
+++ b/SaFE/common/pkg/mcp/server/server.go
@@ -26,6 +26,24 @@ func HTTPRequestFromContext(ctx context.Context) (*http.Request, bool) {
 	return r, ok && r != nil
 }
 
+// requestHasCredentials reports whether the inbound HTTP request carries
+// either an Authorization header or a Cookie. It does NOT validate them;
+// validation is delegated to the downstream REST handlers, but the presence
+// check stops anonymous tools/call traffic at the MCP layer.
+func requestHasCredentials(ctx context.Context) bool {
+	r, ok := HTTPRequestFromContext(ctx)
+	if !ok {
+		return false
+	}
+	if r.Header.Get("Authorization") != "" {
+		return true
+	}
+	if r.Header.Get("Cookie") != "" {
+		return true
+	}
+	return false
+}
+
 var ServerInfo = Implementation{
 	Name:    "SaFE MCP Server",
 	Version: "1.0.0",
@@ -148,6 +166,15 @@ func (s *Server) handleToolsCall(ctx context.Context, req *JSONRPCRequest) *JSON
 	var params ToolsCallParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {
 		return NewErrorResponse(req.ID, ErrorCodeInvalidParams, "Invalid tools/call params", err.Error())
+	}
+
+	// Tools execute real backend calls, so they require authenticated
+	// requests. Discovery methods (initialize / tools/list / ping) stay
+	// anonymous to support standard MCP client handshakes.
+	if !requestHasCredentials(ctx) {
+		klog.Warningf("MCP Server: Rejecting tools/call %s: missing credentials", params.Name)
+		return NewErrorResponse(req.ID, ErrorCodeUnauthorized,
+			"authorization required: send a valid Authorization header or session cookie", nil)
 	}
 
 	klog.Infof("MCP Server: Calling tool %s", params.Name)

--- a/SaFE/common/pkg/mcp/server/server_test.go
+++ b/SaFE/common/pkg/mcp/server/server_test.go
@@ -1,0 +1,474 @@
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+// See LICENSE for license information.
+
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type TestToolRequest struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
+type TestToolResponse struct {
+	Message string `json:"message"`
+	Total   int    `json:"total"`
+}
+
+func createTestTool() *MCPTool {
+	return &MCPTool{
+		Name:        "test_tool",
+		Description: "A test tool",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"name":  map[string]any{"type": "string"},
+				"count": map[string]any{"type": "integer"},
+			},
+		},
+		Handler: func(ctx context.Context, params json.RawMessage) (any, error) {
+			var req TestToolRequest
+			if err := json.Unmarshal(params, &req); err != nil {
+				return nil, err
+			}
+			return &TestToolResponse{
+				Message: "Hello " + req.Name,
+				Total:   req.Count * 2,
+			}, nil
+		},
+	}
+}
+
+func mustMarshal(v any) json.RawMessage {
+	data, _ := json.Marshal(v)
+	return data
+}
+
+func TestServer_Initialize(t *testing.T) {
+	server := New()
+	server.RegisterTool(createTestTool())
+
+	req := JSONRPCRequest{
+		JSONRPC: JSONRPCVersion,
+		ID:      json.RawMessage(`1`),
+		Method:  MethodInitialize,
+		Params: mustMarshal(InitializeParams{
+			ProtocolVersion: MCPProtocolVersion,
+			Capabilities:    ClientCapability{},
+			ClientInfo:      Implementation{Name: "Test Client", Version: "1.0.0"},
+		}),
+	}
+
+	resp := server.HandleRequest(context.Background(), &req)
+	require.NotNil(t, resp)
+	assert.Nil(t, resp.Error)
+
+	var result InitializeResult
+	resultBytes, _ := json.Marshal(resp.Result)
+	err := json.Unmarshal(resultBytes, &result)
+	require.NoError(t, err)
+
+	assert.Equal(t, MCPProtocolVersion, result.ProtocolVersion)
+	assert.NotNil(t, result.Capabilities.Tools)
+	assert.Equal(t, ServerInfo.Name, result.ServerInfo.Name)
+	assert.True(t, server.IsInitialized())
+}
+
+func TestServer_ToolsList(t *testing.T) {
+	server := New()
+	server.RegisterTool(createTestTool())
+
+	req := JSONRPCRequest{
+		JSONRPC: JSONRPCVersion,
+		ID:      json.RawMessage(`2`),
+		Method:  MethodToolsList,
+	}
+
+	resp := server.HandleRequest(context.Background(), &req)
+	require.NotNil(t, resp)
+	assert.Nil(t, resp.Error)
+
+	var result ToolsListResult
+	resultBytes, _ := json.Marshal(resp.Result)
+	err := json.Unmarshal(resultBytes, &result)
+	require.NoError(t, err)
+
+	assert.Len(t, result.Tools, 1)
+	assert.Equal(t, "test_tool", result.Tools[0].Name)
+}
+
+func TestServer_ToolsCall(t *testing.T) {
+	server := New()
+	server.RegisterTool(createTestTool())
+
+	req := JSONRPCRequest{
+		JSONRPC: JSONRPCVersion,
+		ID:      json.RawMessage(`3`),
+		Method:  MethodToolsCall,
+		Params: mustMarshal(ToolsCallParams{
+			Name:      "test_tool",
+			Arguments: map[string]any{"name": "World", "count": 5},
+		}),
+	}
+
+	resp := server.HandleRequest(context.Background(), &req)
+	require.NotNil(t, resp)
+	assert.Nil(t, resp.Error)
+
+	var result ToolsCallResult
+	resultBytes, _ := json.Marshal(resp.Result)
+	err := json.Unmarshal(resultBytes, &result)
+	require.NoError(t, err)
+
+	assert.False(t, result.IsError)
+	require.Len(t, result.Content, 1)
+	assert.Equal(t, "text", result.Content[0].Type)
+
+	var toolResult TestToolResponse
+	err = json.Unmarshal([]byte(result.Content[0].Text), &toolResult)
+	require.NoError(t, err)
+	assert.Equal(t, "Hello World", toolResult.Message)
+	assert.Equal(t, 10, toolResult.Total)
+}
+
+func TestServer_ToolsCall_NotFound(t *testing.T) {
+	server := New()
+
+	req := JSONRPCRequest{
+		JSONRPC: JSONRPCVersion,
+		ID:      json.RawMessage(`4`),
+		Method:  MethodToolsCall,
+		Params:  mustMarshal(ToolsCallParams{Name: "nonexistent_tool"}),
+	}
+
+	resp := server.HandleRequest(context.Background(), &req)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, ErrorCodeToolNotFound, resp.Error.Code)
+}
+
+func TestServer_MethodNotFound(t *testing.T) {
+	server := New()
+	req := JSONRPCRequest{
+		JSONRPC: JSONRPCVersion,
+		ID:      json.RawMessage(`5`),
+		Method:  "unknown/method",
+	}
+	resp := server.HandleRequest(context.Background(), &req)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, ErrorCodeMethodNotFound, resp.Error.Code)
+}
+
+func TestServer_Ping(t *testing.T) {
+	server := New()
+	req := JSONRPCRequest{
+		JSONRPC: JSONRPCVersion,
+		ID:      json.RawMessage(`6`),
+		Method:  MethodPing,
+	}
+	resp := server.HandleRequest(context.Background(), &req)
+	require.NotNil(t, resp)
+	assert.Nil(t, resp.Error)
+}
+
+func TestServer_HandleMessage(t *testing.T) {
+	server := New()
+	server.RegisterTool(createTestTool())
+
+	message := `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`
+	response, err := server.HandleMessage(context.Background(), []byte(message))
+	require.NoError(t, err)
+	require.NotNil(t, response)
+
+	var resp JSONRPCResponse
+	err = json.Unmarshal(response, &resp)
+	require.NoError(t, err)
+	assert.Nil(t, resp.Error)
+}
+
+func TestServer_HandleMessage_ParseError(t *testing.T) {
+	server := New()
+	response, err := server.HandleMessage(context.Background(), []byte(`{invalid json}`))
+	require.NoError(t, err)
+	require.NotNil(t, response)
+
+	var resp JSONRPCResponse
+	err = json.Unmarshal(response, &resp)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, ErrorCodeParseError, resp.Error.Code)
+}
+
+func TestStreamableHTTPTransport(t *testing.T) {
+	server := New()
+	server.RegisterTool(createTestTool())
+
+	transport := NewStreamableHTTPTransport(server)
+	ts := httptest.NewServer(transport.Handler())
+	defer ts.Close()
+
+	req := JSONRPCRequest{
+		JSONRPC: JSONRPCVersion,
+		ID:      json.RawMessage(`1`),
+		Method:  MethodToolsList,
+	}
+	reqBody, _ := json.Marshal(req)
+
+	resp, err := http.Post(ts.URL, "application/json", bytes.NewReader(reqBody))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var rpcResp JSONRPCResponse
+	err = json.NewDecoder(resp.Body).Decode(&rpcResp)
+	require.NoError(t, err)
+	assert.Nil(t, rpcResp.Error)
+}
+
+func TestStreamableHTTPClient(t *testing.T) {
+	server := New()
+	server.RegisterTool(createTestTool())
+
+	transport := NewStreamableHTTPTransport(server)
+	ts := httptest.NewServer(transport.Handler())
+	defer ts.Close()
+
+	client := NewStreamableHTTPClient(ts.URL)
+
+	resp, err := client.Call(context.Background(), MethodInitialize, InitializeParams{
+		ProtocolVersion: MCPProtocolVersion,
+		ClientInfo:      Implementation{Name: "Test", Version: "1.0"},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, resp.Error)
+
+	resp, err = client.Call(context.Background(), MethodToolsList, nil)
+	require.NoError(t, err)
+	assert.Nil(t, resp.Error)
+
+	resp, err = client.Call(context.Background(), MethodToolsCall, ToolsCallParams{
+		Name:      "test_tool",
+		Arguments: map[string]any{"name": "Test", "count": 3},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, resp.Error)
+}
+
+func TestSTDIOTransport(t *testing.T) {
+	server := New()
+	server.RegisterTool(createTestTool())
+
+	input := &bytes.Buffer{}
+	output := &bytes.Buffer{}
+	transport := NewSTDIOTransportWithIO(server, input, output)
+
+	messages := []string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"Test","version":"1.0"}}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/list"}`,
+	}
+	for _, msg := range messages {
+		input.WriteString(msg + "\n")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	_ = transport.Start(ctx)
+
+	outputStr := output.String()
+	lines := strings.Split(strings.TrimSpace(outputStr), "\n")
+	require.GreaterOrEqual(t, len(lines), 1)
+
+	var resp1 JSONRPCResponse
+	err := json.Unmarshal([]byte(lines[0]), &resp1)
+	require.NoError(t, err)
+	assert.Nil(t, resp1.Error)
+}
+
+func TestSSETransport_Health(t *testing.T) {
+	server := New()
+	server.RegisterTool(createTestTool())
+
+	transport := NewSSETransport(server)
+	ts := httptest.NewServer(transport.Handler())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/health")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	var health map[string]any
+	err = json.NewDecoder(resp.Body).Decode(&health)
+	require.NoError(t, err)
+	assert.Equal(t, "ok", health["status"])
+}
+
+func TestServer_RegisterMultipleTools(t *testing.T) {
+	server := New()
+	tools := []*MCPTool{
+		{
+			Name: "tool1", Description: "First tool",
+			InputSchema: map[string]any{"type": "object"},
+			Handler:     func(ctx context.Context, params json.RawMessage) (any, error) { return "tool1 result", nil },
+		},
+		{
+			Name: "tool2", Description: "Second tool",
+			InputSchema: map[string]any{"type": "object"},
+			Handler:     func(ctx context.Context, params json.RawMessage) (any, error) { return "tool2 result", nil },
+		},
+	}
+	server.RegisterTools(tools)
+
+	assert.Equal(t, 2, server.ToolCount())
+	names := server.GetToolNames()
+	assert.Contains(t, names, "tool1")
+	assert.Contains(t, names, "tool2")
+}
+
+func TestServer_Instructions(t *testing.T) {
+	server := New()
+	server.SetInstructions("This server provides SaFE API tools for GPU cluster management.")
+
+	req := JSONRPCRequest{
+		JSONRPC: JSONRPCVersion,
+		ID:      json.RawMessage(`1`),
+		Method:  MethodInitialize,
+		Params: mustMarshal(InitializeParams{
+			ProtocolVersion: MCPProtocolVersion,
+			ClientInfo:      Implementation{Name: "Test", Version: "1.0"},
+		}),
+	}
+
+	resp := server.HandleRequest(context.Background(), &req)
+	require.NotNil(t, resp)
+
+	var result InitializeResult
+	resultBytes, _ := json.Marshal(resp.Result)
+	json.Unmarshal(resultBytes, &result)
+
+	assert.Contains(t, result.Instructions, "SaFE API tools")
+}
+
+func TestNewJSONContent(t *testing.T) {
+	data := map[string]any{"name": "test", "count": 42}
+	content, err := NewJSONContent(data)
+	require.NoError(t, err)
+	assert.Equal(t, "text", content.Type)
+	assert.Contains(t, content.Text, "test")
+	assert.Contains(t, content.Text, "42")
+}
+
+func TestSSETransport_Message(t *testing.T) {
+	server := New()
+	server.RegisterTool(createTestTool())
+
+	transport := NewSSETransport(server)
+	ts := httptest.NewServer(transport.Handler())
+	defer ts.Close()
+
+	req := JSONRPCRequest{
+		JSONRPC: JSONRPCVersion,
+		ID:      json.RawMessage(`1`),
+		Method:  MethodToolsList,
+	}
+	reqBody, _ := json.Marshal(req)
+
+	// No session -> 400
+	resp, err := http.Post(ts.URL+"/message", "application/json", bytes.NewReader(reqBody))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	// Invalid session -> 404
+	resp2, err := http.Post(ts.URL+"/message?session_id=invalid", "application/json", bytes.NewReader(reqBody))
+	require.NoError(t, err)
+	defer func() { io.Copy(io.Discard, resp2.Body); resp2.Body.Close() }()
+	assert.Equal(t, http.StatusNotFound, resp2.StatusCode)
+}
+
+func TestIntegration_FullFlow(t *testing.T) {
+	server := New()
+
+	type ClusterReq struct {
+		Name string `json:"name"`
+	}
+	type ClusterResp struct {
+		Status string `json:"status"`
+		Nodes  int    `json:"nodes"`
+	}
+
+	tool := &MCPTool{
+		Name:        "get_cluster",
+		Description: "Get cluster status",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"name": map[string]any{"type": "string"},
+			},
+		},
+		Handler: func(ctx context.Context, params json.RawMessage) (any, error) {
+			var req ClusterReq
+			if err := json.Unmarshal(params, &req); err != nil {
+				return nil, err
+			}
+			return &ClusterResp{Status: "healthy", Nodes: 10}, nil
+		},
+	}
+	server.RegisterTool(tool)
+
+	transport := NewStreamableHTTPTransport(server)
+	ts := httptest.NewServer(transport.Handler())
+	defer ts.Close()
+
+	client := NewStreamableHTTPClient(ts.URL)
+
+	resp, err := client.Call(context.Background(), MethodInitialize, InitializeParams{
+		ProtocolVersion: MCPProtocolVersion,
+		ClientInfo:      Implementation{Name: "Integration Test", Version: "1.0"},
+	})
+	require.NoError(t, err)
+	require.Nil(t, resp.Error)
+
+	resp, err = client.Call(context.Background(), MethodToolsList, nil)
+	require.NoError(t, err)
+	require.Nil(t, resp.Error)
+
+	var toolsList ToolsListResult
+	resultBytes, _ := json.Marshal(resp.Result)
+	json.Unmarshal(resultBytes, &toolsList)
+	require.Len(t, toolsList.Tools, 1)
+	assert.Equal(t, "get_cluster", toolsList.Tools[0].Name)
+
+	resp, err = client.Call(context.Background(), MethodToolsCall, ToolsCallParams{
+		Name:      "get_cluster",
+		Arguments: map[string]any{"name": "prod"},
+	})
+	require.NoError(t, err)
+	require.Nil(t, resp.Error)
+
+	var callResult ToolsCallResult
+	resultBytes, _ = json.Marshal(resp.Result)
+	json.Unmarshal(resultBytes, &callResult)
+	assert.False(t, callResult.IsError)
+	require.Len(t, callResult.Content, 1)
+
+	var clusterResp ClusterResp
+	json.Unmarshal([]byte(callResult.Content[0].Text), &clusterResp)
+	assert.Equal(t, "healthy", clusterResp.Status)
+	assert.Equal(t, 10, clusterResp.Nodes)
+}

--- a/SaFE/common/pkg/mcp/server/server_test.go
+++ b/SaFE/common/pkg/mcp/server/server_test.go
@@ -451,6 +451,68 @@ func TestSSETransport_Message(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, resp2.StatusCode)
 }
 
+// TestSSETransport_CORS verifies the same-origin-by-default policy and that
+// only Origins on the allowlist receive an Access-Control-Allow-Origin header.
+func TestSSETransport_CORS(t *testing.T) {
+	tests := []struct {
+		name     string
+		allowed  []string
+		origin   string
+		wantACAO string
+	}{
+		{name: "default empty = no header", allowed: nil, origin: "https://evil.com", wantACAO: ""},
+		{name: "matching origin echoed", allowed: []string{"https://safe-ui.example.com"}, origin: "https://safe-ui.example.com", wantACAO: "https://safe-ui.example.com"},
+		{name: "non-matching origin rejected", allowed: []string{"https://safe-ui.example.com"}, origin: "https://evil.com", wantACAO: ""},
+		{name: "wildcard echoed as star", allowed: []string{"*"}, origin: "https://anything.com", wantACAO: "*"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := New()
+			transport := NewSSETransport(srv)
+			transport.AllowedOrigins = tc.allowed
+
+			// Use HandleHealth: same applyCORS path, simpler than driving
+			// the full SSE handshake. Behaviour is identical for all
+			// SSETransport handlers.
+			req := httptest.NewRequest(http.MethodGet, "/health", nil)
+			if tc.origin != "" {
+				req.Header.Set("Origin", tc.origin)
+			}
+			rec := httptest.NewRecorder()
+			transport.HandleHealth(rec, req)
+
+			got := rec.Header().Get("Access-Control-Allow-Origin")
+			assert.Equal(t, tc.wantACAO, got)
+			if len(tc.allowed) > 0 {
+				assert.Equal(t, "Origin", rec.Header().Get("Vary"),
+					"Vary: Origin must be set whenever allowlist is non-empty")
+			}
+		})
+	}
+}
+
+// TestStreamableHTTPTransport_CORS sanity-checks that the streamable HTTP
+// transport shares the same CORS behaviour.
+func TestStreamableHTTPTransport_CORS(t *testing.T) {
+	srv := New()
+	transport := NewStreamableHTTPTransport(srv)
+	transport.AllowedOrigins = []string{"https://allowed.example"}
+
+	body, _ := json.Marshal(JSONRPCRequest{JSONRPC: JSONRPCVersion, ID: json.RawMessage(`1`), Method: MethodPing})
+
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+	req.Header.Set("Origin", "https://allowed.example")
+	rec := httptest.NewRecorder()
+	transport.HandleRPC(rec, req)
+	assert.Equal(t, "https://allowed.example", rec.Header().Get("Access-Control-Allow-Origin"))
+
+	req2 := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+	req2.Header.Set("Origin", "https://evil.example")
+	rec2 := httptest.NewRecorder()
+	transport.HandleRPC(rec2, req2)
+	assert.Empty(t, rec2.Header().Get("Access-Control-Allow-Origin"))
+}
+
 // TestSSETransport_QueueFullReturns503 verifies that when an SSE consumer is
 // blocked and the per-session message channel is full, HandleMessage stops
 // silently dropping responses and returns 503 within SendQueueTimeout.

--- a/SaFE/common/pkg/mcp/server/server_test.go
+++ b/SaFE/common/pkg/mcp/server/server_test.go
@@ -28,6 +28,15 @@ type TestToolResponse struct {
 	Total   int    `json:"total"`
 }
 
+// authedCtx returns a context that carries an HTTP request with an
+// Authorization header, satisfying handleToolsCall's credential check
+// for unit tests that don't go through a real transport.
+func authedCtx() context.Context {
+	r, _ := http.NewRequest(http.MethodPost, "http://test/mcp", nil)
+	r.Header.Set("Authorization", "Bearer unit-test")
+	return ContextWithHTTPRequest(context.Background(), r)
+}
+
 func createTestTool() *MCPTool {
 	return &MCPTool{
 		Name:        "test_tool",
@@ -124,7 +133,7 @@ func TestServer_ToolsCall(t *testing.T) {
 		}),
 	}
 
-	resp := server.HandleRequest(context.Background(), &req)
+	resp := server.HandleRequest(authedCtx(), &req)
 	require.NotNil(t, resp)
 	assert.Nil(t, resp.Error)
 
@@ -154,7 +163,7 @@ func TestServer_ToolsCall_NotFound(t *testing.T) {
 		Params:  mustMarshal(ToolsCallParams{Name: "nonexistent_tool"}),
 	}
 
-	resp := server.HandleRequest(context.Background(), &req)
+	resp := server.HandleRequest(authedCtx(), &req)
 	require.NotNil(t, resp)
 	require.NotNil(t, resp.Error)
 	assert.Equal(t, ErrorCodeToolNotFound, resp.Error.Code)
@@ -171,6 +180,45 @@ func TestServer_MethodNotFound(t *testing.T) {
 	require.NotNil(t, resp)
 	require.NotNil(t, resp.Error)
 	assert.Equal(t, ErrorCodeMethodNotFound, resp.Error.Code)
+}
+
+// TestServer_ToolsCall_Unauthenticated verifies that tools/call is rejected
+// with ErrorCodeUnauthorized when no credentials reach the server, while
+// discovery methods (tools/list, initialize, ping) keep working anonymously.
+func TestServer_ToolsCall_Unauthenticated(t *testing.T) {
+	server := New()
+	server.RegisterTool(createTestTool())
+
+	callReq := JSONRPCRequest{
+		JSONRPC: JSONRPCVersion,
+		ID:      json.RawMessage(`100`),
+		Method:  MethodToolsCall,
+		Params:  mustMarshal(ToolsCallParams{Name: "test_tool", Arguments: map[string]any{}}),
+	}
+	resp := server.HandleRequest(context.Background(), &callReq)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Error, "expected unauthorized error, got result %#v", resp.Result)
+	assert.Equal(t, ErrorCodeUnauthorized, resp.Error.Code)
+
+	// tools/list must remain reachable so the client can advertise tools.
+	listReq := JSONRPCRequest{
+		JSONRPC: JSONRPCVersion,
+		ID:      json.RawMessage(`101`),
+		Method:  MethodToolsList,
+	}
+	listResp := server.HandleRequest(context.Background(), &listReq)
+	require.NotNil(t, listResp)
+	assert.Nil(t, listResp.Error)
+
+	// A request bearing a Cookie (e.g. browser session) is treated as
+	// authenticated at the MCP layer; the downstream REST handlers do the
+	// real validation.
+	r, _ := http.NewRequest(http.MethodPost, "http://test/mcp", nil)
+	r.Header.Set("Cookie", "session=abc")
+	cookieCtx := ContextWithHTTPRequest(context.Background(), r)
+	cookieResp := server.HandleRequest(cookieCtx, &callReq)
+	require.NotNil(t, cookieResp)
+	assert.Nil(t, cookieResp.Error, "Cookie should satisfy credential check")
 }
 
 func TestServer_Ping(t *testing.T) {
@@ -249,6 +297,8 @@ func TestStreamableHTTPClient(t *testing.T) {
 	defer ts.Close()
 
 	client := NewStreamableHTTPClient(ts.URL)
+	// tools/call requires credentials; tests pass a stub Authorization header.
+	client.Headers = map[string]string{"Authorization": "Bearer test"}
 
 	resp, err := client.Call(context.Background(), MethodInitialize, InitializeParams{
 		ProtocolVersion: MCPProtocolVersion,
@@ -401,6 +451,50 @@ func TestSSETransport_Message(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, resp2.StatusCode)
 }
 
+// TestSSETransport_QueueFullReturns503 verifies that when an SSE consumer is
+// blocked and the per-session message channel is full, HandleMessage stops
+// silently dropping responses and returns 503 within SendQueueTimeout.
+func TestSSETransport_QueueFullReturns503(t *testing.T) {
+	server := New()
+	server.RegisterTool(createTestTool())
+
+	transport := NewSSETransport(server)
+	transport.SendQueueTimeout = 50 * time.Millisecond
+	ts := httptest.NewServer(transport.Handler())
+	defer ts.Close()
+
+	// Inject a session whose outbound channel is already full and has no
+	// reader, simulating a stuck SSE client.
+	sessionID := "stuck"
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stuck := &sseSession{
+		id:         sessionID,
+		ctx:        ctx,
+		cancel:     cancel,
+		messages:   make(chan []byte, 1),
+		created:    time.Now(),
+		lastActive: time.Now(),
+	}
+	stuck.messages <- []byte("filler")
+	transport.sessions.Store(sessionID, stuck)
+
+	req := JSONRPCRequest{
+		JSONRPC: JSONRPCVersion,
+		ID:      json.RawMessage(`1`),
+		Method:  MethodPing,
+	}
+	reqBody, _ := json.Marshal(req)
+
+	start := time.Now()
+	resp, err := http.Post(ts.URL+"/message?session_id="+sessionID, "application/json", bytes.NewReader(reqBody))
+	require.NoError(t, err)
+	defer func() { io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	assert.Less(t, time.Since(start), 2*time.Second, "should fail fast, not hang")
+}
+
 func TestIntegration_FullFlow(t *testing.T) {
 	server := New()
 
@@ -436,6 +530,7 @@ func TestIntegration_FullFlow(t *testing.T) {
 	defer ts.Close()
 
 	client := NewStreamableHTTPClient(ts.URL)
+	client.Headers = map[string]string{"Authorization": "Bearer integration-test"}
 
 	resp, err := client.Call(context.Background(), MethodInitialize, InitializeParams{
 		ProtocolVersion: MCPProtocolVersion,

--- a/SaFE/common/pkg/mcp/server/sse.go
+++ b/SaFE/common/pkg/mcp/server/sse.go
@@ -38,6 +38,15 @@ type SSETransport struct {
 	// JSON-RPC response to a slow consumer. On expiry the request fails with
 	// 503 instead of silently dropping the response.
 	SendQueueTimeout time.Duration
+
+	// AllowedOrigins is the CORS allowlist for browser-based MCP clients.
+	// Empty (default) means same-origin only: no Access-Control-Allow-Origin
+	// header is emitted, so cross-origin fetch from arbitrary sites is
+	// blocked. Add explicit origins (e.g. "https://app.example.com") to
+	// opt in. The wildcard "*" is supported but discouraged because
+	// requests bearing cookies will then be rejected by browsers anyway,
+	// and any future flip to Allow-Credentials would open a CSRF hole.
+	AllowedOrigins []string
 }
 
 type sseSession struct {
@@ -107,7 +116,7 @@ func (t *SSETransport) HandleSSE(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
+	t.applyCORS(w, r)
 	w.Header().Set("X-Session-ID", sessionID)
 
 	endpointPath := t.MessageEndpointPath
@@ -141,6 +150,7 @@ cleanup:
 
 // HandleMessage handles POST /message?session_id=... JSON-RPC messages.
 func (t *SSETransport) HandleMessage(w http.ResponseWriter, r *http.Request) {
+	t.applyCORS(w, r)
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -210,6 +220,7 @@ func (t *SSETransport) HandleMessage(w http.ResponseWriter, r *http.Request) {
 
 // HandleHealth returns transport-level health info.
 func (t *SSETransport) HandleHealth(w http.ResponseWriter, r *http.Request) {
+	t.applyCORS(w, r)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	resp := map[string]any{
@@ -219,6 +230,37 @@ func (t *SSETransport) HandleHealth(w http.ResponseWriter, r *http.Request) {
 		"initialized": t.server.IsInitialized(),
 	}
 	json.NewEncoder(w).Encode(resp)
+}
+
+// writeCORS sets Access-Control-Allow-Origin only when the inbound Origin
+// matches the allowlist (or "*" is explicitly configured). Empty allowlist =
+// same-origin only, so no header is emitted and browsers fall back to
+// same-origin enforcement. Vary: Origin is set whenever the allowlist is
+// non-empty to avoid cache poisoning.
+func writeCORS(w http.ResponseWriter, r *http.Request, allowed []string) {
+	if len(allowed) == 0 {
+		return
+	}
+	w.Header().Add("Vary", "Origin")
+	origin := r.Header.Get("Origin")
+	for _, a := range allowed {
+		if a == "*" {
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			return
+		}
+		if origin != "" && origin == a {
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			return
+		}
+	}
+}
+
+func (t *SSETransport) applyCORS(w http.ResponseWriter, r *http.Request) {
+	writeCORS(w, r, t.AllowedOrigins)
+}
+
+func (t *StreamableHTTPTransport) applyCORS(w http.ResponseWriter, r *http.Request) {
+	writeCORS(w, r, t.AllowedOrigins)
 }
 
 func (t *SSETransport) sendEvent(session *sseSession, event, data string) error {
@@ -305,6 +347,10 @@ func (t *SSETransport) StartStandalone(ctx context.Context, addr string) error {
 // StreamableHTTPTransport provides a simpler HTTP request/response transport.
 type StreamableHTTPTransport struct {
 	server *Server
+
+	// AllowedOrigins behaves the same way as SSETransport.AllowedOrigins.
+	// Empty = same-origin only. See SSETransport.applyCORS for details.
+	AllowedOrigins []string
 }
 
 func NewStreamableHTTPTransport(server *Server) *StreamableHTTPTransport {
@@ -317,6 +363,7 @@ func (t *StreamableHTTPTransport) Handler() http.Handler {
 
 // HandleRPC processes a single JSON-RPC POST request and writes the JSON response.
 func (t *StreamableHTTPTransport) HandleRPC(w http.ResponseWriter, r *http.Request) {
+	t.applyCORS(w, r)
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return

--- a/SaFE/common/pkg/mcp/server/sse.go
+++ b/SaFE/common/pkg/mcp/server/sse.go
@@ -33,6 +33,11 @@ type SSETransport struct {
 	// "endpoint" event so they know where to POST JSON-RPC messages. Defaults to
 	// "/mcp/message" but should be overridden when mounted under a custom prefix.
 	MessageEndpointPath string
+
+	// SendQueueTimeout caps how long HandleMessage blocks trying to enqueue a
+	// JSON-RPC response to a slow consumer. On expiry the request fails with
+	// 503 instead of silently dropping the response.
+	SendQueueTimeout time.Duration
 }
 
 type sseSession struct {
@@ -54,6 +59,7 @@ func NewSSETransport(server *Server) *SSETransport {
 		ReadTimeout:         60 * time.Second,
 		WriteTimeout:        10 * time.Second,
 		MessageEndpointPath: "/mcp/message",
+		SendQueueTimeout:    5 * time.Second,
 	}
 }
 
@@ -173,10 +179,27 @@ func (t *SSETransport) HandleMessage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if response != nil {
+		// Bounded wait so a slow / stalled SSE consumer can't silently drop
+		// JSON-RPC responses (the previous non-blocking send would return 202
+		// with the response thrown away). On overload, fail loudly with 503
+		// so the client can retry instead of hanging on a never-arriving id.
+		timeout := t.SendQueueTimeout
+		if timeout <= 0 {
+			timeout = 5 * time.Second
+		}
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
 		select {
 		case session.messages <- response:
-		default:
-			klog.Warningf("MCP SSE: Message queue full for session %s", sessionID)
+		case <-r.Context().Done():
+			return
+		case <-session.ctx.Done():
+			http.Error(w, "Session closed", http.StatusGone)
+			return
+		case <-timer.C:
+			klog.Errorf("MCP SSE: Dropping response for session %s after %s: queue full", sessionID, timeout)
+			http.Error(w, "Session message queue is full", http.StatusServiceUnavailable)
+			return
 		}
 	}
 
@@ -318,9 +341,12 @@ func (t *StreamableHTTPTransport) HandleRPC(w http.ResponseWriter, r *http.Reque
 }
 
 // StreamableHTTPClient is a simple client for the streamable HTTP transport.
+// Headers is optional and applied to every outgoing request, useful for tests
+// or scripts that need to attach Authorization etc.
 type StreamableHTTPClient struct {
 	BaseURL    string
 	HTTPClient *http.Client
+	Headers    map[string]string
 }
 
 func NewStreamableHTTPClient(baseURL string) *StreamableHTTPClient {
@@ -351,6 +377,9 @@ func (c *StreamableHTTPClient) Call(ctx context.Context, method string, params a
 		return nil, err
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
+	for k, v := range c.Headers {
+		httpReq.Header.Set(k, v)
+	}
 
 	httpResp, err := c.HTTPClient.Do(httpReq)
 	if err != nil {

--- a/SaFE/common/pkg/mcp/server/sse.go
+++ b/SaFE/common/pkg/mcp/server/sse.go
@@ -1,0 +1,457 @@
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+// See LICENSE for license information.
+
+package server
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/uuid"
+	"k8s.io/klog/v2"
+)
+
+// SSETransport implements the MCP SSE transport protocol.
+type SSETransport struct {
+	server       *Server
+	sessions     sync.Map
+	sessionCount int64
+
+	HeartbeatInterval time.Duration
+	ReadTimeout       time.Duration
+	WriteTimeout      time.Duration
+
+	// MessageEndpointPath is the absolute URL path returned to clients via the SSE
+	// "endpoint" event so they know where to POST JSON-RPC messages. Defaults to
+	// "/mcp/message" but should be overridden when mounted under a custom prefix.
+	MessageEndpointPath string
+}
+
+type sseSession struct {
+	id         string
+	writer     http.ResponseWriter
+	flusher    http.Flusher
+	ctx        context.Context
+	cancel     context.CancelFunc
+	messages   chan []byte
+	created    time.Time
+	lastActive time.Time
+	mu         sync.Mutex
+}
+
+func NewSSETransport(server *Server) *SSETransport {
+	return &SSETransport{
+		server:              server,
+		HeartbeatInterval:   30 * time.Second,
+		ReadTimeout:         60 * time.Second,
+		WriteTimeout:        10 * time.Second,
+		MessageEndpointPath: "/mcp/message",
+	}
+}
+
+// Handler returns an http.Handler that serves the SSE transport on absolute paths
+// /sse, /message, /health. Kept for standalone usage; framework integrations
+// should call HandleSSE / HandleMessage / HandleHealth directly so the mount
+// path is controlled by the framework router.
+func (t *SSETransport) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/sse", t.HandleSSE)
+	mux.HandleFunc("/message", t.HandleMessage)
+	mux.HandleFunc("/health", t.HandleHealth)
+	return mux
+}
+
+// HandleSSE handles the GET /sse stream open request.
+func (t *SSETransport) HandleSSE(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "SSE not supported", http.StatusInternalServerError)
+		return
+	}
+
+	sessionID := uuid.New().String()
+	ctx, cancel := context.WithCancel(r.Context())
+	session := &sseSession{
+		id:         sessionID,
+		writer:     w,
+		flusher:    flusher,
+		ctx:        ctx,
+		cancel:     cancel,
+		messages:   make(chan []byte, 100),
+		created:    time.Now(),
+		lastActive: time.Now(),
+	}
+	t.sessions.Store(sessionID, session)
+	atomic.AddInt64(&t.sessionCount, 1)
+
+	klog.Infof("MCP SSE: New session %s from %s", sessionID, r.RemoteAddr)
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("X-Session-ID", sessionID)
+
+	endpointPath := t.MessageEndpointPath
+	if endpointPath == "" {
+		endpointPath = "/mcp/message"
+	}
+	messageEndpoint := fmt.Sprintf("%s?session_id=%s", endpointPath, sessionID)
+	t.sendEvent(session, "endpoint", messageEndpoint)
+
+	go t.heartbeat(session)
+
+	for {
+		select {
+		case <-ctx.Done():
+			klog.Infof("MCP SSE: Session %s closed (context done)", sessionID)
+			goto cleanup
+		case msg := <-session.messages:
+			if err := t.sendEvent(session, "message", string(msg)); err != nil {
+				klog.Errorf("MCP SSE: Failed to send message to session %s: %v", sessionID, err)
+				goto cleanup
+			}
+		}
+	}
+
+cleanup:
+	t.sessions.Delete(sessionID)
+	atomic.AddInt64(&t.sessionCount, -1)
+	cancel()
+	klog.Infof("MCP SSE: Session %s cleaned up", sessionID)
+}
+
+// HandleMessage handles POST /message?session_id=... JSON-RPC messages.
+func (t *SSETransport) HandleMessage(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	sessionID := r.URL.Query().Get("session_id")
+	if sessionID == "" {
+		http.Error(w, "Missing session_id", http.StatusBadRequest)
+		return
+	}
+	sessionVal, ok := t.sessions.Load(sessionID)
+	if !ok {
+		http.Error(w, "Session not found", http.StatusNotFound)
+		return
+	}
+	session := sessionVal.(*sseSession)
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "Failed to read body", http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	klog.V(4).Infof("MCP SSE: Received message for session %s: %s", sessionID, string(body))
+
+	session.mu.Lock()
+	session.lastActive = time.Now()
+	session.mu.Unlock()
+
+	ctx := ContextWithHTTPRequest(session.ctx, r)
+	response, err := t.server.HandleMessage(ctx, body)
+	if err != nil {
+		klog.Errorf("MCP SSE: Failed to handle message: %v", err)
+		http.Error(w, "Failed to handle message", http.StatusInternalServerError)
+		return
+	}
+
+	if response != nil {
+		select {
+		case session.messages <- response:
+		default:
+			klog.Warningf("MCP SSE: Message queue full for session %s", sessionID)
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	w.Write([]byte(`{"status":"accepted"}`))
+}
+
+// HandleHealth returns transport-level health info.
+func (t *SSETransport) HandleHealth(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	resp := map[string]any{
+		"status":      "ok",
+		"sessions":    atomic.LoadInt64(&t.sessionCount),
+		"tools":       t.server.ToolCount(),
+		"initialized": t.server.IsInitialized(),
+	}
+	json.NewEncoder(w).Encode(resp)
+}
+
+func (t *SSETransport) sendEvent(session *sseSession, event, data string) error {
+	session.mu.Lock()
+	defer session.mu.Unlock()
+
+	var sb strings.Builder
+	if event != "" {
+		sb.WriteString("event: ")
+		sb.WriteString(event)
+		sb.WriteString("\n")
+	}
+	for _, line := range strings.Split(data, "\n") {
+		sb.WriteString("data: ")
+		sb.WriteString(line)
+		sb.WriteString("\n")
+	}
+	sb.WriteString("\n")
+
+	_, err := session.writer.Write([]byte(sb.String()))
+	if err != nil {
+		return err
+	}
+	session.flusher.Flush()
+	return nil
+}
+
+func (t *SSETransport) heartbeat(session *sseSession) {
+	ticker := time.NewTicker(t.HeartbeatInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-session.ctx.Done():
+			return
+		case <-ticker.C:
+			if err := t.sendEvent(session, "ping", ""); err != nil {
+				klog.V(4).Infof("MCP SSE: Heartbeat failed for session %s: %v", session.id, err)
+				session.cancel()
+				return
+			}
+		}
+	}
+}
+
+func (t *SSETransport) SessionCount() int64 {
+	return atomic.LoadInt64(&t.sessionCount)
+}
+
+func (t *SSETransport) CloseSession(sessionID string) {
+	if sessionVal, ok := t.sessions.Load(sessionID); ok {
+		session := sessionVal.(*sseSession)
+		session.cancel()
+	}
+}
+
+func (t *SSETransport) CloseAllSessions() {
+	t.sessions.Range(func(key, value any) bool {
+		session := value.(*sseSession)
+		session.cancel()
+		return true
+	})
+}
+
+func (t *SSETransport) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	t.Handler().ServeHTTP(w, r)
+}
+
+func (t *SSETransport) StartStandalone(ctx context.Context, addr string) error {
+	srv := &http.Server{Addr: addr, Handler: t.Handler()}
+	go func() {
+		<-ctx.Done()
+		klog.Info("MCP SSE: Shutting down server...")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		srv.Shutdown(shutdownCtx)
+	}()
+	klog.Infof("MCP SSE: Starting server on %s", addr)
+	if err := srv.ListenAndServe(); err != http.ErrServerClosed {
+		return err
+	}
+	return nil
+}
+
+// StreamableHTTPTransport provides a simpler HTTP request/response transport.
+type StreamableHTTPTransport struct {
+	server *Server
+}
+
+func NewStreamableHTTPTransport(server *Server) *StreamableHTTPTransport {
+	return &StreamableHTTPTransport{server: server}
+}
+
+func (t *StreamableHTTPTransport) Handler() http.Handler {
+	return http.HandlerFunc(t.HandleRPC)
+}
+
+// HandleRPC processes a single JSON-RPC POST request and writes the JSON response.
+func (t *StreamableHTTPTransport) HandleRPC(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "Failed to read body", http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	ctx := ContextWithHTTPRequest(r.Context(), r)
+	response, err := t.server.HandleMessage(ctx, body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if response != nil {
+		w.Write(response)
+	}
+}
+
+// StreamableHTTPClient is a simple client for the streamable HTTP transport.
+type StreamableHTTPClient struct {
+	BaseURL    string
+	HTTPClient *http.Client
+}
+
+func NewStreamableHTTPClient(baseURL string) *StreamableHTTPClient {
+	return &StreamableHTTPClient{
+		BaseURL:    baseURL,
+		HTTPClient: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+func (c *StreamableHTTPClient) Call(ctx context.Context, method string, params any) (*JSONRPCResponse, error) {
+	paramsJSON, err := json.Marshal(params)
+	if err != nil {
+		return nil, err
+	}
+	req := JSONRPCRequest{
+		JSONRPC: JSONRPCVersion,
+		ID:      json.RawMessage(`1`),
+		Method:  method,
+		Params:  paramsJSON,
+	}
+	reqBody, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL, strings.NewReader(string(reqBody)))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := c.HTTPClient.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	defer httpResp.Body.Close()
+
+	var resp JSONRPCResponse
+	if err := json.NewDecoder(httpResp.Body).Decode(&resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// SSEClient is a simple client for testing SSE transport.
+type SSEClient struct {
+	BaseURL    string
+	HTTPClient *http.Client
+	sessionID  string
+}
+
+func NewSSEClient(baseURL string) *SSEClient {
+	return &SSEClient{
+		BaseURL:    baseURL,
+		HTTPClient: &http.Client{Timeout: 0},
+	}
+}
+
+func (c *SSEClient) Connect(ctx context.Context) (<-chan string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL+"/sse", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		return nil, fmt.Errorf("unexpected status: %d", resp.StatusCode)
+	}
+	c.sessionID = resp.Header.Get("X-Session-ID")
+
+	events := make(chan string, 100)
+	go func() {
+		defer resp.Body.Close()
+		defer close(events)
+		reader := bufio.NewReader(resp.Body)
+		for {
+			line, err := reader.ReadString('\n')
+			if err != nil {
+				return
+			}
+			if strings.HasPrefix(line, "data: ") {
+				data := strings.TrimPrefix(line, "data: ")
+				data = strings.TrimSuffix(data, "\n")
+				select {
+				case events <- data:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}()
+	return events, nil
+}
+
+func (c *SSEClient) SendMessage(ctx context.Context, method string, params any) error {
+	paramsJSON, err := json.Marshal(params)
+	if err != nil {
+		return err
+	}
+	req := JSONRPCRequest{
+		JSONRPC: JSONRPCVersion,
+		ID:      json.RawMessage(`1`),
+		Method:  method,
+		Params:  paramsJSON,
+	}
+	reqBody, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+
+	url := fmt.Sprintf("%s/message?session_id=%s", c.BaseURL, c.sessionID)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(reqBody)))
+	if err != nil {
+		return err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := c.HTTPClient.Do(httpReq)
+	if err != nil {
+		return err
+	}
+	defer httpResp.Body.Close()
+	if httpResp.StatusCode != http.StatusAccepted {
+		return fmt.Errorf("unexpected status: %d", httpResp.StatusCode)
+	}
+	return nil
+}
+
+func (c *SSEClient) SessionID() string {
+	return c.sessionID
+}

--- a/SaFE/common/pkg/mcp/server/stdio.go
+++ b/SaFE/common/pkg/mcp/server/stdio.go
@@ -1,0 +1,153 @@
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+// See LICENSE for license information.
+
+package server
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"sync"
+
+	"k8s.io/klog/v2"
+)
+
+// STDIOTransport implements the MCP STDIO transport protocol.
+// Preferred transport for IDE integrations like Cursor.
+type STDIOTransport struct {
+	server *Server
+	reader io.Reader
+	writer io.Writer
+	done   chan struct{}
+	wg     sync.WaitGroup
+}
+
+func NewSTDIOTransport(server *Server) *STDIOTransport {
+	return &STDIOTransport{
+		server: server,
+		reader: os.Stdin,
+		writer: os.Stdout,
+		done:   make(chan struct{}),
+	}
+}
+
+func NewSTDIOTransportWithIO(server *Server, reader io.Reader, writer io.Writer) *STDIOTransport {
+	return &STDIOTransport{
+		server: server,
+		reader: reader,
+		writer: writer,
+		done:   make(chan struct{}),
+	}
+}
+
+func (t *STDIOTransport) Start(ctx context.Context) error {
+	klog.Info("MCP STDIO: Starting transport")
+
+	scanner := bufio.NewScanner(t.reader)
+	scanner.Buffer(make([]byte, 1024*1024), 10*1024*1024)
+
+	t.wg.Add(1)
+	go func() {
+		defer t.wg.Done()
+		<-ctx.Done()
+		close(t.done)
+	}()
+
+	for {
+		select {
+		case <-t.done:
+			klog.Info("MCP STDIO: Shutting down")
+			return nil
+		default:
+		}
+
+		if !scanner.Scan() {
+			if err := scanner.Err(); err != nil {
+				klog.Errorf("MCP STDIO: Read error: %v", err)
+				return err
+			}
+			klog.Info("MCP STDIO: EOF reached")
+			return nil
+		}
+
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		klog.V(4).Infof("MCP STDIO: Received: %s", string(line))
+
+		response, err := t.server.HandleMessage(ctx, line)
+		if err != nil {
+			klog.Errorf("MCP STDIO: Handle error: %v", err)
+			errResp := NewErrorResponse(nil, ErrorCodeInternalError, err.Error(), nil)
+			response, _ = json.Marshal(errResp)
+		}
+
+		if response != nil {
+			klog.V(4).Infof("MCP STDIO: Sending: %s", string(response))
+			if err := t.writeResponse(response); err != nil {
+				klog.Errorf("MCP STDIO: Write error: %v", err)
+				return err
+			}
+		}
+	}
+}
+
+func (t *STDIOTransport) writeResponse(data []byte) error {
+	if _, err := t.writer.Write(data); err != nil {
+		return err
+	}
+	if _, err := t.writer.Write([]byte("\n")); err != nil {
+		return err
+	}
+	if f, ok := t.writer.(interface{ Flush() error }); ok {
+		return f.Flush()
+	}
+	if f, ok := t.writer.(*os.File); ok {
+		return f.Sync()
+	}
+	return nil
+}
+
+func (t *STDIOTransport) Stop() {
+	select {
+	case <-t.done:
+	default:
+		close(t.done)
+	}
+	t.wg.Wait()
+}
+
+// RunStdio starts an MCP server with STDIO transport.
+func RunStdio(ctx context.Context, server *Server) error {
+	transport := NewSTDIOTransport(server)
+	return transport.Start(ctx)
+}
+
+// STDIOServer wraps Server + STDIOTransport for simple usage.
+type STDIOServer struct {
+	mcpServer *Server
+	transport *STDIOTransport
+}
+
+func NewSTDIOServer(mcpServer *Server) *STDIOServer {
+	return &STDIOServer{
+		mcpServer: mcpServer,
+		transport: NewSTDIOTransport(mcpServer),
+	}
+}
+
+func (s *STDIOServer) Run(ctx context.Context) error {
+	return s.transport.Start(ctx)
+}
+
+func (s *STDIOServer) Stop() {
+	s.transport.Stop()
+}
+
+func (s *STDIOServer) Server() *Server {
+	return s.mcpServer
+}


### PR DESCRIPTION
Expose SaFE REST APIs as MCP tools so AI assistants (Cursor, Claude Desktop, etc.) can manage clusters, workspaces, nodes, workloads, ops-jobs, flavors and API keys without bespoke clients.

What's included:
- common/pkg/mcp/server: JSON-RPC 2.0 core, SSE / Streamable HTTP / STDIO transports, with HTTP request propagated through context so tool handlers can access auth headers.
- apiserver/pkg/mcp/unified: lens-style endpoint registry that can expose handlers as both HTTP and MCP tools (kept for future declarative migration).
- apiserver/pkg/mcp/tools: 47 built-in tools matching the external primus-safe-core42 spec (cluster_*, workspace_*, node_*, workload_*, opsjob_*, flavor_*, apikey_*). Tool handlers loop back into the apiserver REST API on the same host, forwarding Authorization / Cookie / userId / userName headers from the MCP context so existing authn / authz applies unchanged.
- apiserver/pkg/handlers: mountMCPRoutes mounts /sse, /message, /rpc, /health and / under the configurable base path; SSE returns the correct message endpoint for any base path.
- charts: opt-in mcp.enabled (default false), mcp.base_path (default /mcp) and mcp.instructions wired into the apiserver ConfigMap.
- handlers_mcp_test.go: integration tests covering default + custom base paths and Authorization header forwarding.

Disabled by default; enabling only adds new routes and does not affect existing handlers or chart consumers.

Made-with: Cursor