### PR TITLE
fix: support provider auth headers in llm proxy

### DIFF
--- a/SaFE/apiserver/pkg/handlers/llm-gateway/handler.go
+++ b/SaFE/apiserver/pkg/handlers/llm-gateway/handler.go
@@ -7,6 +7,7 @@ package llmgateway
 
 import (
 	"net/http"
+	"strings"
 
 	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
 	"github.com/AMD-AIG-AIMA/SAFE/apiserver/pkg/handlers/authority"
@@ -87,10 +88,71 @@ func InitRoutes(engine *gin.Engine, handler *Handler) {
 	// Web proxy forwards as: /api/v1/llm-proxy/v1/chat/completions
 	// Director strips /api/v1/llm-proxy, forwards /v1/chat/completions to LiteLLM.
 	llmProxy := engine.Group(llmProxyPrefix)
-	llmProxy.Use(authMiddleware)
+	llmProxy.Use(llmProxyAuthMiddleware)
 	llmProxy.Any("/*proxyPath", handler.ProxyLLMRequest)
 
 	klog.Info("LLM Gateway: routes registered successfully (management + LLM proxy)")
+}
+
+const (
+	llmProxyAuthHeaderStyleKey = "llm_proxy_auth_header_style"
+	llmProxyAuthHeaderAuth     = "authorization"
+	llmProxyAuthHeaderXAPIKey  = "x-api-key"
+)
+
+type llmProxyAuthHeaderMapping struct {
+	style  string
+	header string
+}
+
+var llmProxyAuthHeaderMappings = []llmProxyAuthHeaderMapping{
+	{style: llmProxyAuthHeaderAuth, header: "Authorization"},
+	{style: llmProxyAuthHeaderXAPIKey, header: "X-Api-Key"},
+}
+
+func llmProxyAuthMiddleware(c *gin.Context) {
+	normalizeProxyAPIKeyHeader(c)
+	if err := authority.ParseToken(c); err != nil {
+		apiutils.AbortWithApiError(c, err)
+		return
+	}
+	c.Next()
+}
+
+func normalizeProxyAPIKeyHeader(c *gin.Context) {
+	mapping, apiKey, ok := selectProxyAuthHeader(c)
+	if !ok {
+		return
+	}
+	c.Set(llmProxyAuthHeaderStyleKey, mapping.style)
+	if mapping.style == llmProxyAuthHeaderXAPIKey {
+		c.Request.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+}
+
+func selectProxyAuthHeader(c *gin.Context) (llmProxyAuthHeaderMapping, string, bool) {
+	mappings := llmProxyAuthHeaderMappings
+	if isAnthropicMessagesRequest(c) {
+		mappings = []llmProxyAuthHeaderMapping{
+			{style: llmProxyAuthHeaderXAPIKey, header: "X-Api-Key"},
+			{style: llmProxyAuthHeaderAuth, header: "Authorization"},
+		}
+	}
+	for _, mapping := range mappings {
+		value := c.GetHeader(mapping.header)
+		if value == "" {
+			continue
+		}
+		if mapping.style == llmProxyAuthHeaderAuth {
+			return mapping, authority.ExtractApiKeyFromRequest(value), true
+		}
+		return mapping, value, true
+	}
+	return llmProxyAuthHeaderMapping{}, "", false
+}
+
+func isAnthropicMessagesRequest(c *gin.Context) bool {
+	return strings.HasSuffix(c.Request.URL.Path, "/v1/messages")
 }
 
 // ── Handlers ──────────────────────────────────────────────────────────────

--- a/SaFE/apiserver/pkg/handlers/llm-gateway/handler_test.go
+++ b/SaFE/apiserver/pkg/handlers/llm-gateway/handler_test.go
@@ -55,6 +55,111 @@ func setUserContext(c *gin.Context, userId, userName string) {
 	c.Set(common.UserName, userName)
 }
 
+func TestNormalizeProxyAPIKeyHeader_Authorization(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req, _ := http.NewRequest("POST", "/api/v1/llm-proxy/v1/chat/completions", nil)
+	req.Header.Set("Authorization", "Bearer ak-auth")
+	c.Request = req
+
+	normalizeProxyAPIKeyHeader(c)
+
+	assert.Equal(t, "Bearer ak-auth", c.GetHeader("Authorization"))
+	style, exists := c.Get(llmProxyAuthHeaderStyleKey)
+	assert.True(t, exists)
+	assert.Equal(t, llmProxyAuthHeaderAuth, style)
+}
+
+func TestNormalizeProxyAPIKeyHeader_XAPIKey(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req, _ := http.NewRequest("POST", "/api/v1/llm-proxy/v1/messages", nil)
+	req.Header.Set("X-Api-Key", "ak-test")
+	c.Request = req
+
+	normalizeProxyAPIKeyHeader(c)
+
+	assert.Equal(t, "Bearer ak-test", c.GetHeader("Authorization"))
+	style, exists := c.Get(llmProxyAuthHeaderStyleKey)
+	assert.True(t, exists)
+	assert.Equal(t, llmProxyAuthHeaderXAPIKey, style)
+}
+
+func TestNormalizeProxyAPIKeyHeader_AuthorizationTakesPriority(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req, _ := http.NewRequest("POST", "/api/v1/llm-proxy/v1/chat/completions", nil)
+	req.Header.Set("Authorization", "Bearer ak-auth")
+	req.Header.Set("X-Api-Key", "ak-x-api-key")
+	c.Request = req
+
+	normalizeProxyAPIKeyHeader(c)
+
+	assert.Equal(t, "Bearer ak-auth", c.GetHeader("Authorization"))
+	style, exists := c.Get(llmProxyAuthHeaderStyleKey)
+	assert.True(t, exists)
+	assert.Equal(t, llmProxyAuthHeaderAuth, style)
+}
+
+func TestNormalizeProxyAPIKeyHeader_MessagesPrefersXAPIKey(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req, _ := http.NewRequest("POST", "/api/v1/llm-proxy/v1/messages", nil)
+	req.Header.Set("Authorization", "Bearer ak-auth")
+	req.Header.Set("X-Api-Key", "ak-x-api-key")
+	c.Request = req
+
+	normalizeProxyAPIKeyHeader(c)
+
+	assert.Equal(t, "Bearer ak-x-api-key", c.GetHeader("Authorization"))
+	style, exists := c.Get(llmProxyAuthHeaderStyleKey)
+	assert.True(t, exists)
+	assert.Equal(t, llmProxyAuthHeaderXAPIKey, style)
+}
+
+func TestNormalizeProxyAPIKeyHeader_NoSupportedHeader(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req, _ := http.NewRequest("POST", "/api/v1/llm-proxy/v1/chat/completions", nil)
+	c.Request = req
+
+	normalizeProxyAPIKeyHeader(c)
+
+	assert.Empty(t, c.GetHeader("Authorization"))
+	_, exists := c.Get(llmProxyAuthHeaderStyleKey)
+	assert.False(t, exists)
+}
+
+func TestApplyProxyVirtualKeyHeader_AuthorizationClearsOtherAuthHeaders(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req, _ := http.NewRequest("POST", "/api/v1/llm-proxy/v1/chat/completions", nil)
+	req.Header.Set("Authorization", "Bearer ak-auth")
+	req.Header.Set("X-Api-Key", "ak-x-api-key")
+	c.Request = req
+	c.Set(llmProxyAuthHeaderStyleKey, llmProxyAuthHeaderAuth)
+
+	applyProxyVirtualKeyHeader(c, "sk-test-virtual-key")
+
+	assert.Equal(t, "Bearer sk-test-virtual-key", c.GetHeader("Authorization"))
+	assert.Empty(t, c.GetHeader("X-Api-Key"))
+}
+
+func TestApplyProxyVirtualKeyHeader_XAPIKeyClearsOtherAuthHeaders(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req, _ := http.NewRequest("POST", "/api/v1/llm-proxy/v1/messages", nil)
+	req.Header.Set("Authorization", "Bearer ak-test")
+	req.Header.Set("X-Api-Key", "ak-test")
+	c.Request = req
+	c.Set(llmProxyAuthHeaderStyleKey, llmProxyAuthHeaderXAPIKey)
+
+	applyProxyVirtualKeyHeader(c, "sk-test-virtual-key")
+
+	assert.Empty(t, c.GetHeader("Authorization"))
+	assert.Equal(t, "sk-test-virtual-key", c.GetHeader("X-Api-Key"))
+}
+
 // ── maskKey tests ─────────────────────────────────────────────────────────
 
 func TestMaskKey(t *testing.T) {
@@ -416,6 +521,7 @@ func TestProxyLLMRequest_Success(t *testing.T) {
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		auth := r.Header.Get("Authorization")
 		assert.True(t, strings.HasPrefix(auth, "Bearer sk-"))
+		assert.Empty(t, r.Header.Get("X-Api-Key"))
 		assert.Equal(t, "/v1/chat/completions", r.URL.Path)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{"choices":[{"message":{"content":"hello"}}]}`))
@@ -449,6 +555,97 @@ func TestProxyLLMRequest_Success(t *testing.T) {
 	resp, err := http.Post(server.URL+"/api/v1/llm-proxy/v1/chat/completions",
 		"application/json",
 		strings.NewReader(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`))
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestProxyLLMRequest_XAPIKeyStyleForwardsVirtualKey(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := mock_client.NewMockInterface(ctrl)
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Empty(t, r.Header.Get("Authorization"))
+		assert.Equal(t, "sk-test-virtual-key", r.Header.Get("X-Api-Key"))
+		assert.Equal(t, "/v1/messages", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"content":[{"type":"text","text":"hello"}]}`))
+	}))
+	defer backend.Close()
+
+	handler := newTestHandler(t, mockDB, backend)
+
+	binding := &dbclient.LLMGatewayUserBinding{
+		UserEmail:         "test@amd.com",
+		LiteLLMVirtualKey: "sk-test-virtual-key",
+		LiteLLMKeyHash:    "hash123",
+	}
+	mockDB.EXPECT().GetLLMBindingByEmail(gomock.Any(), "test@amd.com").Return(binding, nil)
+
+	router := gin.New()
+	router.POST("/api/v1/llm-proxy/*proxyPath", func(c *gin.Context) {
+		setUserContext(c, "user1", "test@amd.com")
+		c.Set(llmProxyAuthHeaderStyleKey, llmProxyAuthHeaderXAPIKey)
+		handler.ProxyLLMRequest(c)
+	})
+
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	req, _ := http.NewRequest("POST", server.URL+"/api/v1/llm-proxy/v1/messages",
+		strings.NewReader(`{"model":"claude-opus-4-6","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Api-Key", "ak-test")
+	resp, err := http.DefaultClient.Do(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestProxyLLMRequest_OOBDoubleHeaderMessagesForwardsXAPIKey(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := mock_client.NewMockInterface(ctrl)
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Empty(t, r.Header.Get("Authorization"))
+		assert.Equal(t, "sk-test-virtual-key", r.Header.Get("X-Api-Key"))
+		assert.Equal(t, "/v1/messages", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"content":[{"type":"text","text":"hello"}]}`))
+	}))
+	defer backend.Close()
+
+	handler := newTestHandler(t, mockDB, backend)
+
+	binding := &dbclient.LLMGatewayUserBinding{
+		UserEmail:         "test@amd.com",
+		LiteLLMVirtualKey: "sk-test-virtual-key",
+		LiteLLMKeyHash:    "hash123",
+	}
+	mockDB.EXPECT().GetLLMBindingByEmail(gomock.Any(), "test@amd.com").Return(binding, nil)
+
+	router := gin.New()
+	router.POST("/api/v1/llm-proxy/*proxyPath", func(c *gin.Context) {
+		normalizeProxyAPIKeyHeader(c)
+		setUserContext(c, "user1", "test@amd.com")
+		handler.ProxyLLMRequest(c)
+	})
+
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	req, _ := http.NewRequest("POST", server.URL+"/api/v1/llm-proxy/v1/messages",
+		strings.NewReader(`{"model":"claude-opus-4-6","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer ak-auth")
+	req.Header.Set("X-Api-Key", "ak-x-api-key")
+	resp, err := http.DefaultClient.Do(req)
 	assert.NoError(t, err)
 	defer resp.Body.Close()
 

--- a/SaFE/apiserver/pkg/handlers/llm-gateway/handler_test.go
+++ b/SaFE/apiserver/pkg/handlers/llm-gateway/handler_test.go
@@ -42,7 +42,7 @@ func newTestHandler(t *testing.T, mockDB *mock_client.MockInterface, litellmServ
 
 	return &Handler{
 		dbClient:      mockDB,
-		litellmClient: NewLiteLLMClient(litellmServer.URL, "sk-test-master-key", "test-team-id"),
+		litellmClient: NewLiteLLMClient(litellmServer.URL, "test_master_key", "test-team-id"),
 		crypto:        crypto,
 		proxy:         proxy,
 		// accessController is nil — getUserEmail will fallback to userName
@@ -59,12 +59,12 @@ func TestNormalizeProxyAPIKeyHeader_Authorization(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	req, _ := http.NewRequest("POST", "/api/v1/llm-proxy/v1/chat/completions", nil)
-	req.Header.Set("Authorization", "Bearer ak-auth")
+	req.Header.Set("Authorization", "Bearer api_auth")
 	c.Request = req
 
 	normalizeProxyAPIKeyHeader(c)
 
-	assert.Equal(t, "Bearer ak-auth", c.GetHeader("Authorization"))
+	assert.Equal(t, "Bearer api_auth", c.GetHeader("Authorization"))
 	style, exists := c.Get(llmProxyAuthHeaderStyleKey)
 	assert.True(t, exists)
 	assert.Equal(t, llmProxyAuthHeaderAuth, style)
@@ -74,12 +74,12 @@ func TestNormalizeProxyAPIKeyHeader_XAPIKey(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	req, _ := http.NewRequest("POST", "/api/v1/llm-proxy/v1/messages", nil)
-	req.Header.Set("X-Api-Key", "ak-test")
+	req.Header.Set("X-Api-Key", "api_test")
 	c.Request = req
 
 	normalizeProxyAPIKeyHeader(c)
 
-	assert.Equal(t, "Bearer ak-test", c.GetHeader("Authorization"))
+	assert.Equal(t, "Bearer api_test", c.GetHeader("Authorization"))
 	style, exists := c.Get(llmProxyAuthHeaderStyleKey)
 	assert.True(t, exists)
 	assert.Equal(t, llmProxyAuthHeaderXAPIKey, style)
@@ -89,13 +89,13 @@ func TestNormalizeProxyAPIKeyHeader_AuthorizationTakesPriority(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	req, _ := http.NewRequest("POST", "/api/v1/llm-proxy/v1/chat/completions", nil)
-	req.Header.Set("Authorization", "Bearer ak-auth")
-	req.Header.Set("X-Api-Key", "ak-x-api-key")
+	req.Header.Set("Authorization", "Bearer api_auth")
+	req.Header.Set("X-Api-Key", "api_x_key")
 	c.Request = req
 
 	normalizeProxyAPIKeyHeader(c)
 
-	assert.Equal(t, "Bearer ak-auth", c.GetHeader("Authorization"))
+	assert.Equal(t, "Bearer api_auth", c.GetHeader("Authorization"))
 	style, exists := c.Get(llmProxyAuthHeaderStyleKey)
 	assert.True(t, exists)
 	assert.Equal(t, llmProxyAuthHeaderAuth, style)
@@ -105,13 +105,13 @@ func TestNormalizeProxyAPIKeyHeader_MessagesPrefersXAPIKey(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	req, _ := http.NewRequest("POST", "/api/v1/llm-proxy/v1/messages", nil)
-	req.Header.Set("Authorization", "Bearer ak-auth")
-	req.Header.Set("X-Api-Key", "ak-x-api-key")
+	req.Header.Set("Authorization", "Bearer api_auth")
+	req.Header.Set("X-Api-Key", "api_x_key")
 	c.Request = req
 
 	normalizeProxyAPIKeyHeader(c)
 
-	assert.Equal(t, "Bearer ak-x-api-key", c.GetHeader("Authorization"))
+	assert.Equal(t, "Bearer api_x_key", c.GetHeader("Authorization"))
 	style, exists := c.Get(llmProxyAuthHeaderStyleKey)
 	assert.True(t, exists)
 	assert.Equal(t, llmProxyAuthHeaderXAPIKey, style)
@@ -134,14 +134,14 @@ func TestApplyProxyVirtualKeyHeader_AuthorizationClearsOtherAuthHeaders(t *testi
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	req, _ := http.NewRequest("POST", "/api/v1/llm-proxy/v1/chat/completions", nil)
-	req.Header.Set("Authorization", "Bearer ak-auth")
-	req.Header.Set("X-Api-Key", "ak-x-api-key")
+	req.Header.Set("Authorization", "Bearer api_auth")
+	req.Header.Set("X-Api-Key", "api_x_key")
 	c.Request = req
 	c.Set(llmProxyAuthHeaderStyleKey, llmProxyAuthHeaderAuth)
 
-	applyProxyVirtualKeyHeader(c, "sk-test-virtual-key")
+	applyProxyVirtualKeyHeader(c, "virtual_key_test")
 
-	assert.Equal(t, "Bearer sk-test-virtual-key", c.GetHeader("Authorization"))
+	assert.Equal(t, "Bearer virtual_key_test", c.GetHeader("Authorization"))
 	assert.Empty(t, c.GetHeader("X-Api-Key"))
 }
 
@@ -149,15 +149,15 @@ func TestApplyProxyVirtualKeyHeader_XAPIKeyClearsOtherAuthHeaders(t *testing.T) 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	req, _ := http.NewRequest("POST", "/api/v1/llm-proxy/v1/messages", nil)
-	req.Header.Set("Authorization", "Bearer ak-test")
-	req.Header.Set("X-Api-Key", "ak-test")
+	req.Header.Set("Authorization", "Bearer api_test")
+	req.Header.Set("X-Api-Key", "api_test")
 	c.Request = req
 	c.Set(llmProxyAuthHeaderStyleKey, llmProxyAuthHeaderXAPIKey)
 
-	applyProxyVirtualKeyHeader(c, "sk-test-virtual-key")
+	applyProxyVirtualKeyHeader(c, "virtual_key_test")
 
 	assert.Empty(t, c.GetHeader("Authorization"))
-	assert.Equal(t, "sk-test-virtual-key", c.GetHeader("X-Api-Key"))
+	assert.Equal(t, "virtual_key_test", c.GetHeader("X-Api-Key"))
 }
 
 // ── maskKey tests ─────────────────────────────────────────────────────────
@@ -171,7 +171,7 @@ func TestMaskKey(t *testing.T) {
 		{"short key", "abc", "ab****"},
 		{"8 char key", "abcdefgh", "ab****"},
 		{"normal key", "abcdefghijklmnop", "abcd********mnop"},
-		{"long key", "sk-1234567890abcdefghijklmnop", "sk-1********mnop"},
+		{"long key", "safe1234567890abcdefghijklmnop", "safe********mnop"},
 	}
 
 	for _, tt := range tests {
@@ -272,7 +272,7 @@ func TestCreateBinding_Success(t *testing.T) {
 		case r.URL.Path == "/key/generate":
 			w.WriteHeader(http.StatusOK)
 			json.NewEncoder(w).Encode(CreateKeyResponse{
-				Key:     "sk-test-virtual-key",
+				Key:     "virtual_key_test",
 				KeyName: "sk-...key",
 				TokenID: "abc123hash",
 			})
@@ -301,7 +301,7 @@ func TestCreateBinding_Success(t *testing.T) {
 	var resp BindingResponse
 	json.Unmarshal(w.Body.Bytes(), &resp)
 	assert.True(t, resp.HasAPIMKey)
-	assert.Equal(t, "sk-test-virtual-key", resp.VirtualKey)
+	assert.Equal(t, "virtual_key_test", resp.VirtualKey)
 	assert.Equal(t, "test@amd.com", resp.KeyAlias)
 }
 
@@ -372,7 +372,7 @@ func TestCreateBinding_LiteLLMUserAlreadyExists(t *testing.T) {
 		case r.URL.Path == "/key/generate":
 			w.WriteHeader(http.StatusOK)
 			json.NewEncoder(w).Encode(CreateKeyResponse{
-				Key:     "sk-new-key",
+				Key:     "new_virtual_key",
 				TokenID: "newhash123",
 			})
 		}
@@ -520,7 +520,7 @@ func TestProxyLLMRequest_Success(t *testing.T) {
 
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		auth := r.Header.Get("Authorization")
-		assert.True(t, strings.HasPrefix(auth, "Bearer sk-"))
+		assert.Equal(t, "Bearer virtual_key_test", auth)
 		assert.Empty(t, r.Header.Get("X-Api-Key"))
 		assert.Equal(t, "/v1/chat/completions", r.URL.Path)
 		w.WriteHeader(http.StatusOK)
@@ -530,7 +530,7 @@ func TestProxyLLMRequest_Success(t *testing.T) {
 
 	handler := newTestHandler(t, mockDB, backend)
 
-	vkey := "sk-test-virtual-key"
+	vkey := "virtual_key_test"
 	if handler.crypto != nil {
 		encrypted, _ := handler.crypto.Encrypt([]byte(vkey))
 		vkey = encrypted
@@ -569,7 +569,7 @@ func TestProxyLLMRequest_XAPIKeyStyleForwardsVirtualKey(t *testing.T) {
 
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Empty(t, r.Header.Get("Authorization"))
-		assert.Equal(t, "sk-test-virtual-key", r.Header.Get("X-Api-Key"))
+		assert.Equal(t, "virtual_key_test", r.Header.Get("X-Api-Key"))
 		assert.Equal(t, "/v1/messages", r.URL.Path)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{"content":[{"type":"text","text":"hello"}]}`))
@@ -580,7 +580,7 @@ func TestProxyLLMRequest_XAPIKeyStyleForwardsVirtualKey(t *testing.T) {
 
 	binding := &dbclient.LLMGatewayUserBinding{
 		UserEmail:         "test@amd.com",
-		LiteLLMVirtualKey: "sk-test-virtual-key",
+		LiteLLMVirtualKey: "virtual_key_test",
 		LiteLLMKeyHash:    "hash123",
 	}
 	mockDB.EXPECT().GetLLMBindingByEmail(gomock.Any(), "test@amd.com").Return(binding, nil)
@@ -598,7 +598,7 @@ func TestProxyLLMRequest_XAPIKeyStyleForwardsVirtualKey(t *testing.T) {
 	req, _ := http.NewRequest("POST", server.URL+"/api/v1/llm-proxy/v1/messages",
 		strings.NewReader(`{"model":"claude-opus-4-6","messages":[{"role":"user","content":"hi"}]}`))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Api-Key", "ak-test")
+	req.Header.Set("X-Api-Key", "api_test")
 	resp, err := http.DefaultClient.Do(req)
 	assert.NoError(t, err)
 	defer resp.Body.Close()
@@ -614,7 +614,7 @@ func TestProxyLLMRequest_OOBDoubleHeaderMessagesForwardsXAPIKey(t *testing.T) {
 
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Empty(t, r.Header.Get("Authorization"))
-		assert.Equal(t, "sk-test-virtual-key", r.Header.Get("X-Api-Key"))
+		assert.Equal(t, "virtual_key_test", r.Header.Get("X-Api-Key"))
 		assert.Equal(t, "/v1/messages", r.URL.Path)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{"content":[{"type":"text","text":"hello"}]}`))
@@ -625,7 +625,7 @@ func TestProxyLLMRequest_OOBDoubleHeaderMessagesForwardsXAPIKey(t *testing.T) {
 
 	binding := &dbclient.LLMGatewayUserBinding{
 		UserEmail:         "test@amd.com",
-		LiteLLMVirtualKey: "sk-test-virtual-key",
+		LiteLLMVirtualKey: "virtual_key_test",
 		LiteLLMKeyHash:    "hash123",
 	}
 	mockDB.EXPECT().GetLLMBindingByEmail(gomock.Any(), "test@amd.com").Return(binding, nil)
@@ -643,8 +643,8 @@ func TestProxyLLMRequest_OOBDoubleHeaderMessagesForwardsXAPIKey(t *testing.T) {
 	req, _ := http.NewRequest("POST", server.URL+"/api/v1/llm-proxy/v1/messages",
 		strings.NewReader(`{"model":"claude-opus-4-6","messages":[{"role":"user","content":"hi"}]}`))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer ak-auth")
-	req.Header.Set("X-Api-Key", "ak-x-api-key")
+	req.Header.Set("Authorization", "Bearer api_auth")
+	req.Header.Set("X-Api-Key", "api_x_key")
 	resp, err := http.DefaultClient.Do(req)
 	assert.NoError(t, err)
 	defer resp.Body.Close()
@@ -898,7 +898,7 @@ func TestCreateUser_AutoCreateKeyFalse(t *testing.T) {
 	}))
 	defer litellm.Close()
 
-	client := NewLiteLLMClient(litellm.URL, "sk-master", "team-id")
+	client := NewLiteLLMClient(litellm.URL, "master_key", "team-id")
 	err := client.CreateUser(context.Background(), "test@amd.com")
 	assert.NoError(t, err)
 	assert.False(t, receivedBody.AutoCreateKey)
@@ -912,7 +912,7 @@ func TestCreateUser_ConflictIsOK(t *testing.T) {
 	}))
 	defer litellm.Close()
 
-	client := NewLiteLLMClient(litellm.URL, "sk-master", "team-id")
+	client := NewLiteLLMClient(litellm.URL, "master_key", "team-id")
 	err := client.CreateUser(context.Background(), "test@amd.com")
 	assert.NoError(t, err)
 }
@@ -934,7 +934,7 @@ func TestDeleteKey_FallbackToAlias(t *testing.T) {
 	}))
 	defer litellm.Close()
 
-	client := NewLiteLLMClient(litellm.URL, "sk-master", "team-id")
+	client := NewLiteLLMClient(litellm.URL, "master_key", "team-id")
 	err := client.DeleteKey(context.Background(), "wrong-hash-123456789", "test@amd.com")
 	assert.NoError(t, err)
 	assert.Equal(t, 2, callCount)

--- a/SaFE/apiserver/pkg/handlers/llm-gateway/proxy.go
+++ b/SaFE/apiserver/pkg/handlers/llm-gateway/proxy.go
@@ -99,7 +99,41 @@ func (h *Handler) ProxyLLMRequest(c *gin.Context) {
 		return
 	}
 
-	c.Request.Header.Set("Authorization", "Bearer "+virtualKey)
+	applyProxyVirtualKeyHeader(c, virtualKey)
 
 	h.proxy.ServeHTTP(c.Writer, c.Request)
+}
+
+func applyProxyVirtualKeyHeader(c *gin.Context, virtualKey string) {
+	style, _ := c.Get(llmProxyAuthHeaderStyleKey)
+	mapping := proxyAuthHeaderMappingByStyle(style)
+	if mapping.style == "" {
+		mapping = llmProxyAuthHeaderMappings[0]
+	}
+
+	clearProxyAuthHeaders(c)
+	if mapping.style == llmProxyAuthHeaderAuth {
+		c.Request.Header.Set(mapping.header, "Bearer "+virtualKey)
+		return
+	}
+	c.Request.Header.Set(mapping.header, virtualKey)
+}
+
+func proxyAuthHeaderMappingByStyle(style any) llmProxyAuthHeaderMapping {
+	styleString, ok := style.(string)
+	if !ok {
+		return llmProxyAuthHeaderMapping{}
+	}
+	for _, mapping := range llmProxyAuthHeaderMappings {
+		if mapping.style == styleString {
+			return mapping
+		}
+	}
+	return llmProxyAuthHeaderMapping{}
+}
+
+func clearProxyAuthHeaders(c *gin.Context) {
+	for _, mapping := range llmProxyAuthHeaderMappings {
+		c.Request.Header.Del(mapping.header)
+	}
 }


### PR DESCRIPTION
Preserve provider-specific auth header shapes so SaFE can authenticate ak keys and forward sk keys for both OpenAI and Anthropic proxy requests.