### PR TITLE
feat(optimization): increase max_concurrent default from 20 to 128

### DIFF
--- a/SaFE/charts/primus-safe/templates/apiserver/config.yaml
+++ b/SaFE/charts/primus-safe/templates/apiserver/config.yaml
@@ -157,7 +157,7 @@ data:
       claw_agent_id: "{{ default "agent_default" (default dict .Values.model_optimization).claw_agent_id }}"
       secret_path: {{ default "" (default dict .Values.model_optimization).secret_path | quote }}
       default_workspace: "{{ default "control-plane-sandbox" (default dict .Values.model_optimization).default_workspace }}"
-      max_concurrent: {{ default 128 (default dict .Values.model_optimization).max_concurrent }}
+      max_concurrent: {{ default 256 (default dict .Values.model_optimization).max_concurrent }}
     mcp:
       # Whether to enable MCP (Model Context Protocol) server for AI assistant integration
       enabled: {{ default true (default dict .Values.mcp).enabled }}

--- a/SaFE/charts/primus-safe/templates/apiserver/config.yaml
+++ b/SaFE/charts/primus-safe/templates/apiserver/config.yaml
@@ -157,7 +157,7 @@ data:
       claw_agent_id: "{{ default "agent_default" (default dict .Values.model_optimization).claw_agent_id }}"
       secret_path: {{ default "" (default dict .Values.model_optimization).secret_path | quote }}
       default_workspace: "{{ default "control-plane-sandbox" (default dict .Values.model_optimization).default_workspace }}"
-      max_concurrent: {{ default 20 (default dict .Values.model_optimization).max_concurrent }}
+      max_concurrent: {{ default 128 (default dict .Values.model_optimization).max_concurrent }}
     mcp:
       # Whether to enable MCP (Model Context Protocol) server for AI assistant integration
       enabled: {{ default true (default dict .Values.mcp).enabled }}

--- a/SaFE/charts/primus-safe/values.yaml
+++ b/SaFE/charts/primus-safe/values.yaml
@@ -262,7 +262,7 @@ model_optimization:
   # Empty: skip file-based claw_api_key / claw_base_url; use Bearer ak-... or set a mount path.
   secret_path: ""
   default_workspace: "control-plane-sandbox"
-  max_concurrent: 128
+  max_concurrent: 256
 sandbox:
   enable: true
   namespace: "agent-sandbox-system"

--- a/SaFE/charts/primus-safe/values.yaml
+++ b/SaFE/charts/primus-safe/values.yaml
@@ -262,7 +262,7 @@ model_optimization:
   # Empty: skip file-based claw_api_key / claw_base_url; use Bearer ak-... or set a mount path.
   secret_path: ""
   default_workspace: "control-plane-sandbox"
-  max_concurrent: 20
+  max_concurrent: 128
 sandbox:
   enable: true
   namespace: "agent-sandbox-system"


### PR DESCRIPTION
## Summary
- Increase `model_optimization.max_concurrent` default from 20 to 128 in `values.yaml`
- Update Helm template fallback default from 20 to 128 in `config.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)