### PR TITLE
fix(ray): make ray 2.44.1 compatible with click 8.3.x in sglang images

### DIFF
--- a/SaFE/charts/primus-safe-cr/templates/addon_template/kuberay-operator.1.4.2.yaml
+++ b/SaFE/charts/primus-safe-cr/templates/addon_template/kuberay-operator.1.4.2.yaml
@@ -21,3 +21,12 @@ spec:
   version: 1.4.2
   type: helm
   helmDefaultNamespace: ray-system
+  helmDefaultValues: |
+    # Disable KubeRay's default wait-gcs-ready init container injection on workers.
+    # Background: that init runs `ray health-check`, which on sglang images carrying
+    # click==8.3.x is incompatible with ray==2.44.1 (add_command_alias deepcopy
+    # triggers a Sentinel exception) and loops forever. We inject our own
+    # wait-gcs-ready (using bash /dev/tcp probe) in the RayJob template instead.
+    env:
+      - name: ENABLE_INIT_CONTAINER_INJECTION
+        value: "false"

--- a/SaFE/charts/primus-safe/templates/configmap/ray_job_template.yaml
+++ b/SaFE/charts/primus-safe/templates/configmap/ray_job_template.yaml
@@ -58,6 +58,37 @@ data:
                   mountPath: /shared-data
           containers:
             - name: ray-job-submitter
+              # Do NOT set image: SaFE injects the same main image (sglang) used
+              # by head/worker, which provides the ray CLI. Hard-coding the
+              # preprocess image would not have ray installed.
+              #
+              # We override command/args because some sglang images ship
+              # click==8.3.x, which is incompatible with ray==2.44.1's
+              # add_command_alias (copy.deepcopy of a Sentinel raises ValueError).
+              # As a side effect KubeRay 1.4 stops injecting its default
+              # `ray job submit ... && ray job logs --follow` flow once a user
+              # command exists, so we replicate it explicitly below.
+              #
+              # ray[default]==2.44.1 is required: the ray jobs CLI/SDK depend on
+              # the `default` extras and some sglang images do not ship them,
+              # which would otherwise raise:
+              #   RuntimeError: The Ray jobs CLI & SDK require the
+              #                 ray[default] installation
+              command: ["/bin/bash", "-ce", "--"]
+              args:
+                - |
+                  set -e
+                  echo '[wrapper] installing click<8.3.0 + ray[default] (skip if already satisfied)'
+                  pip install --quiet 'click<8.3.0' 'ray[default]==2.44.1' 2>/dev/null || true
+                  ADDR="http://${RAY_DASHBOARD_ADDRESS}"
+                  ENTRYPOINT="$(echo "${RAY_JOB_ENTRYPOINT}" | base64 -d)"
+                  echo "[wrapper] ADDR=${ADDR} SUB_ID=${RAY_JOB_SUBMISSION_ID}"
+                  echo "[wrapper] ENTRYPOINT=${ENTRYPOINT}"
+                  if ! ray job status --address "$ADDR" "$RAY_JOB_SUBMISSION_ID" >/dev/null 2>&1; then
+                    eval ray job submit --address "$ADDR" --no-wait \
+                      --submission-id "$RAY_JOB_SUBMISSION_ID" -- "$ENTRYPOINT"
+                  fi
+                  ray job logs --address "$ADDR" --follow "$RAY_JOB_SUBMISSION_ID"
               volumeMounts:
                 - name: shared-data
                   mountPath: /shared-data
@@ -180,6 +211,39 @@ data:
                 volumeMounts:
                   - name: shared-data
                     mountPath: /shared-data
+              # Replaces KubeRay's default wait-gcs-ready init (disabled via
+              # ENABLE_INIT_CONTAINER_INJECTION=false on the operator) because the
+              # default runs `ray health-check`, which loops forever on sglang
+              # images carrying click==8.3.x with ray==2.44.1. Name MUST stay
+              # wait-gcs-ready so that even if KubeRay re-enables injection later
+              # it skips the same-named container instead of duplicating it.
+              - name: wait-gcs-ready
+                image: {{ .Values.global.image_registry }}/primussafe/{{ .Values.preprocess.image }}
+                imagePullPolicy: IfNotPresent
+                command: ["/usr/bin/bash", "-c"]
+                args:
+                  - |
+                    set -u
+                    HOST="${FQ_RAY_IP}"
+                    PORT=6379
+                    echo "waiting for GCS at ${HOST}:${PORT}"
+                    SECONDS=0
+                    while true; do
+                      if timeout 2 bash -c "exec 3<>/dev/tcp/${HOST}/${PORT}" 2>/dev/null; then
+                        echo "GCS is ready (TCP reachable after ${SECONDS}s)."
+                        break
+                      fi
+                      echo "${SECONDS}s elapsed: waiting for GCS to be ready..."
+                      SECONDS=$((SECONDS+5))
+                      sleep 5
+                    done
+                resources:
+                  requests:
+                    cpu: 100m
+                    memory: 64Mi
+                  limits:
+                    cpu: 200m
+                    memory: 128Mi
               containers:
               - name: main
                 env:
