### PR TITLE
fix(etcd): set quota to 8GB and enable auto-compaction on cluster creation

### DIFF
--- a/Bootstrap/bootstrap.sh
+++ b/Bootstrap/bootstrap.sh
@@ -89,6 +89,7 @@ ansible-playbook -i "../$CONFIG_FILE" cluster.yml --become --become-user=root \
   -e nginx_image_repo="$NGINX_IMAGE" \
   -e kube_network_plugin="$KUBE_NETWORK_PLUGIN" \
   -e etcd_quota_backend_bytes="8589934592" \
+  -e etcd_compaction_retention="1h" \
   -e etcd_memory_limit="8GB" \
   -v
 

--- a/SaFE/resource-manager/pkg/resource/cluster_helper.go
+++ b/SaFE/resource-manager/pkg/resource/cluster_helper.go
@@ -482,6 +482,9 @@ func getKubeSprayEnv(cluster *v1.Cluster) string {
 	}
 	cmd = fmt.Sprintf("%s -e auto_renew_certificates=true -e nginx_image_repo=public.ecr.aws/docker/library/nginx", cmd)
 	cmd = fmt.Sprintf("%s -e kube_controller_node_monitor_grace_period=5m -e kube_apiserver_pod_eviction_not_ready_timeout_seconds=60 -e kube_apiserver_pod_eviction_unreachable_timeout_seconds=60", cmd)
+	// Set etcd quota to 8GB and enable auto-compaction (periodic mode, retain 1 hour)
+	// etcd_compaction_retention maps to ETCD_AUTO_COMPACTION_RETENTION; mode defaults to periodic in etcd
+	cmd = fmt.Sprintf("%s -e etcd_quota_backend_bytes=8589934592 -e etcd_compaction_retention=1h", cmd)
 	return cmd
 }
 


### PR DESCRIPTION
## Summary
- `bootstrap.sh`: add `-e etcd_compaction_retention="1h"` to kubespray `cluster.yml` invocation
- `cluster_helper.go`: add `etcd_quota_backend_bytes=8589934592` and `etcd_compaction_retention=1h` to `getKubeSprayEnv` for data-plane cluster creation

## Background
core42 etcd repeatedly hit NOSPACE alarm due to default 2GB quota and missing auto-compaction config. Manually fixed on the live cluster; this PR ensures new clusters are provisioned with correct settings from the start.

## Changes
- etcd quota: 2GB → 8GB (`ETCD_QUOTA_BACKEND_BYTES`)
- etcd auto-compaction: enabled, periodic mode, 1h retention (`ETCD_AUTO_COMPACTION_RETENTION`)

Made with [Cursor](https://cursor.com)