### PR TITLE
feat(optimization): support PromptPrefix and PromptSuffix on CreateTa…

### DIFF
--- a/SaFE/apiserver/pkg/handlers/optimization/handler.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/handler.go
@@ -876,6 +876,8 @@ func promptConfigFromRequest(req *CreateTaskRequest, m *ResolvedModel, workspace
 		TargetGpu:      req.TargetGpu,
 		BaselineCSV:    req.BaselineCSV,
 		BaselineCount:  req.BaselineCount,
+		PromptPrefix:   req.PromptPrefix,
+		PromptSuffix:   req.PromptSuffix,
 	}
 }
 

--- a/SaFE/apiserver/pkg/handlers/optimization/prompt_builder.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/prompt_builder.go
@@ -73,6 +73,15 @@ type PromptConfig struct {
 	TargetGpu      string
 	BaselineCSV    string
 	BaselineCount  int
+
+	// PromptPrefix / PromptSuffix are optional free-form text snippets the
+	// caller can inject before / after the generated prompt body. They are
+	// emitted verbatim with a single blank line of separation. Used by the
+	// Hyperloom CI batch job to point the skill at an alternate SKILL.md
+	// (e.g. /wekafs/HyperloomV2/inference_optimizer/SKILL.md) before the
+	// pipeline starts.
+	PromptPrefix string
+	PromptSuffix string
 }
 
 // NormalizePromptConfig fills zero-valued fields with sensible defaults.
@@ -250,7 +259,22 @@ func BuildHyperloomPrompt(cfg PromptConfig) string {
 		))
 	}
 
-	return strings.Join(lines, "\n")
+	body := strings.Join(lines, "\n")
+
+	// Splice in the optional prefix / suffix with one blank line of padding
+	// on each side so the generated prompt still parses cleanly. We use
+	// TrimRight to avoid emitting trailing blank lines when only one side is
+	// set.
+	prefix := strings.TrimSpace(cfg.PromptPrefix)
+	suffix := strings.TrimSpace(cfg.PromptSuffix)
+	if prefix != "" {
+		body = prefix + "\n\n" + body
+	}
+	if suffix != "" {
+		body = body + "\n\n" + suffix
+	}
+
+	return body
 }
 
 // firstNonEmpty returns the first non-empty string in the argument list, or an

--- a/SaFE/apiserver/pkg/handlers/optimization/types.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/types.go
@@ -86,6 +86,17 @@ type CreateTaskRequest struct {
 	TargetGpu     string `json:"targetGpu,omitempty"`
 	BaselineCSV   string `json:"baselineCSV,omitempty"`
 	BaselineCount int    `json:"baselineCount,omitempty"`
+
+	// Optional free-form text prepended / appended to the auto-generated
+	// prompt produced by BuildHyperloomPrompt. The Hyperloom CI batch job
+	// uses PromptPrefix to point the skill at an alternate SKILL.md
+	// (e.g. /wekafs/HyperloomV2/inference_optimizer/SKILL.md) and to chdir
+	// into the per-batch working directory before the main pipeline kicks
+	// off. PromptSuffix is symmetric for callers that need to append
+	// reminders. Both are empty by default and have no effect on
+	// Hyperloom-Web-submitted tasks.
+	PromptPrefix string `json:"promptPrefix,omitempty"`
+	PromptSuffix string `json:"promptSuffix,omitempty"`
 }
 
 // TaskInfo is the response shape for a single task (list item or detail).


### PR DESCRIPTION
…skRequest

Add two optional fields to the optimization create-task API that are prepended and appended verbatim to the prompt produced by BuildHyperloomPrompt:

  promptPrefix string  - emitted before the auto-generated header line
  promptSuffix string  - emitted after the InferenceX baseline section

Existing callers (Hyperloom-Web, prior optimize_submit runs) leave both empty and produce the same prompt as before, so the change is fully backward compatible.

The Hyperloom CI batch uses this to point the agent at an alternate SKILL.md living under /wekafs/HyperloomV2/ without baking a new sandbox image. The request field is wired through PromptConfig into BuildHyperloomPrompt; TrimSpace plus a blank-line separator keeps the combined body parsing cleanly when only one side is set.