@@ -264,6 +328,35 @@ data:
                 volumeMounts:
                   - name: shared-data
                     mountPath: /shared-data
+              # See groupName "1" comment above for why we inject our own
+              # wait-gcs-ready and why the name must stay exactly this.
+              - name: wait-gcs-ready
+                image: {{ .Values.global.image_registry }}/primussafe/{{ .Values.preprocess.image }}
+                imagePullPolicy: IfNotPresent
+                command: ["/usr/bin/bash", "-c"]
+                args:
+                  - |
+                    set -u
+                    HOST="${FQ_RAY_IP}"
+                    PORT=6379
+                    echo "waiting for GCS at ${HOST}:${PORT}"
+                    SECONDS=0
+                    while true; do
+                      if timeout 2 bash -c "exec 3<>/dev/tcp/${HOST}/${PORT}" 2>/dev/null; then
+                        echo "GCS is ready (TCP reachable after ${SECONDS}s)."
+                        break
+                      fi
+                      echo "${SECONDS}s elapsed: waiting for GCS to be ready..."
+                      SECONDS=$((SECONDS+5))
+                      sleep 5
+                    done
+                resources:
+                  requests:
+                    cpu: 100m
+                    memory: 64Mi
+                  limits:
+                    cpu: 200m
+                    memory: 128Mi
               containers:
               - name: main
                 env:

--- a/SaFE/job-manager/pkg/dispatcher/test_data.go
+++ b/SaFE/job-manager/pkg/dispatcher/test_data.go
@@ -425,6 +425,21 @@ data:
                   mountPath: /shared-data
           containers:
             - name: ray-job-submitter
+              command: ["/bin/bash", "-ce", "--"]
+              args:
+                - |
+                  set -e
+                  echo '[wrapper] installing click<8.3.0 + ray[default] (skip if already satisfied)'
+                  pip install --quiet 'click<8.3.0' 'ray[default]==2.44.1' 2>/dev/null || true
+                  ADDR="http://${RAY_DASHBOARD_ADDRESS}"
+                  ENTRYPOINT="$(echo "${RAY_JOB_ENTRYPOINT}" | base64 -d)"
+                  echo "[wrapper] ADDR=${ADDR} SUB_ID=${RAY_JOB_SUBMISSION_ID}"
+                  echo "[wrapper] ENTRYPOINT=${ENTRYPOINT}"
+                  if ! ray job status --address "$ADDR" "$RAY_JOB_SUBMISSION_ID" >/dev/null 2>&1; then
+                    eval ray job submit --address "$ADDR" --no-wait \
+                      --submission-id "$RAY_JOB_SUBMISSION_ID" -- "$ENTRYPOINT"
+                  fi
+                  ray job logs --address "$ADDR" --follow "$RAY_JOB_SUBMISSION_ID"
               volumeMounts:
                 - name: shared-data
                   mountPath: /shared-data
@@ -539,6 +554,33 @@ data:
                 volumeMounts:
                   - name: shared-data
                     mountPath: /shared-data
+              - name: wait-gcs-ready
+                image: docker.io/primussafe/latest
+                imagePullPolicy: IfNotPresent
+                command: ["/usr/bin/bash", "-c"]
+                args:
+                  - |
+                    set -u
+                    HOST="${FQ_RAY_IP}"
+                    PORT=6379
+                    echo "waiting for GCS at ${HOST}:${PORT}"
+                    SECONDS=0
+                    while true; do
+                      if timeout 2 bash -c "exec 3<>/dev/tcp/${HOST}/${PORT}" 2>/dev/null; then
+                        echo "GCS is ready (TCP reachable after ${SECONDS}s)."
+                        break
+                      fi
+                      echo "${SECONDS}s elapsed: waiting for GCS to be ready..."
+                      SECONDS=$((SECONDS+5))
+                      sleep 5
+                    done
+                resources:
+                  requests:
+                    cpu: 100m
+                    memory: 64Mi
+                  limits:
+                    cpu: 200m
+                    memory: 128Mi
               containers:
               - name: main
                 env:
@@ -617,6 +659,33 @@ data:
                 volumeMounts:
                   - name: shared-data
                     mountPath: /shared-data
+              - name: wait-gcs-ready
+                image: docker.io/primussafe/latest
+                imagePullPolicy: IfNotPresent
+                command: ["/usr/bin/bash", "-c"]
+                args:
+                  - |
+                    set -u
+                    HOST="${FQ_RAY_IP}"
+                    PORT=6379
+                    echo "waiting for GCS at ${HOST}:${PORT}"
+                    SECONDS=0
+                    while true; do
+                      if timeout 2 bash -c "exec 3<>/dev/tcp/${HOST}/${PORT}" 2>/dev/null; then
+                        echo "GCS is ready (TCP reachable after ${SECONDS}s)."
+                        break
+                      fi
+                      echo "${SECONDS}s elapsed: waiting for GCS to be ready..."
+                      SECONDS=$((SECONDS+5))
+                      sleep 5
+                    done
+                resources:
+                  requests:
+                    cpu: 100m
+                    memory: 64Mi
+                  limits:
+                    cpu: 200m
+                    memory: 128Mi
               containers:
               - name: main
                 env:


