### PR TITLE
fix(webhooks): inject gpuName into `env.RESOURCES` for CICD runners

### DIFF
--- a/SaFE/webhooks/pkg/workload_webhook.go
+++ b/SaFE/webhooks/pkg/workload_webhook.go
@@ -141,7 +141,7 @@ func (m *WorkloadMutator) mutateCommon(ctx context.Context, oldWorkload, newWork
 	case common.AuthoringKind:
 		m.mutateAuthoring(newWorkload)
 	case common.CICDScaleRunnerSetKind:
-		m.mutateCICDScaleSet(newWorkload)
+		m.mutateCICDScaleSet(newWorkload, workspace)
 	case common.MonarchJob:
 		m.mutateMonarchJob(newWorkload)
 	case common.RayJobKind:
@@ -388,13 +388,45 @@ func (m *WorkloadMutator) mutateAuthoring(workload *v1.Workload) {
 }
 
 // mutateCICDScaleSet sets one-replica, disable Supervised for cicd.
-func (m *WorkloadMutator) mutateCICDScaleSet(workload *v1.Workload) {
+func (m *WorkloadMutator) mutateCICDScaleSet(workload *v1.Workload, workspace *v1.Workspace) {
 	workload.Spec.IsSupervised = false
 	if len(workload.Spec.Resources) > 0 {
 		workload.Spec.Resources = workload.Spec.Resources[0:1]
 		workload.Spec.Resources[0].Replica = 1
 	}
 	workload.Spec.Dependencies = nil
+	mutateCICDResourcesEnv(workload, workspace)
+}
+
+// mutateCICDResourcesEnv mirrors mutateResources for the runner-template payload that CICD
+// AutoscalingRunnerSet workloads stash inside spec.env["RESOURCES"]. Without this, GPU-backed
+// CICD runners are admitted with an empty gpuName in env.RESOURCES and validateCICDScalingRunnerSet
+// rejects them with a misleading "workspace has no GPU resources" error.
+func mutateCICDResourcesEnv(workload *v1.Workload, workspace *v1.Workspace) {
+	if workspace == nil {
+		return
+	}
+	raw, ok := workload.Spec.Env[ResourcesEnv]
+	if !ok || raw == "" {
+		return
+	}
+	res := &v1.WorkloadResource{}
+	if err := json.Unmarshal([]byte(raw), res); err != nil {
+		return
+	}
+	if !res.HasGpu() || res.GPUName != "" {
+		return
+	}
+	gpuName := v1.GetGpuResourceName(workspace)
+	if gpuName == "" {
+		return
+	}
+	res.GPUName = gpuName
+	b, err := json.Marshal(res)
+	if err != nil {
+		return
+	}
+	workload.Spec.Env[ResourcesEnv] = string(b)
 }
 
 // mutateMonarchJob sets no-retry, disable Supervised

--- a/SaFE/webhooks/pkg/workload_webhook_test.go
+++ b/SaFE/webhooks/pkg/workload_webhook_test.go
@@ -7,6 +7,7 @@ package webhooks
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -170,6 +171,72 @@ func TestMutateResources(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestMutateCICDScaleSet_GPURunnerPassesValidation is the regression test for the bug where
+// GPU-backed CICD AutoscalingRunnerSet workloads were rejected with a misleading
+// "workspace has no GPU resources" error. The UI sends a CPU-only fixed spec.resources[0]
+// alongside the user's actual GPU request encoded in env["RESOURCES"]; the mutator must
+// inject gpuName into env["RESOURCES"] so the CICD validator's resource check passes.
+func TestMutateCICDScaleSet_GPURunnerPassesValidation(t *testing.T) {
+	const (
+		gpuResourceName = "amd.com/gpu"
+		workspaceName   = "ws-1"
+	)
+
+	workspace := &v1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: workspaceName,
+			Annotations: map[string]string{
+				v1.GpuResourceNameAnnotation: gpuResourceName,
+			},
+		},
+	}
+
+	userResource := v1.WorkloadResource{
+		Replica:          1,
+		CPU:              "16",
+		GPU:              "8",
+		Memory:           "500Gi",
+		SharedMemory:     "250Gi",
+		EphemeralStorage: "1000Gi",
+	}
+	resourcesEnvJSON, err := json.Marshal(userResource)
+	assert.NilError(t, err)
+
+	workload := &v1.Workload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cicd-1",
+		},
+		Spec: v1.WorkloadSpec{
+			Workspace:        workspaceName,
+			GroupVersionKind: v1.GroupVersionKind{Kind: common.CICDScaleRunnerSetKind},
+			Resources: []v1.WorkloadResource{
+				{Replica: 1, CPU: "1", GPU: "0", Memory: "4Gi", EphemeralStorage: "10Gi"},
+			},
+			Env: map[string]string{
+				ResourcesEnv:           string(resourcesEnvJSON),
+				ImageEnv:               "ghcr.io/example/runner:latest",
+				EntrypointEnv:          "ZXhlYyAuL3J1bi5zaA==",
+				common.GithubConfigUrl: "https://github.com/example/repo",
+			},
+		},
+	}
+
+	var mutator WorkloadMutator
+	var validator WorkloadValidator
+
+	mutator.mutateCICDScaleSet(workload, workspace)
+	validateErr := validator.validateCICDScalingRunnerSet(workload)
+
+	mutated := &v1.WorkloadResource{}
+	assert.NilError(t, json.Unmarshal([]byte(workload.Spec.Env[ResourcesEnv]), mutated),
+		"env.RESOURCES should still be valid JSON after mutation")
+	assert.Equal(t, gpuResourceName, mutated.GPUName,
+		"mutator should inject the workspace's GPU resource name into env.RESOURCES")
+	assert.Equal(t, "8", mutated.GPU, "GPU count must be preserved through mutation")
+	assert.NilError(t, validateErr,
+		"a GPU-backed CICD runner should pass admission after mutation")
 }
 
 func newTestScheme(t *testing.T) *runtime.Scheme {


### PR DESCRIPTION
## Summary

Currently, the GPU-backed CICD AutoscalingRunnerSet workloads were being rejected at admission with the error:

> `Primus.00002: admission webhook "vworkload.sh.io" denied the request: Bad request. This workspace default-default has no GPU resources`

However the workspace did have GPU resources. The workaround we used on Friday (create the CICD with 0 GPU in the UI, then patch the row in the primus-safe DB to give it 8 GPUs) is fragile and undocumented; this PR removes the need for it by fixing the underlying webhook issue.

## Technical Details (⚠️ I wrote all of this code with AI )

I think the issue is this.

For `CICDScaleRunnerSetKind` workloads, the UI submits two parallel resource representations:

- A fixed CPU-only `spec.resources[0]` (cpu/memory/storage for the runner controller pod itself).
- The user's actual runner request (which may be GPU-backed) as JSON inside `spec.env["RESOURCES"]`. This is what the runner-proxy later forwards to create each `EphemeralRunner`.

The mutator `mutateResources` in `SaFE/webhooks/pkg/workload_webhook.go` only touches `spec.resources` and fills `GPUName` from the workspace's `GpuResourceNameAnnotation`. It never touched `env["RESOURCES"]`. The CICD validator `validateCICDScalingRunnerSet` then unmarshals `env["RESOURCES"]` and runs `validateResource` against that copy, which since PR #464 (`2a50c99c`) requires `gpuName` whenever `gpu > 0` — producing the misleading "no GPU resources" message.

This PR adds an env-side mutation that mirrors what `mutateResources` already does for `spec.resources`:

- `mutateCICDScaleSet` now takes the `*v1.Workspace` and uses a new helper function `mutateCICDResourcesEnv`.
- `mutateCICDResourcesEnv` parses `spec.env["RESOURCES"]`, and if the request `HasGpu()` and `GPUName` is empty, fills `GPUName` from `v1.GetGpuResourceName(workspace)` and re-marshals. 

## Test Plan

- Add new test `TestMutateCICDScaleSet_GPURunnerPassesValidation` in `SaFE/webhooks/pkg/workload_webhook_test.go`. 

     - It builds a workspace with `GpuResourceNameAnnotation = "amd.com/gpu"` and a CICD workload whose `env["RESOURCES"]` requests `gpu: "8"` with no `gpuName` — i.e. the shape the UI submits. It then runs the real mutator followed by the real validator and asserts (a) `env["RESOURCES"]` is still valid JSON, (b) `GPUName` is now populated, (c) `gpu` count is preserved, (d) `validateCICDScalingRunnerSet` returns nil. 
- Verified locally with the same command CI runs: `cd SaFE/webhooks && go test -v -race ./pkg/...`.

## Test Result

Local test passes:
```bash
cd SaFE/webhooks
go test -v -race ./pkg/...
```

<details> <Summary>Test results </Summary>

```bash
[17:42:00] ama10002  $     ~/Primus-SaFE/SaFE/webhooks   fix/andrewma/gpu-cicd-runner-validation-fails  go test -v -race ./pkg/...
=== RUN   TestGenerateDestPath
=== RUN   TestGenerateDestPath/non-download_type_job_should_not_modify_destPath
=== RUN   TestGenerateDestPath/download_type_job_with_PFS_volume_workspace_-_destPath_should_be_modified
=== RUN   TestGenerateDestPath/download_type_job_with_non-PFS_volume_workspace_-_uses_first_volume
=== RUN   TestGenerateDestPath/download_type_job_with_workspace_without_volumes_-_should_error
=== RUN   TestGenerateDestPath/download_type_job_with_multiple_volumes_-_PFS_has_priority
--- PASS: TestGenerateDestPath (0.01s)
    --- PASS: TestGenerateDestPath/non-download_type_job_should_not_modify_destPath (0.00s)
    --- PASS: TestGenerateDestPath/download_type_job_with_PFS_volume_workspace_-_destPath_should_be_modified (0.00s)
    --- PASS: TestGenerateDestPath/download_type_job_with_non-PFS_volume_workspace_-_uses_first_volume (0.00s)
    --- PASS: TestGenerateDestPath/download_type_job_with_workspace_without_volumes_-_should_error (0.00s)
    --- PASS: TestGenerateDestPath/download_type_job_with_multiple_volumes_-_PFS_has_priority (0.00s)
=== RUN   TestValidateDisplayName
=== RUN   TestValidateDisplayName/empty_name_is_valid
=== RUN   TestValidateDisplayName/valid_simple_name
=== RUN   TestValidateDisplayName/valid_name_with_dots
=== RUN   TestValidateDisplayName/valid_name_with_hyphens
=== RUN   TestValidateDisplayName/valid_minimum_length_name
=== RUN   TestValidateDisplayName/invalid_-_starts_with_number
=== RUN   TestValidateDisplayName/invalid_-_starts_with_hyphen
=== RUN   TestValidateDisplayName/invalid_-_ends_with_hyphen
=== RUN   TestValidateDisplayName/invalid_-_ends_with_dot
=== RUN   TestValidateDisplayName/invalid_-_uppercase_letters
=== RUN   TestValidateDisplayName/invalid_-_contains_underscore
=== RUN   TestValidateDisplayName/invalid_-_single_character
=== RUN   TestValidateDisplayName/valid_max_length_for_deployment
=== RUN   TestValidateDisplayName/invalid_-_exceeds_max_length_for_deployment
=== RUN   TestValidateDisplayName/valid_max_length_for_pytorchjob
=== RUN   TestValidateDisplayName/invalid_-_exceeds_max_length_for_pytorchjob
=== RUN   TestValidateDisplayName/valid_max_length_for_torchft
=== RUN   TestValidateDisplayName/invalid_-_exceeds_max_length_for_torchft
=== RUN   TestValidateDisplayName/valid_for_unknown_workload_kind_uses_default_length
--- PASS: TestValidateDisplayName (0.02s)
    --- PASS: TestValidateDisplayName/empty_name_is_valid (0.00s)
    --- PASS: TestValidateDisplayName/valid_simple_name (0.00s)
    --- PASS: TestValidateDisplayName/valid_name_with_dots (0.00s)
    --- PASS: TestValidateDisplayName/valid_name_with_hyphens (0.00s)
    --- PASS: TestValidateDisplayName/valid_minimum_length_name (0.00s)
    --- PASS: TestValidateDisplayName/invalid_-_starts_with_number (0.00s)
    --- PASS: TestValidateDisplayName/invalid_-_starts_with_hyphen (0.00s)
    --- PASS: TestValidateDisplayName/invalid_-_ends_with_hyphen (0.00s)
    --- PASS: TestValidateDisplayName/invalid_-_ends_with_dot (0.00s)
    --- PASS: TestValidateDisplayName/invalid_-_uppercase_letters (0.00s)
    --- PASS: TestValidateDisplayName/invalid_-_contains_underscore (0.00s)
    --- PASS: TestValidateDisplayName/invalid_-_single_character (0.00s)
    --- PASS: TestValidateDisplayName/valid_max_length_for_deployment (0.00s)
    --- PASS: TestValidateDisplayName/invalid_-_exceeds_max_length_for_deployment (0.00s)
    --- PASS: TestValidateDisplayName/valid_max_length_for_pytorchjob (0.00s)
    --- PASS: TestValidateDisplayName/invalid_-_exceeds_max_length_for_pytorchjob (0.00s)
    --- PASS: TestValidateDisplayName/valid_max_length_for_torchft (0.00s)
    --- PASS: TestValidateDisplayName/invalid_-_exceeds_max_length_for_torchft (0.00s)
    --- PASS: TestValidateDisplayName/valid_for_unknown_workload_kind_uses_default_length (0.00s)
=== RUN   TestValidateCronJobs
--- PASS: TestValidateCronJobs (0.00s)
=== RUN   TestMutateResources
=== RUN   TestMutateResources/Replica_0_is_filtered_out
=== RUN   TestMutateResources/GPU_'0'_cleared_and_GPUName_set_from_workspace
=== RUN   TestMutateResources/SharedMemory_and_EphemeralStorage_get_defaults
=== RUN   TestMutateResources/SharedMemory_and_EphemeralStorage_not_overwritten_if_set
=== RUN   TestMutateResources/Multiple_resources_with_mixed_scenarios
--- PASS: TestMutateResources (0.00s)
    --- PASS: TestMutateResources/Replica_0_is_filtered_out (0.00s)
    --- PASS: TestMutateResources/GPU_'0'_cleared_and_GPUName_set_from_workspace (0.00s)
    --- PASS: TestMutateResources/SharedMemory_and_EphemeralStorage_get_defaults (0.00s)
    --- PASS: TestMutateResources/SharedMemory_and_EphemeralStorage_not_overwritten_if_set (0.00s)
    --- PASS: TestMutateResources/Multiple_resources_with_mixed_scenarios (0.00s)
=== RUN   TestMutateCICDScaleSet_GPURunnerPassesValidation
--- PASS: TestMutateCICDScaleSet_GPURunnerPassesValidation (0.00s)
=== RUN   TestMutateStickyNodes_EnablePreempt
--- PASS: TestMutateStickyNodes_EnablePreempt (0.00s)
=== RUN   TestMutateStickyNodes_UnsupportedKind
--- PASS: TestMutateStickyNodes_UnsupportedKind (0.00s)
=== RUN   TestMutateStickyNodes_GpuCountMismatch
--- PASS: TestMutateStickyNodes_GpuCountMismatch (0.00s)
=== RUN   TestMutateStickyNodes_AllConditionsPass
--- PASS: TestMutateStickyNodes_AllConditionsPass (0.00s)
=== RUN   TestValidateResourceEnough_CpuFlavorWithGpuRequest
=== RUN   TestValidateResourceEnough_CpuFlavorWithGpuRequest/gpu_request_on_cpu-only_flavor_should_fail
=== RUN   TestValidateResourceEnough_CpuFlavorWithGpuRequest/cpu-only_request_on_cpu_flavor_should_pass
=== RUN   TestValidateResourceEnough_CpuFlavorWithGpuRequest/cpu_request_exceeding_flavor_should_fail
=== RUN   TestValidateResourceEnough_CpuFlavorWithGpuRequest/memory_request_exceeding_flavor_should_fail
--- PASS: TestValidateResourceEnough_CpuFlavorWithGpuRequest (0.00s)
    --- PASS: TestValidateResourceEnough_CpuFlavorWithGpuRequest/gpu_request_on_cpu-only_flavor_should_fail (0.00s)
    --- PASS: TestValidateResourceEnough_CpuFlavorWithGpuRequest/cpu-only_request_on_cpu_flavor_should_pass (0.00s)
    --- PASS: TestValidateResourceEnough_CpuFlavorWithGpuRequest/cpu_request_exceeding_flavor_should_fail (0.00s)
    --- PASS: TestValidateResourceEnough_CpuFlavorWithGpuRequest/memory_request_exceeding_flavor_should_fail (0.00s)
=== RUN   TestMutateManagers_AddManager
--- PASS: TestMutateManagers_AddManager (0.00s)
=== RUN   TestMutateManagers_RemoveManager
--- PASS: TestMutateManagers_RemoveManager (0.00s)
=== RUN   TestMutateManagers_AddManager_UserNotFound
--- PASS: TestMutateManagers_AddManager_UserNotFound (0.00s)
=== RUN   TestMutateWorkloadsOfWorkspace_EnablePreempt
--- PASS: TestMutateWorkloadsOfWorkspace_EnablePreempt (0.01s)
=== RUN   TestMutateWorkloadsOfWorkspace_DisablePreempt
--- PASS: TestMutateWorkloadsOfWorkspace_DisablePreempt (0.00s)
=== RUN   TestMutateWorkloadsOfWorkspace_SetTimeout
--- PASS: TestMutateWorkloadsOfWorkspace_SetTimeout (0.00s)
PASS
ok      github.com/AMD-AIG-AIMA/SAFE/webhooks/pkg       (cached)
[17:42:28] ama10002  $     ~/Primus-SaFE/SaFE/webhooks   fix/andrewma/gpu-cicd-runner-validation-fails  
```

<img width="947" height="961" alt="Screenshot 2026-05-06 170721" src="https://github.com/user-attachments/assets/36794fb8-e2c6-4a46-82fc-075cfe9a8b58" />

</details>

### Workaround

If somebody needs a GPU CICD runner currently, we can make a 0 GPU CICD runner and then later update the workload in the primus-safe-db database to give the workload 8 GPUs. 
