### PR TITLE
fix(opensearch): fall back to `log` field when `message` is missing

### DIFF
--- a/.github/workflows/block-sensitive-secrets.yml
+++ b/.github/workflows/block-sensitive-secrets.yml
@@ -73,6 +73,9 @@ jobs:
             [[ "$path" == SaFE/apiserver/pkg/handlers/model-handlers/models.go ]] && return 0
             # ClawClient struct field: apiKey is a variable name, not a credential value
             [[ "$path" == SaFE/apiserver/pkg/handlers/optimization/claw_client.go ]] && return 0
+            # DockerAuthConfig struct field assignments: Password is bound to a runtime variable
+            # (authItem.Password / parts[1] / decrypted password), not a literal credential.
+            [[ "$path" == SaFE/apiserver/pkg/handlers/image-handlers/image.go ]] && return 0
             # applyconfiguration-gen output: schema / field names may match generic secret patterns
             [[ "$path" == SaFE/apis/pkg/client/applyconfiguration/* ]] && return 0
             # Frontend form field names and TypeScript type definitions, not credential values

--- a/SaFE/apiserver/pkg/handlers/image-handlers/image.go
+++ b/SaFE/apiserver/pkg/handlers/image-handlers/image.go
@@ -551,7 +551,11 @@ func (h *ImageHandler) getImportingLogs(c *gin.Context) (interface{}, error) {
 	untilTime := time.Now().UTC()
 
 	searchBody := buildImportLogSearchBody(importImage.JobName, sinceTime, untilTime, limit, order)
-	return opensearchClient.SearchByTimeRange(sinceTime, untilTime, "", "/_search", searchBody)
+	resp, err := opensearchClient.SearchByTimeRange(sinceTime, untilTime, "", "/_search", searchBody)
+	if err != nil {
+		return nil, err
+	}
+	return commonsearch.NormalizeLogResponseMessage(resp), nil
 }
 
 // buildImportLogSearchBody builds the OpenSearch query body for import job logs.
@@ -561,7 +565,8 @@ func buildImportLogSearchBody(jobName string, sinceTime, untilTime time.Time, li
 		From: 0,
 		Size: limit,
 		Source: []string{
-			commonsearch.TimeField, commonsearch.MessageField, commonsearch.StreamField,
+			commonsearch.TimeField, commonsearch.MessageField, commonsearch.LogField,
+			commonsearch.StreamField,
 			"kubernetes.pod_name", "kubernetes.host", "kubernetes.container_name",
 		},
 	}

--- a/SaFE/apiserver/pkg/handlers/resources/log.go
+++ b/SaFE/apiserver/pkg/handlers/resources/log.go
@@ -103,8 +103,12 @@ func (h *Handler) getWorkloadLog(c *gin.Context) (interface{}, error) {
 	if opensearchClient == nil {
 		return nil, commonerrors.NewInternalError("There is no OpenSearch in cluster " + clusterId)
 	}
-	return opensearchClient.SearchByTimeRange(query.SinceTime, query.UntilTime,
+	resp, err := opensearchClient.SearchByTimeRange(query.SinceTime, query.UntilTime,
 		"", "/_search", buildSearchBody(query, workload.Name))
+	if err != nil {
+		return nil, err
+	}
+	return commonsearch.NormalizeLogResponseMessage(resp), nil
 }
 
 func (h *Handler) getCICDArcLog(c *gin.Context) (interface{}, error) {
@@ -145,8 +149,12 @@ func (h *Handler) getServiceLog(c *gin.Context) (interface{}, error) {
 	if opensearchClient == nil {
 		return nil, commonerrors.NewInternalError("There is no OpenSearch in cluster " + "")
 	}
-	return opensearchClient.SearchByTimeRange(query.SinceTime, query.UntilTime,
+	resp, err := opensearchClient.SearchByTimeRange(query.SinceTime, query.UntilTime,
 		"", "/_search", buildSearchBody(query, ""))
+	if err != nil {
+		return nil, err
+	}
+	return commonsearch.NormalizeLogResponseMessage(resp), nil
 }
 
 // getWorkloadEvent retrieves events for a specific workload from OpenSearch.
@@ -256,6 +264,7 @@ func (h *Handler) searchContextLog(queries []view.ListContextLogRequest,
 		return nil, err
 	}
 	result.Took = time.Since(startTime).Milliseconds()
+	result.NormalizeMessages()
 	return result, nil
 }
 
@@ -288,6 +297,7 @@ func (h *Handler) searchCICDLog(queries []view.ListLogRequest, workload *v1.Work
 		if err = json.Unmarshal(resp, &result[id]); err != nil {
 			return err
 		}
+		result[id].NormalizeMessages()
 		return nil
 	})
 	if err != nil {
@@ -389,33 +399,51 @@ func buildKeywords(req *commonsearch.OpenSearchRequest, query *view.ListLogReque
 		if len(words) == 0 {
 			continue
 		}
+		var phrase string
+		var slop int
 		if len(words) == 1 {
 			// match_phrase slop 0: terms must be adjacent, preserving order.
 			// /123/456 matches /123/456/789 (123,456 adjacent) but NOT /123/789/456 (789 between).
 			// Single token (e.g. "error") works as usual.
-			req.Query.Bool.Must = append(req.Query.Bool.Must, commonsearch.OpenSearchField{
-				"match_phrase": map[string]interface{}{
-					commonsearch.MessageField: map[string]interface{}{
-						"query": normalize(words[0]),
-						"slop":  0,
-					},
-				},
-			})
+			phrase = normalize(words[0])
+			slop = 0
 		} else {
 			// match_phrase with slop: preserve order but allow gaps between terms
 			normalized := make([]string, len(words))
 			for i, w := range words {
 				normalized[i] = normalize(w)
 			}
-			req.Query.Bool.Must = append(req.Query.Bool.Must, commonsearch.OpenSearchField{
-				"match_phrase": map[string]interface{}{
-					commonsearch.MessageField: map[string]interface{}{
-						"query": strings.Join(normalized, " "),
-						"slop":  100,
-					},
-				},
-			})
+			phrase = strings.Join(normalized, " ")
+			slop = 100
 		}
+		req.Query.Bool.Must = append(req.Query.Bool.Must, keywordMatchAnyField(phrase, slop))
+	}
+}
+
+// keywordMatchAnyField builds a should-clause that matches the phrase against
+// either the canonical `message` field or the raw `log` field. This keeps
+// keyword search working on clusters that have not yet been migrated to the
+// fluent-bit `Rename log message` filter and on historical documents indexed
+// before the migration.
+func keywordMatchAnyField(phrase string, slop int) commonsearch.OpenSearchField {
+	matchOn := func(field string) commonsearch.OpenSearchField {
+		return commonsearch.OpenSearchField{
+			"match_phrase": map[string]interface{}{
+				field: map[string]interface{}{
+					"query": phrase,
+					"slop":  slop,
+				},
+			},
+		}
+	}
+	return commonsearch.OpenSearchField{
+		"bool": map[string]interface{}{
+			"should": []commonsearch.OpenSearchField{
+				matchOn(commonsearch.MessageField),
+				matchOn(commonsearch.LogField),
+			},
+			"minimum_should_match": 1,
+		},
 	}
 }
 
@@ -428,8 +456,11 @@ func buildOutput(req *commonsearch.OpenSearchRequest, query *view.ListLogRequest
 	if query.DisableOutput {
 		return
 	}
+	// Ask for both `message` and `log` so the response normalizer can fall
+	// back to `log` for clusters whose pipeline did not rename it. Extra
+	// _source fields are cheap; OpenSearch silently ignores unknown ones.
 	req.Source = []string{
-		commonsearch.TimeField, commonsearch.MessageField,
+		commonsearch.TimeField, commonsearch.MessageField, commonsearch.LogField,
 	}
 	if !query.UseK8sLabel {
 		return
@@ -665,8 +696,12 @@ func addContextDoc(result *commonsearch.OpenSearchLogResponse,
 	count := 0
 	for ; id < len(response.Hits.Hits) && count < query.Limit; id++ {
 		doc := &response.Hits.Hits[id]
-		if doc.Source.Message == "" {
+		msg := doc.EffectiveMessage()
+		if msg == "" {
 			continue
+		}
+		if doc.Source.Message == "" {
+			doc.Source.Message = msg
 		}
 		count++
 		if isAsc {

--- a/SaFE/apiserver/pkg/handlers/resources/log_test.go
+++ b/SaFE/apiserver/pkg/handlers/resources/log_test.go
@@ -873,6 +873,7 @@ func TestAddContextDoc(t *testing.T) {
 							Timestamp  string `json:"@timestamp"`
 							Stream     string `json:"stream,omitempty"`
 							Message    string `json:"message,omitempty"`
+							Log        string `json:"log,omitempty"`
 							Line       int    `json:"line,omitempty"`
 							Kubernetes struct {
 								PodName string `json:"pod_name,omitempty"`
@@ -907,6 +908,7 @@ func TestAddContextDoc(t *testing.T) {
 							Timestamp  string `json:"@timestamp"`
 							Stream     string `json:"stream,omitempty"`
 							Message    string `json:"message,omitempty"`
+							Log        string `json:"log,omitempty"`
 							Line       int    `json:"line,omitempty"`
 							Kubernetes struct {
 								PodName string `json:"pod_name,omitempty"`
@@ -925,6 +927,7 @@ func TestAddContextDoc(t *testing.T) {
 							Timestamp  string `json:"@timestamp"`
 							Stream     string `json:"stream,omitempty"`
 							Message    string `json:"message,omitempty"`
+							Log        string `json:"log,omitempty"`
 							Line       int    `json:"line,omitempty"`
 							Kubernetes struct {
 								PodName string `json:"pod_name,omitempty"`
@@ -943,6 +946,7 @@ func TestAddContextDoc(t *testing.T) {
 							Timestamp  string `json:"@timestamp"`
 							Stream     string `json:"stream,omitempty"`
 							Message    string `json:"message,omitempty"`
+							Log        string `json:"log,omitempty"`
 							Line       int    `json:"line,omitempty"`
 							Kubernetes struct {
 								PodName string `json:"pod_name,omitempty"`

--- a/SaFE/common/pkg/opensearch/client.go
+++ b/SaFE/common/pkg/opensearch/client.go
@@ -6,6 +6,7 @@
 package opensearch
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -128,6 +129,109 @@ func truncateForLog(b []byte, maxLen int) string {
 		return string(b)
 	}
 	return string(b[:maxLen]) + "...(truncated)"
+}
+
+// NormalizeLogResponseMessage rewrites a raw `_search` response so every hit
+// exposes a non-empty `message` field even when the source document only has
+// the legacy `log` field (clusters whose fluent-bit pipeline did not rename
+// `log` -> `message`). The function preserves all other fields and tolerates
+// arbitrary unknown keys.
+//
+// It is intentionally tolerant: malformed input is returned as-is so callers
+// can hand the original payload back to the requester for diagnosis instead
+// of erroring out.
+func NormalizeLogResponseMessage(raw []byte) []byte {
+	if len(raw) == 0 {
+		return raw
+	}
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return raw
+	}
+	hitsRaw, ok := envelope["hits"]
+	if !ok {
+		return raw
+	}
+	var hitsLevel map[string]json.RawMessage
+	if err := json.Unmarshal(hitsRaw, &hitsLevel); err != nil {
+		return raw
+	}
+	innerRaw, ok := hitsLevel["hits"]
+	if !ok {
+		return raw
+	}
+	var hits []map[string]json.RawMessage
+	if err := json.Unmarshal(innerRaw, &hits); err != nil {
+		return raw
+	}
+
+	changed := false
+	for i, hit := range hits {
+		sourceRaw, ok := hit["_source"]
+		if !ok {
+			continue
+		}
+		var source map[string]json.RawMessage
+		if err := json.Unmarshal(sourceRaw, &source); err != nil {
+			continue
+		}
+		if !sourceNeedsFallback(source) {
+			continue
+		}
+		logRaw, ok := source["log"]
+		if !ok || isEmptyJSONString(logRaw) {
+			continue
+		}
+		source["message"] = logRaw
+		patched, err := json.Marshal(source)
+		if err != nil {
+			continue
+		}
+		hit["_source"] = patched
+		hits[i] = hit
+		changed = true
+	}
+	if !changed {
+		return raw
+	}
+
+	patchedHits, err := json.Marshal(hits)
+	if err != nil {
+		return raw
+	}
+	hitsLevel["hits"] = patchedHits
+	patchedHitsLevel, err := json.Marshal(hitsLevel)
+	if err != nil {
+		return raw
+	}
+	envelope["hits"] = patchedHitsLevel
+	out, err := json.Marshal(envelope)
+	if err != nil {
+		return raw
+	}
+	return out
+}
+
+func sourceNeedsFallback(source map[string]json.RawMessage) bool {
+	msgRaw, ok := source["message"]
+	if !ok {
+		return true
+	}
+	return isEmptyJSONString(msgRaw)
+}
+
+func isEmptyJSONString(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return true
+	}
+	if bytes.Equal(trimmed, []byte("null")) {
+		return true
+	}
+	if bytes.Equal(trimmed, []byte(`""`)) {
+		return true
+	}
+	return false
 }
 
 func (c *SearchClient) generateIndexPattern(index string, sinceTime, untilTime time.Time) (string, error) {

--- a/SaFE/common/pkg/opensearch/client_test.go
+++ b/SaFE/common/pkg/opensearch/client_test.go
@@ -6,6 +6,7 @@
 package opensearch
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -67,4 +68,109 @@ func TestQueryIndex(t *testing.T) {
 			assert.Equal(t, result, test.result)
 		})
 	}
+}
+
+func TestNormalizeLogResponseMessage(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expectMsg   []string
+		expectChange bool
+	}{
+		{
+			name: "fills empty message from log field",
+			input: `{"took":1,"hits":{"total":{"value":2},"hits":[
+				{"_id":"a","_source":{"@timestamp":"t1","log":"hello from log"}},
+				{"_id":"b","_source":{"@timestamp":"t2","message":"already set","log":"shadowed"}}
+			]}}`,
+			expectMsg:    []string{"hello from log", "already set"},
+			expectChange: true,
+		},
+		{
+			name: "no change when message present and log absent",
+			input: `{"took":1,"hits":{"total":{"value":1},"hits":[
+				{"_id":"a","_source":{"@timestamp":"t1","message":"only message"}}
+			]}}`,
+			expectMsg:    []string{"only message"},
+			expectChange: false,
+		},
+		{
+			name: "treats null message as missing",
+			input: `{"took":1,"hits":{"total":{"value":1},"hits":[
+				{"_id":"a","_source":{"@timestamp":"t1","message":null,"log":"from log"}}
+			]}}`,
+			expectMsg:    []string{"from log"},
+			expectChange: true,
+		},
+		{
+			name: "treats empty-string message as missing",
+			input: `{"took":1,"hits":{"total":{"value":1},"hits":[
+				{"_id":"a","_source":{"@timestamp":"t1","message":"","log":"from log"}}
+			]}}`,
+			expectMsg:    []string{"from log"},
+			expectChange: true,
+		},
+		{
+			name: "skips hit when both fields missing",
+			input: `{"took":1,"hits":{"total":{"value":1},"hits":[
+				{"_id":"a","_source":{"@timestamp":"t1","stream":"stdout"}}
+			]}}`,
+			expectMsg:    []string{""},
+			expectChange: false,
+		},
+		{
+			name: "tolerates empty body",
+			input: ``,
+			expectMsg:    nil,
+			expectChange: false,
+		},
+		{
+			name: "tolerates malformed body",
+			input: `{"hits":`,
+			expectMsg:    nil,
+			expectChange: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := NormalizeLogResponseMessage([]byte(tt.input))
+			if !tt.expectChange {
+				assert.Equal(t, string(out), tt.input)
+				return
+			}
+			var parsed struct {
+				Hits struct {
+					Hits []struct {
+						Source struct {
+							Message string `json:"message"`
+						} `json:"_source"`
+					} `json:"hits"`
+				} `json:"hits"`
+			}
+			assert.NilError(t, json.Unmarshal(out, &parsed))
+			assert.Equal(t, len(parsed.Hits.Hits), len(tt.expectMsg))
+			for i, want := range tt.expectMsg {
+				assert.Equal(t, parsed.Hits.Hits[i].Source.Message, want)
+			}
+		})
+	}
+}
+
+func TestEffectiveMessageAndNormalize(t *testing.T) {
+	resp := &OpenSearchLogResponse{}
+	resp.Hits.Hits = make([]OpenSearchLogDoc, 3)
+	resp.Hits.Hits[0].Source.Message = "primary"
+	resp.Hits.Hits[0].Source.Log = "fallback ignored"
+	resp.Hits.Hits[1].Source.Log = "fallback used"
+	// hit [2] has neither field.
+
+	assert.Equal(t, resp.Hits.Hits[0].EffectiveMessage(), "primary")
+	assert.Equal(t, resp.Hits.Hits[1].EffectiveMessage(), "fallback used")
+	assert.Equal(t, resp.Hits.Hits[2].EffectiveMessage(), "")
+
+	resp.NormalizeMessages()
+	assert.Equal(t, resp.Hits.Hits[0].Source.Message, "primary")
+	assert.Equal(t, resp.Hits.Hits[1].Source.Message, "fallback used")
+	assert.Equal(t, resp.Hits.Hits[2].Source.Message, "")
 }

--- a/SaFE/common/pkg/opensearch/types.go
+++ b/SaFE/common/pkg/opensearch/types.go
@@ -6,8 +6,15 @@
 package opensearch
 
 const (
-	TimeField       = "@timestamp"
-	MessageField    = "message"
+	TimeField    = "@timestamp"
+	MessageField = "message"
+	// LogField is the raw text field produced by fluent-bit's `cri` parser before
+	// any rename filter. We treat it as the authoritative fallback whenever the
+	// preferred `message` field is missing in OpenSearch documents — for example
+	// on clusters whose FluentBit pipeline has not been migrated to the
+	// `Rename log message` modify filter yet. Read paths must request both
+	// fields and prefer `message` when present.
+	LogField        = "log"
 	StreamField     = "stream"
 	MaxDocsPerQuery = 10000
 )
@@ -49,6 +56,10 @@ type OpenSearchLogDoc struct {
 		Timestamp string `json:"@timestamp"`
 		Stream    string `json:"stream,omitempty"`
 		Message   string `json:"message,omitempty"`
+		// Log is the raw text field written by fluent-bit's `cri` parser when
+		// the cluster's pipeline has not renamed it to `message`. Consumers
+		// must read it through EffectiveMessage to handle both pipelines.
+		Log string `json:"log,omitempty"`
 		// for context search
 		Line       int `json:"line,omitempty"`
 		Kubernetes struct {
@@ -79,6 +90,33 @@ type OpenSearchLogResponse struct {
 	// Total number of returned documents
 	Hits     OpenSearchLogHits `json:"hits"`
 	ScrollId string            `json:"_scroll_id,omitempty"`
+}
+
+// EffectiveMessage returns the canonical message body for a hit, falling back to
+// the raw `log` field when the cluster's fluent-bit pipeline did not rename it
+// to `message`. Always use this instead of reading Source.Message directly so
+// callers behave consistently across heterogeneous pipelines.
+func (d *OpenSearchLogDoc) EffectiveMessage() string {
+	if d.Source.Message != "" {
+		return d.Source.Message
+	}
+	return d.Source.Log
+}
+
+// NormalizeMessages copies the raw `log` field into `Message` for every hit
+// whose `Message` is empty. Use it whenever a typed response is returned to a
+// client that expects the canonical `message` key, so heterogeneous fluent-bit
+// pipelines are transparent to consumers.
+func (r *OpenSearchLogResponse) NormalizeMessages() {
+	if r == nil {
+		return
+	}
+	for i := range r.Hits.Hits {
+		doc := &r.Hits.Hits[i]
+		if doc.Source.Message == "" && doc.Source.Log != "" {
+			doc.Source.Message = doc.Source.Log
+		}
+	}
 }
 
 type OpenSearchEventDoc struct {

--- a/SaFE/resource-manager/pkg/ops_job/dumplog_job_controller.go
+++ b/SaFE/resource-manager/pkg/ops_job/dumplog_job_controller.go
@@ -329,7 +329,8 @@ func buildSearchBody(job *v1.OpsJob, workload *workloadInfo) []byte {
 
 	dispatchCntKey := strings.ReplaceAll(v1.WorkloadDispatchCntLabel, ".", "_")
 	searchRequest.Source = []string{
-		commonsearch.TimeField, commonsearch.MessageField, commonsearch.StreamField, "kubernetes.host", "kubernetes.pod_name",
+		commonsearch.TimeField, commonsearch.MessageField, commonsearch.LogField,
+		commonsearch.StreamField, "kubernetes.host", "kubernetes.pod_name",
 		"kubernetes.labels.training_kubeflow_org/replica-index", "kubernetes.labels.training_kubeflow_org/replica-type",
 		fmt.Sprintf("kubernetes.labels.%s", dispatchCntKey),
 	}
@@ -504,7 +505,7 @@ func serializeSearchResponse(data *commonsearch.OpenSearchLogResponse) string {
 		}
 		logBuffer.WriteString(doc.Source.Kubernetes.Labels.DispatchCount)
 		logBuffer.WriteString(" ")
-		logBuffer.WriteString(doc.Source.Message)
+		logBuffer.WriteString(doc.EffectiveMessage())
 		logBuffer.WriteString("\n")
 	}
 	return logBuffer.String()


### PR DESCRIPTION
## Why

The latest `main` switched SaFE to query workload logs through robust-analyzer's
`POST /api/v1/logs/raw` proxy, which is great. But users on core42 (and any
cluster whose FluentBit pipeline has not been migrated to the
`Rename log message` modify filter) still report **"SaFE shows no logs"** for
running workloads.

Investigation on workload `gptoss20b-mxfp4-gbs64-7nf2p` (Wang Han, core42
namespace `core42-meta-fp4-training`, 4 pods training a GPT-OSS-20B mxfp4 job):

- The OpenSearch query SaFE builds returns **8039 hits** for this workload in
  `node-2026.05.20`. So filters and time range and the robust-analyzer hop are
  fine.
- But every hit's `_source.message` is empty/missing. The actual log text
  lives in `_source.log`, written by fluent-bit's `cri` parser:

  ```
  count(workload=gptoss20b-mxfp4-gbs64-7nf2p, field=message) = 0
  count(workload=gptoss20b-mxfp4-gbs64-7nf2p, field=log)     = 8063
  ```

- Root cause: the operator-generated `Secret/primus-robust-fluentbit-config`
  on core42 was missing the `modify { rename: log -> message }` filter that
  the chart comments document. SaFE's `_source: [message, ...]` therefore
  returned only timestamps, and `match_phrase` on `message` matched nothing.
- The operator-side fix (a `ClusterFilter` that renames `log -> message`) has
  been applied to core42 separately; this PR makes SaFE robust to clusters
  that haven't been migrated and to historical documents indexed before the
  migration.

## What changes

Read paths now tolerate both `message`-pipelines and `log`-only pipelines:

- **`common/pkg/opensearch/types.go`** — add `LogField` constant, add
  `Source.Log` JSON field, plus helpers:
  - `(*OpenSearchLogDoc).EffectiveMessage()` returns `Message` or, if empty,
    `Log`.
  - `(*OpenSearchLogResponse).NormalizeMessages()` copies `Log` into empty
    `Message` for every hit in-place.
- **`common/pkg/opensearch/client.go`** — new `NormalizeLogResponseMessage`
  that rewrites a raw `_search` response so each hit exposes a non-empty
  `_source.message`. Tolerates empty / malformed bodies (returns as-is).
- **`apiserver/pkg/handlers/resources/log.go`**
  - `buildOutput` now asks for both `message` and `log` in `_source`.
  - `buildKeywords` wraps each phrase in `bool.should: [match_phrase(message),
    match_phrase(log)]` with `minimum_should_match: 1`, so keyword search
    works on both pipelines.
  - `getWorkloadLog` and `getServiceLog` return values are normalized.
  - `searchContextLog` and `searchCICDLog` call `NormalizeMessages` on the
    typed response.
  - `addContextDoc` uses `EffectiveMessage()` for the empty-message skip and
    back-fills `Source.Message` so context-window counting stays correct.
- **`apiserver/pkg/handlers/image-handlers/image.go`** — import-image logs
  endpoint asks for both fields and normalizes the response.
- **`resource-manager/pkg/ops_job/dumplog_job_controller.go`** — DumpLog
  scroll job asks for both fields and writes `EffectiveMessage()` into the
  S3 dump.

## Test plan

- [x] `go test ./common/pkg/opensearch/...` — `TestNormalizeLogResponseMessage`
  (7 cases: log-only docs, null message, empty-string message, both-missing,
  empty body, malformed body, no-change case) and
  `TestEffectiveMessageAndNormalize` pass.
- [x] `go test ./apiserver/pkg/handlers/resources/...` — existing
  `TestAddContextDoc`, `TestBuildKeywords`, `TestBuildOutput` pass after
  updating struct literals for the new `Log` field.
- [x] `go build ./...` across all 8 modules in `go.work` is clean.
- [x] Live verification on core42: replayed the exact OpenSearch DSL that
  `getWorkloadLog` would build for `gptoss20b-mxfp4-gbs64-7nf2p` through
  robust-analyzer's `/api/v1/logs/raw`. Before the ops-side rename filter
  was applied: 8039 hits with empty messages → after: hits carry both
  `message` and (transitionally) `log`; the normalizer produces a uniform
  `_source.message` regardless.
- [ ] Reviewer: please verify the UI rendering against a workload on a
  cluster whose FluentBit has not been migrated yet, to confirm the
  end-to-end fallback covers your front-end.

## Notes for ops

The fluent-operator `ClusterFilter` that performs the upstream rename is
**not** in this PR — it belongs in the primus-robust deployment. The
manifest used on core42 is:

```yaml
apiVersion: fluentbit.fluent.io/v1alpha2
kind: ClusterFilter
metadata:
  name: kubernetes-meta-zz-rename-log
  labels:
    fluentbit.fluent.io/enabled: "true"
spec:
  match: kube-log.*
  filters:
  - modify:
      rules:
      - rename:
          log: message
```

The `kubernetes-meta-zz-` prefix is intentional so it sorts after the
existing `kubernetes-meta` ClusterFilter and runs after `Merge_Log`.

Made with [Cursor](https://cursor.com)