### PR DESCRIPTION
## Background

`sglang:v0.5.9-rocm700-mi35x` and other sglang main images ship `click==8.3.x`, which is incompatible with `ray==2.44.1`'s `add_command_alias` (`copy.deepcopy` on a Sentinel raises a `ValueError`). Any container that touches the ray CLI on startup crash-loops. The head/worker `main` containers are already covered by `launcher.sh`, which runs `pip install 'click<8.3.0' 'ray==2.44.1' 'ray[default]'`. This PR plugs the three remaining gaps: the KubeRay operator, the worker `wait-gcs-ready` init container, and the submitter container's startup command.

## Changes

| # | File | What |
|---|---|---|
| 1 | `SaFE/charts/primus-safe-cr/templates/addon_template/kuberay-operator.1.4.2.yaml` | Add `helmDefaultValues` so the KubeRay operator runs with `env: ENABLE_INIT_CONTAINER_INJECTION=false`. This disables the operator's auto-injected `wait-gcs-ready` init container, which runs `ray health-check` and dead-loops on sglang images. |
| 2 | `SaFE/charts/primus-safe/templates/configmap/ray_job_template.yaml` | Both `workerGroupSpecs` (groupName `"1"` and `"2"`) get a custom `wait-gcs-ready` init container that probes head GCS via bash `/dev/tcp` on port 6379. Reuses the preprocess image (zero new dependency). The name MUST stay `wait-gcs-ready` so KubeRay would skip it even if injection is re-enabled later. |
| 3 | Same file | The `submitterPodTemplate.spec.containers[ray-job-submitter]` now sets `command: [/bin/bash, -ce, --]` and a wrapper `args` that first runs `pip install --quiet 'click<8.3.0' 'ray[default]==2.44.1'` (pip skips already-installed packages), then replicates KubeRay 1.4's default `ray job status / submit --no-wait / logs --follow` flow. The container intentionally does NOT set `image`, so SaFE keeps injecting the same sglang main image (which has the ray CLI). The `-ce --` form mirrors KubeRay v1.4.2's own `GetContainerCommand` implementation. |
| sync | `SaFE/job-manager/pkg/dispatcher/test_data.go` | `TestRayJobTemplateConfig` is updated to mirror changes 2 and 3, keeping the unit test fixture aligned with production. |

## Rollout order (important)

Deploy strictly **1 → 2 → 3**, and note that change 1 lands on the c04u01 data cluster while changes 2 and 3 land on the primus05 management cluster:

1. c04u01: upgrade the KubeRay operator chart so `ENABLE_INIT_CONTAINER_INJECTION=false` takes effect.
2. primus05: roll the primus-safe chart so the `amd-ray-job-template` ConfigMap carries `wait-gcs-ready` on every worker group.
3. primus05: same chart, the submitter wrapper command/args becomes effective.

Reversing the order would let the new template's `wait-gcs-ready` collide with KubeRay's still-auto-injected init container of the same name, and Kubernetes will outright refuse to create the worker pod.

> Note: this PR only touches chart templates. On clusters where the KubeRay operator is already running, the live env will NOT be reconciled automatically. The operator-side rollout is handled out-of-band (e.g. `kubectl set env deploy/kuberay-operator -n ray-system ENABLE_INIT_CONTAINER_INJECTION=false`).

## Verification

- Helm-rendered ConfigMap and the inner RayJob template both parse cleanly (after stripping `{{ }}` placeholders for offline parsing).
- Both worker groups end up with `initContainers = [preprocess, wait-gcs-ready]`.
- Submitter container has `command=[/bin/bash, -ce, --]`, no `image` field, and the args wrapper contains `click<8.3.0`, `ray[default]==2.44.1`, and `ray job logs`.
- `helmDefaultValues` parses to `env: [{name: ENABLE_INIT_CONTAINER_INJECTION, value: "false"}]`.
- `go test ./pkg/dispatcher/...` passes (including `TestCreateRayJob`).
- No lint errors.

## Smoke checks after rollout

```bash
# Change 1
kubectl get deploy -n ray-system kuberay-operator \
  -o jsonpath='{.spec.template.spec.containers[0].env}'
# Expect: [{"name":"ENABLE_INIT_CONTAINER_INJECTION","value":"false"}]

# Change 2
kubectl get cm -n primus-safe amd-ray-job-template -o jsonpath='{.data.template}' \
  | python3 -c "
import sys, yaml
tpl = yaml.safe_load(sys.stdin)
for g in tpl['spec']['rayClusterSpec']['workerGroupSpecs']:
    print(g['groupName'], [c['name'] for c in g['template']['spec']['initContainers']])
"
# Expect: 1 ['preprocess', 'wait-gcs-ready'] / 2 ['preprocess', 'wait-gcs-ready']

# Change 3 (after triggering a fresh RayJob)
kubectl logs -n core42-hyperloom <submitter-pod> --tail=20
# Expect head: [wrapper] installing click<8.3.0 + ray[default] (skip if already satisfied)
# No more RuntimeError or ValueError: ... not a valid Sentinel
```
