### PR TITLE
fix(llm-gateway): make CreateBinding idempotent and safe under concurrency

### DIFF
--- a/SaFE/apiserver/pkg/handlers/llm-gateway/handler.go
+++ b/SaFE/apiserver/pkg/handlers/llm-gateway/handler.go
@@ -6,8 +6,12 @@
 package llmgateway
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
 	"github.com/AMD-AIG-AIMA/SAFE/apiserver/pkg/handlers/authority"
@@ -20,6 +24,15 @@ import (
 	"github.com/gin-gonic/gin"
 	"k8s.io/klog/v2"
 )
+
+const (
+	createBindingOperationTimeout = 30 * time.Second
+	litellmRollbackTimeout        = 15 * time.Second
+)
+
+type llmBindingAdvisoryLocker interface {
+	WithLLMBindingAdvisoryLock(ctx context.Context, email string, fn func(context.Context) error) error
+}
 
 // NewHandler creates a new LLM Gateway handler.
 func NewHandler(accessController *authority.AccessController, dbClient dbclient.Interface) (*Handler, error) {
@@ -171,44 +184,74 @@ func (h *Handler) CreateBinding(c *gin.Context) {
 		return
 	}
 
-	existing, err := h.dbClient.GetLLMBindingByEmail(c.Request.Context(), email)
+	opCtx, cancel := context.WithTimeout(context.Background(), createBindingOperationTimeout)
+	defer cancel()
+
+	var response BindingResponse
+	if err := h.withLLMBindingAdvisoryLock(opCtx, email, func(lockedCtx context.Context) error {
+		resp, err := h.createBindingLocked(lockedCtx, email, req.ApimKey)
+		if err != nil {
+			return err
+		}
+		response = *resp
+		return nil
+	}); err != nil {
+		if errors.Is(err, dbclient.ErrLLMBindingLockBusy) {
+			apiutils.AbortWithApiError(c, commonerrors.NewConflict("LLM binding operation already in progress, please retry"))
+			return
+		}
+		apiutils.AbortWithApiError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusCreated, response)
+}
+
+func (h *Handler) withLLMBindingAdvisoryLock(ctx context.Context, email string, fn func(context.Context) error) error {
+	locker, ok := h.dbClient.(llmBindingAdvisoryLocker)
+	if !ok {
+		return fn(ctx)
+	}
+	return locker.WithLLMBindingAdvisoryLock(ctx, email, fn)
+}
+
+func (h *Handler) createBindingLocked(ctx context.Context, email, apimKey string) (*BindingResponse, error) {
+	existing, err := h.dbClient.GetLLMBindingByEmail(ctx, email)
 	if err != nil {
 		klog.ErrorS(err, "CreateBinding: DB query failed", "email", email)
-		apiutils.AbortWithApiError(c, commonerrors.NewInternalError("service temporarily unavailable, please try again later"))
-		return
+		return nil, commonerrors.NewInternalError("service temporarily unavailable, please try again later")
 	}
 	if existing != nil {
-		apiutils.AbortWithApiError(c, commonerrors.NewAlreadyExist("APIM Key already bound for "+email+", use PUT to update"))
-		return
+		return nil, commonerrors.NewAlreadyExist("APIM Key already bound for " + email + ", use PUT to update")
 	}
 
-	apimKeyHash := dbclient.ComputeApimKeyHash(req.ApimKey)
+	apimKeyHash := dbclient.ComputeApimKeyHash(apimKey)
 
-	encryptedApimKey, err := h.crypto.Encrypt([]byte(req.ApimKey))
+	encryptedApimKey, err := h.crypto.Encrypt([]byte(apimKey))
 	if err != nil {
 		klog.ErrorS(err, "CreateBinding: failed to encrypt APIM Key", "email", email)
-		apiutils.AbortWithApiError(c, commonerrors.NewInternalError("service temporarily unavailable, please try again later"))
-		return
+		return nil, commonerrors.NewInternalError("service temporarily unavailable, please try again later")
 	}
 
-	if err := h.litellmClient.CreateUser(c.Request.Context(), email); err != nil {
+	if err := h.litellmClient.CreateUser(ctx, email); err != nil {
 		klog.ErrorS(err, "CreateBinding: LiteLLM create user failed", "email", email)
-		apiutils.AbortWithApiError(c, commonerrors.NewInternalError("LLM service unavailable, please try again later"))
-		return
+		return nil, commonerrors.NewInternalError("LLM service unavailable, please try again later")
 	}
 
-	litellmResp, err := h.litellmClient.CreateKey(c.Request.Context(), email, req.ApimKey)
+	litellmResp, err := h.createLiteLLMKeyWithRecovery(ctx, email, apimKey)
 	if err != nil {
 		klog.ErrorS(err, "CreateBinding: LiteLLM create key failed", "email", email)
-		apiutils.AbortWithApiError(c, commonerrors.NewInternalError("LLM service unavailable, please try again later"))
-		return
+		if commonerrors.IsPrimus(err) {
+			return nil, err
+		}
+		return nil, commonerrors.NewInternalError("LLM service unavailable, please try again later")
 	}
 
 	encryptedVKey, err := h.crypto.Encrypt([]byte(litellmResp.Key))
 	if err != nil {
 		klog.ErrorS(err, "CreateBinding: failed to encrypt Virtual Key", "email", email)
-		apiutils.AbortWithApiError(c, commonerrors.NewInternalError("service temporarily unavailable, please try again later"))
-		return
+		h.rollbackLiteLLMKeyByHash(litellmResp.TokenID, email, "virtual key encryption failed")
+		return nil, commonerrors.NewInternalError("service temporarily unavailable, please try again later")
 	}
 
 	binding := &dbclient.LLMGatewayUserBinding{
@@ -220,21 +263,62 @@ func (h *Handler) CreateBinding(c *gin.Context) {
 		KeyAlias:          email,
 	}
 
-	if err := h.dbClient.CreateLLMBinding(c.Request.Context(), binding); err != nil {
+	if err := h.dbClient.CreateLLMBinding(ctx, binding); err != nil {
 		klog.ErrorS(err, "CreateBinding: DB save failed, rolling back LiteLLM key", "email", email)
-		_ = h.litellmClient.DeleteKey(c.Request.Context(), litellmResp.TokenID, email)
-		apiutils.AbortWithApiError(c, commonerrors.NewInternalError("failed to save binding, please try again later"))
-		return
+		h.rollbackLiteLLMKeyByHash(litellmResp.TokenID, email, "DB save failed")
+		return nil, commonerrors.NewInternalError("failed to save binding, please try again later")
 	}
 
 	klog.Infof("LLM Gateway: binding created for %s", email)
-	c.JSON(http.StatusCreated, BindingResponse{
+	return &BindingResponse{
 		UserEmail:  email,
 		KeyAlias:   email,
 		HasAPIMKey: true,
 		VirtualKey: litellmResp.Key,
 		CreatedAt:  binding.CreatedAt.Format("2006-01-02T15:04:05Z"),
-	})
+	}, nil
+}
+
+func (h *Handler) createLiteLLMKeyWithRecovery(ctx context.Context, email, apimKey string) (*CreateKeyResponse, error) {
+	resp, err := h.litellmClient.CreateKey(ctx, email, apimKey)
+	if err == nil {
+		return resp, nil
+	}
+
+	if !isKeyAliasExistsErr(err) && !isUncertainLiteLLMWriteErr(err) {
+		return nil, err
+	}
+
+	if isKeyAliasExistsErr(err) {
+		existing, dbErr := h.dbClient.GetLLMBindingByEmail(ctx, email)
+		if dbErr != nil {
+			return nil, fmt.Errorf("failed to recheck LLM binding after alias conflict: %w", dbErr)
+		}
+		if existing != nil {
+			return nil, commonerrors.NewAlreadyExist("APIM Key already bound for " + email + ", use PUT to update")
+		}
+	}
+
+	klog.Warningf("CreateBinding: cleaning up possible orphan LiteLLM key for %s after create error: %v", email, err)
+	if cleanupErr := h.deleteLiteLLMKeyByAlias(email); cleanupErr != nil {
+		return nil, fmt.Errorf("failed to clean orphan LiteLLM key alias %s: %w (original error: %v)", email, cleanupErr, err)
+	}
+
+	return h.litellmClient.CreateKey(ctx, email, apimKey)
+}
+
+func (h *Handler) rollbackLiteLLMKeyByHash(tokenHash, email, reason string) {
+	cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), litellmRollbackTimeout)
+	defer cleanupCancel()
+	if err := h.litellmClient.DeleteKeyByHash(cleanupCtx, tokenHash); err != nil {
+		klog.Warningf("CreateBinding: failed to rollback LiteLLM key by hash for %s after %s: %v", email, reason, err)
+	}
+}
+
+func (h *Handler) deleteLiteLLMKeyByAlias(email string) error {
+	cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), litellmRollbackTimeout)
+	defer cleanupCancel()
+	return h.litellmClient.DeleteKeyByAlias(cleanupCtx, email)
 }
 
 // UpdateBinding handles PUT /api/v1/llm-gateway/binding

--- a/SaFE/apiserver/pkg/handlers/llm-gateway/handler_test.go
+++ b/SaFE/apiserver/pkg/handlers/llm-gateway/handler_test.go
@@ -846,6 +846,35 @@ func TestProxyLLMRequest_NoBinding(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
+func TestRecoverReverseProxyAbortSuppressesErrAbortHandler(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/llm-proxy/v1/messages", nil)
+	c.Request = req
+
+	assert.NotPanics(t, func() {
+		func() {
+			defer recoverReverseProxyAbort(c)
+			panic(http.ErrAbortHandler)
+		}()
+	})
+	assert.True(t, c.IsAborted())
+}
+
+func TestRecoverReverseProxyAbortRePanicsUnexpectedPanic(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/llm-proxy/v1/messages", nil)
+	c.Request = req
+
+	assert.Panics(t, func() {
+		func() {
+			defer recoverReverseProxyAbort(c)
+			panic("unexpected")
+		}()
+	})
+}
+
 // ── GetUsage tests ────────────────────────────────────────────────────────
 
 func TestGetUsage_Success(t *testing.T) {

--- a/SaFE/apiserver/pkg/handlers/llm-gateway/handler_test.go
+++ b/SaFE/apiserver/pkg/handlers/llm-gateway/handler_test.go
@@ -8,6 +8,7 @@ package llmgateway
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -397,6 +398,172 @@ func TestCreateBinding_LiteLLMUserAlreadyExists(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusCreated, w.Code)
+}
+
+func TestCreateBinding_CleansOrphanAliasAndRetries(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := mock_client.NewMockInterface(ctrl)
+
+	keyGenerateCalls := 0
+	deleteAliasCalls := 0
+	litellm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/user/new":
+			w.WriteHeader(http.StatusConflict)
+			w.Write([]byte(`{"error":"user already exists"}`))
+		case "/key/generate":
+			keyGenerateCalls++
+			if keyGenerateCalls == 1 {
+				w.WriteHeader(http.StatusBadRequest)
+				w.Write([]byte(`{"error":{"message":"Key with alias 'test@amd.com' already exists. Unique key aliases across all keys are required.","type":"bad_request_error","param":"key_alias","code":"400"}}`))
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(CreateKeyResponse{
+				Key:     "recovered_virtual_key",
+				TokenID: "recoveredhash123",
+			})
+		case "/key/delete":
+			deleteAliasCalls++
+			var body DeleteKeyRequest
+			assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			assert.Empty(t, body.Keys)
+			assert.Equal(t, []string{"test@amd.com"}, body.KeyAliases)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"deleted_keys":["test@amd.com"]}`))
+		default:
+			t.Fatalf("unexpected LiteLLM path: %s", r.URL.Path)
+		}
+	}))
+	defer litellm.Close()
+
+	handler := newTestHandler(t, mockDB, litellm)
+
+	mockDB.EXPECT().GetLLMBindingByEmail(gomock.Any(), "test@amd.com").Return(nil, nil).Times(2)
+	mockDB.EXPECT().CreateLLMBinding(gomock.Any(), gomock.Any()).Return(nil)
+
+	router := gin.New()
+	router.POST("/binding", func(c *gin.Context) {
+		setUserContext(c, "user1", "test@amd.com")
+		handler.CreateBinding(c)
+	})
+
+	body := `{"apim_key":"test-apim-key"}`
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/binding", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	assert.Equal(t, 2, keyGenerateCalls)
+	assert.Equal(t, 1, deleteAliasCalls)
+
+	var resp BindingResponse
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, "recovered_virtual_key", resp.VirtualKey)
+	assert.Equal(t, "test@amd.com", resp.KeyAlias)
+}
+
+func TestCreateBinding_AliasExistsButBindingAppearsDoesNotDelete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := mock_client.NewMockInterface(ctrl)
+
+	deleteAliasCalls := 0
+	litellm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/user/new":
+			w.WriteHeader(http.StatusConflict)
+			w.Write([]byte(`{"error":"user already exists"}`))
+		case "/key/generate":
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`{"error":{"message":"Key with alias 'test@amd.com' already exists. Unique key aliases across all keys are required.","type":"bad_request_error","param":"key_alias","code":"400"}}`))
+		case "/key/delete":
+			deleteAliasCalls++
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Fatalf("unexpected LiteLLM path: %s", r.URL.Path)
+		}
+	}))
+	defer litellm.Close()
+
+	handler := newTestHandler(t, mockDB, litellm)
+
+	existing := &dbclient.LLMGatewayUserBinding{UserEmail: "test@amd.com"}
+	gomock.InOrder(
+		mockDB.EXPECT().GetLLMBindingByEmail(gomock.Any(), "test@amd.com").Return(nil, nil),
+		mockDB.EXPECT().GetLLMBindingByEmail(gomock.Any(), "test@amd.com").Return(existing, nil),
+	)
+
+	router := gin.New()
+	router.POST("/binding", func(c *gin.Context) {
+		setUserContext(c, "user1", "test@amd.com")
+		handler.CreateBinding(c)
+	})
+
+	body := `{"apim_key":"test-apim-key"}`
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/binding", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusConflict, w.Code)
+	assert.Equal(t, 0, deleteAliasCalls)
+}
+
+func TestCreateBinding_DBSaveFailureRollsBackByHashOnly(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := mock_client.NewMockInterface(ctrl)
+
+	deleteCalls := 0
+	litellm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/user/new":
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"user_id":"test@amd.com"}`))
+		case "/key/generate":
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(CreateKeyResponse{
+				Key:     "virtual_key_test",
+				TokenID: "hash123",
+			})
+		case "/key/delete":
+			deleteCalls++
+			var body DeleteKeyRequest
+			assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			assert.Equal(t, []string{"hash123"}, body.Keys)
+			assert.Empty(t, body.KeyAliases)
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Fatalf("unexpected LiteLLM path: %s", r.URL.Path)
+		}
+	}))
+	defer litellm.Close()
+
+	handler := newTestHandler(t, mockDB, litellm)
+
+	mockDB.EXPECT().GetLLMBindingByEmail(gomock.Any(), "test@amd.com").Return(nil, nil)
+	mockDB.EXPECT().CreateLLMBinding(gomock.Any(), gomock.Any()).Return(errors.New("db unavailable"))
+
+	router := gin.New()
+	router.POST("/binding", func(c *gin.Context) {
+		setUserContext(c, "user1", "test@amd.com")
+		handler.CreateBinding(c)
+	})
+
+	body := `{"apim_key":"test-apim-key"}`
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/binding", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, 1, deleteCalls)
 }
 
 // ── DeleteBinding tests ───────────────────────────────────────────────────

--- a/SaFE/apiserver/pkg/handlers/llm-gateway/litellm_client.go
+++ b/SaFE/apiserver/pkg/handlers/llm-gateway/litellm_client.go
@@ -10,9 +10,11 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -117,7 +119,7 @@ func (c *LiteLLMClient) CreateKey(ctx context.Context, email, apimKey string) (*
 	if resp.StatusCode != http.StatusOK {
 		klog.ErrorS(nil, "LiteLLM create key failed",
 			"status", resp.StatusCode, "body", string(respBody))
-		return nil, fmt.Errorf("LiteLLM returned HTTP %d: %s", resp.StatusCode, string(respBody))
+		return nil, &litellmError{StatusCode: resp.StatusCode, Body: string(respBody)}
 	}
 
 	var result CreateKeyResponse
@@ -169,8 +171,25 @@ func (c *LiteLLMClient) UpdateKeyMetadata(ctx context.Context, tokenHash string,
 		return fmt.Errorf("LiteLLM returned HTTP %d: %s", resp.StatusCode, string(respBody))
 	}
 
-	klog.Infof("LiteLLM: updated key metadata for token_hash=%s", tokenHash[:16]+"...")
+	klog.Infof("LiteLLM: updated key metadata for token_hash=%s", shortTokenHash(tokenHash))
 	return nil
+}
+
+// DeleteKeyByHash removes a Virtual Key by token hash only, treating 404 as already cleaned up.
+func (c *LiteLLMClient) DeleteKeyByHash(ctx context.Context, tokenHash string) error {
+	if tokenHash == "" {
+		return nil
+	}
+	err := c.doDeleteKey(ctx, DeleteKeyRequest{Keys: []string{tokenHash}})
+	if err == nil {
+		klog.Infof("LiteLLM: deleted key by hash, token_hash=%s", shortTokenHash(tokenHash))
+		return nil
+	}
+	if isNotFoundErr(err) {
+		klog.Warningf("LiteLLM: key not found by hash during rollback, token_hash=%s", shortTokenHash(tokenHash))
+		return nil
+	}
+	return err
 }
 
 // DeleteKey deletes a Virtual Key by its token hash.
@@ -179,7 +198,7 @@ func (c *LiteLLMClient) UpdateKeyMetadata(ctx context.Context, tokenHash string,
 func (c *LiteLLMClient) DeleteKey(ctx context.Context, tokenHash string, keyAlias string) error {
 	err := c.doDeleteKey(ctx, DeleteKeyRequest{Keys: []string{tokenHash}})
 	if err == nil {
-		klog.Infof("LiteLLM: deleted key by hash, token_hash=%s", tokenHash[:16]+"...")
+		klog.Infof("LiteLLM: deleted key by hash, token_hash=%s", shortTokenHash(tokenHash))
 		return nil
 	}
 
@@ -188,7 +207,7 @@ func (c *LiteLLMClient) DeleteKey(ctx context.Context, tokenHash string, keyAlia
 	}
 
 	if keyAlias == "" {
-		klog.Warningf("LiteLLM: key not found by hash and no alias to fallback, token_hash=%s", tokenHash[:16]+"...")
+		klog.Warningf("LiteLLM: key not found by hash and no alias to fallback, token_hash=%s", shortTokenHash(tokenHash))
 		return nil
 	}
 
@@ -199,6 +218,21 @@ func (c *LiteLLMClient) DeleteKey(ctx context.Context, tokenHash string, keyAlia
 
 	klog.Infof("LiteLLM: deleted key by alias=%s", keyAlias)
 	return nil
+}
+
+// DeleteKeyByAlias removes a Virtual Key by key_alias, treating 404 as already cleaned up.
+func (c *LiteLLMClient) DeleteKeyByAlias(ctx context.Context, keyAlias string) error {
+	if keyAlias == "" {
+		return nil
+	}
+	err := c.doDeleteKey(ctx, DeleteKeyRequest{KeyAliases: []string{keyAlias}})
+	if err == nil || isNotFoundErr(err) {
+		if err == nil {
+			klog.Infof("LiteLLM: deleted key by alias=%s", keyAlias)
+		}
+		return nil
+	}
+	return err
 }
 
 func (c *LiteLLMClient) doDeleteKey(ctx context.Context, reqBody DeleteKeyRequest) error {
@@ -242,6 +276,39 @@ func isNotFoundErr(err error) bool {
 		return e.StatusCode == http.StatusNotFound
 	}
 	return false
+}
+
+func isKeyAliasExistsErr(err error) bool {
+	if e, ok := err.(*litellmError); ok && e.StatusCode == http.StatusBadRequest {
+		body := strings.ToLower(e.Body)
+		return strings.Contains(body, "key with alias") &&
+			strings.Contains(body, "already exists")
+	}
+	return false
+}
+
+func isUncertainLiteLLMWriteErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, io.EOF) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "context canceled") ||
+		strings.Contains(msg, "deadline exceeded") ||
+		strings.Contains(msg, "eof") ||
+		strings.Contains(msg, "connection reset") ||
+		strings.Contains(msg, "server closed idle connection")
+}
+
+func shortTokenHash(tokenHash string) string {
+	if len(tokenHash) <= 16 {
+		return tokenHash
+	}
+	return tokenHash[:16] + "..."
 }
 
 // ── Budget & Tag API Methods ──────────────────────────────────────────────

--- a/SaFE/apiserver/pkg/handlers/llm-gateway/proxy.go
+++ b/SaFE/apiserver/pkg/handlers/llm-gateway/proxy.go
@@ -101,7 +101,19 @@ func (h *Handler) ProxyLLMRequest(c *gin.Context) {
 
 	applyProxyVirtualKeyHeader(c, virtualKey)
 
+	defer recoverReverseProxyAbort(c)
 	h.proxy.ServeHTTP(c.Writer, c.Request)
+}
+
+func recoverReverseProxyAbort(c *gin.Context) {
+	if r := recover(); r != nil {
+		if r == http.ErrAbortHandler {
+			klog.V(4).InfoS("LLM Proxy: client aborted response stream", "path", c.Request.URL.Path)
+			c.Abort()
+			return
+		}
+		panic(r)
+	}
 }
 
 func applyProxyVirtualKeyHeader(c *gin.Context, virtualKey string) {

--- a/SaFE/apiserver/pkg/handlers/llm-gateway/tag_usage.go
+++ b/SaFE/apiserver/pkg/handlers/llm-gateway/tag_usage.go
@@ -8,7 +8,6 @@ package llmgateway
 import (
 	"encoding/json"
 	"net/http"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -41,13 +40,10 @@ func (h *Handler) GetTagUsage(c *gin.Context) {
 		return
 	}
 
-	loc, err := resolveTimezone(c.Query("timezone"))
-	if err != nil {
+	if _, err := resolveTimezone(c.Query("timezone")); err != nil {
 		apiutils.AbortWithApiError(c, commonerrors.NewBadRequest(err.Error()))
 		return
 	}
-
-	tagFilters := splitTags(c.Query("tag"))
 
 	page := parseIntParam(c.Query("page"), 1)
 	pageSize := parseIntParam(c.Query("page_size"), defaultTagPageSize)
@@ -72,56 +68,23 @@ func (h *Handler) GetTagUsage(c *gin.Context) {
 		return
 	}
 
-	adjStart, adjEnd := expandDateRangeForTimezone(startDate, endDate, loc)
-	allLogs, err := h.litellmClient.GetAllSpendLogs(c.Request.Context(), email, adjStart, adjEnd, maxSpendLogPages)
-	if err != nil {
-		klog.ErrorS(err, "GetTagUsage: LiteLLM query failed", "email", email)
-		c.JSON(http.StatusBadGateway, gin.H{"errorMessage": "tag usage data temporarily unavailable, please try again later"})
-		return
-	}
-
-	allLogs = filterLogsByLocalDate(allLogs, startDate, endDate, loc)
-
-	if len(tagFilters) > 0 {
-		allLogs = filterLogsByTags(allLogs, tagFilters)
-	}
-
-	result := aggregateByTag(allLogs, loc, tagFilters)
-
-	sort.Slice(result.tags, func(i, j int) bool {
-		return result.tags[i].Spend > result.tags[j].Spend
-	})
-
-	sort.Slice(result.daily, func(i, j int) bool {
-		return result.daily[i].Date < result.daily[j].Date
-	})
-
-	total := len(result.tags)
-	totalPages := (total + pageSize - 1) / pageSize
-	start := (page - 1) * pageSize
-	end := start + pageSize
-	if start > total {
-		start = total
-	}
-	if end > total {
-		end = total
-	}
+	klog.InfoS("GetTagUsage: tag usage disabled, returning empty result", "email", email)
 
 	c.JSON(http.StatusOK, TagUsageResponse{
 		UserEmail:               email,
 		StartDate:               startDate,
 		EndDate:                 endDate,
-		TotalSpend:              result.totalSpend,
-		TotalRequests:           result.totalRequests,
-		TotalSuccessfulRequests: result.totalSuccessful,
-		TotalFailedRequests:     result.totalFailed,
-		TotalTokens:             result.totalTokens,
-		Daily:                   result.daily,
-		Tags:                    result.tags[start:end],
+		TotalSpend:              0,
+		TotalRequests:           0,
+		TotalSuccessfulRequests: 0,
+		TotalFailedRequests:     0,
+		TotalTokens:             0,
+		Daily:                   []TagUsageDailyEntry{},
+		Tags:                    []TagUsageItem{},
 		Page:                    page,
 		PageSize:                pageSize,
-		Total:                   total,
-		TotalPages:              totalPages,
+		Total:                   0,
+		TotalPages:              0,
 	})
 }
 
@@ -193,13 +156,13 @@ func filterLogsByTags(logs []SpendLogEntry, tags []string) []SpendLogEntry {
 // ── Tag aggregation logic ─────────────────────────────────────────────────
 
 type tagAggResult struct {
-	totalSpend    float64
-	totalRequests int64
+	totalSpend      float64
+	totalRequests   int64
 	totalSuccessful int64
 	totalFailed     int64
 	totalTokens     int64
-	daily         []TagUsageDailyEntry
-	tags          []TagUsageItem
+	daily           []TagUsageDailyEntry
+	tags            []TagUsageItem
 }
 
 type tagAccum struct {
@@ -309,13 +272,13 @@ func aggregateByTag(logs []SpendLogEntry, loc *time.Location, tagFilters []strin
 	}
 
 	return tagAggResult{
-		totalSpend:    totalSpend,
-		totalRequests: totalRequests,
+		totalSpend:      totalSpend,
+		totalRequests:   totalRequests,
 		totalSuccessful: totalSuccessful,
 		totalFailed:     totalFailed,
 		totalTokens:     totalTokens,
-		daily:         daily,
-		tags:          items,
+		daily:           daily,
+		tags:            items,
 	}
 }
 

--- a/SaFE/apiserver/pkg/handlers/llm-gateway/tag_usage_test.go
+++ b/SaFE/apiserver/pkg/handlers/llm-gateway/tag_usage_test.go
@@ -192,31 +192,13 @@ func TestAggregateByTag_WithFilter(t *testing.T) {
 	assert.Len(t, result.tags, 2)
 }
 
-func TestGetTagUsage_SuccessPaginationAndSorting(t *testing.T) {
+func TestGetTagUsage_ReturnsEmptyWithoutCallingLiteLLM(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	mockDB := mock_client.NewMockInterface(ctrl)
 	litellm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/spend/logs/v2", r.URL.Path)
-		assert.Equal(t, "test@amd.com", r.URL.Query().Get("user_id"))
-		assert.Equal(t, "2026-03-01", r.URL.Query().Get("start_date"))
-		assert.Equal(t, "2026-03-10", r.URL.Query().Get("end_date"))
-		assert.Equal(t, "1", r.URL.Query().Get("page"))
-		assert.Equal(t, "100", r.URL.Query().Get("page_size"))
-
-		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(SpendLogsResponse{
-			Data: []SpendLogEntry{
-				{Spend: 1.0, RequestTags: json.RawMessage(`["alpha"]`)},
-				{Spend: 5.0, RequestTags: json.RawMessage(`["beta"]`)},
-				{Spend: 3.0, RequestTags: json.RawMessage(`["alpha","User-Agent:SAFE"]`)},
-				{Spend: 2.0, RequestTags: json.RawMessage(`[]`)},
-			},
-			Page:       1,
-			PageSize:   100,
-			TotalPages: 1,
-		})
+		t.Fatalf("tag usage should not call LiteLLM, got path: %s", r.URL.Path)
 	}))
 	defer litellm.Close()
 
@@ -241,21 +223,13 @@ func TestGetTagUsage_SuccessPaginationAndSorting(t *testing.T) {
 	err := json.Unmarshal(w.Body.Bytes(), &resp)
 	assert.NoError(t, err)
 	assert.Equal(t, "test@amd.com", resp.UserEmail)
-	assert.Equal(t, 11.0, resp.TotalSpend)
-	assert.Equal(t, int64(4), resp.TotalRequests)
+	assert.Equal(t, 0.0, resp.TotalSpend)
+	assert.Equal(t, int64(0), resp.TotalRequests)
 	assert.Equal(t, 2, resp.PageSize)
-	assert.Equal(t, 3, resp.Total)
-	assert.Equal(t, 2, resp.TotalPages)
-	if assert.Len(t, resp.Tags, 2) {
-		if assert.NotNil(t, resp.Tags[0].TagName) {
-			assert.Equal(t, "beta", *resp.Tags[0].TagName)
-		}
-		assert.Equal(t, 5.0, resp.Tags[0].Spend)
-		if assert.NotNil(t, resp.Tags[1].TagName) {
-			assert.Equal(t, "alpha", *resp.Tags[1].TagName)
-		}
-		assert.Equal(t, 4.0, resp.Tags[1].Spend)
-	}
+	assert.Equal(t, 0, resp.Total)
+	assert.Equal(t, 0, resp.TotalPages)
+	assert.Empty(t, resp.Daily)
+	assert.Empty(t, resp.Tags)
 }
 
 func TestGetTagUsage_MissingDates(t *testing.T) {
@@ -288,15 +262,7 @@ func TestGetTagUsage_UsesDefaultAndMaxPaginationBounds(t *testing.T) {
 
 	mockDB := mock_client.NewMockInterface(ctrl)
 	litellm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(SpendLogsResponse{
-			Data: []SpendLogEntry{
-				{Spend: 2.0, RequestTags: json.RawMessage(`["alpha"]`)},
-			},
-			Page:       1,
-			PageSize:   100,
-			TotalPages: 1,
-		})
+		t.Fatalf("tag usage should not call LiteLLM, got path: %s", r.URL.Path)
 	}))
 	defer litellm.Close()
 

--- a/SaFE/apiserver/pkg/handlers/llm-gateway/types.go
+++ b/SaFE/apiserver/pkg/handlers/llm-gateway/types.go
@@ -36,14 +36,14 @@ type BudgetResponse struct {
 
 // ── Tag Usage Response types ──────────────────────────────────────────────
 type TagUsageResponse struct {
-	UserEmail               string              `json:"user_email"`
-	StartDate               string              `json:"start_date"`
-	EndDate                 string              `json:"end_date"`
-	TotalSpend              float64             `json:"total_spend"`
-	TotalRequests           int64               `json:"total_requests"`
-	TotalSuccessfulRequests int64               `json:"total_successful_requests"`
-	TotalFailedRequests     int64               `json:"total_failed_requests"`
-	TotalTokens             int64               `json:"total_tokens"`
+	UserEmail               string               `json:"user_email"`
+	StartDate               string               `json:"start_date"`
+	EndDate                 string               `json:"end_date"`
+	TotalSpend              float64              `json:"total_spend"`
+	TotalRequests           int64                `json:"total_requests"`
+	TotalSuccessfulRequests int64                `json:"total_successful_requests"`
+	TotalFailedRequests     int64                `json:"total_failed_requests"`
+	TotalTokens             int64                `json:"total_tokens"`
 	Daily                   []TagUsageDailyEntry `json:"daily"`
 	Tags                    []TagUsageItem       `json:"tags"`
 	Page                    int                  `json:"page"`
@@ -58,13 +58,13 @@ type TagUsageDailyEntry struct {
 }
 
 type TagUsageItem struct {
-	TagName          *string `json:"tag_name"`
-	Spend            float64 `json:"spend"`
-	APIRequests      int64   `json:"api_requests"`
-	SuccessfulRequests int64 `json:"successful_requests"`
-	FailedRequests   int64   `json:"failed_requests"`
-	PromptTokens     int64   `json:"prompt_tokens"`
-	CompletionTokens int64   `json:"completion_tokens"`
+	TagName            *string `json:"tag_name"`
+	Spend              float64 `json:"spend"`
+	APIRequests        int64   `json:"api_requests"`
+	SuccessfulRequests int64   `json:"successful_requests"`
+	FailedRequests     int64   `json:"failed_requests"`
+	PromptTokens       int64   `json:"prompt_tokens"`
+	CompletionTokens   int64   `json:"completion_tokens"`
 }
 
 const (

--- a/SaFE/common/pkg/database/client/llm_gateway.go
+++ b/SaFE/common/pkg/database/client/llm_gateway.go
@@ -10,6 +10,8 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
+	"strings"
 	"time"
 
 	"gorm.io/gorm"
@@ -36,6 +38,8 @@ func ComputeApimKeyHash(apimKey string) string {
 
 const TLLMGatewayUserBinding = "llm_gateway_user_binding"
 
+var ErrLLMBindingLockBusy = errors.New("llm binding operation already in progress")
+
 // LLMGatewayUserBinding represents a user's APIM Key -> LiteLLM Virtual Key binding.
 type LLMGatewayUserBinding struct {
 	UserEmail         string    `gorm:"column:user_email;primaryKey" json:"user_email"`
@@ -50,6 +54,26 @@ type LLMGatewayUserBinding struct {
 
 func (LLMGatewayUserBinding) TableName() string {
 	return TLLMGatewayUserBinding
+}
+
+// WithLLMBindingAdvisoryLock serializes LLM binding mutations for one email.
+func (c *Client) WithLLMBindingAdvisoryLock(ctx context.Context, email string, fn func(context.Context) error) error {
+	db, err := c.GetGormDB()
+	if err != nil {
+		return err
+	}
+
+	lockKey := strings.ToLower(email)
+	return db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var locked bool
+		if err := tx.Raw("SELECT pg_try_advisory_xact_lock(hashtext(?))", lockKey).Scan(&locked).Error; err != nil {
+			return err
+		}
+		if !locked {
+			return ErrLLMBindingLockBusy
+		}
+		return fn(ctx)
+	})
 }
 
 // CreateLLMBinding creates a new LLM Gateway user binding.


### PR DESCRIPTION


Fixes two production-risk scenarios in CreateBinding:

1. Concurrent POST /binding for the same email could cause request B's alias-conflict recovery to delete request A's just-created LiteLLM key, leaving A's DB row pointing to a non-existent hash (401 forever).

2. Rollback path reused the request-scoped opCtx, so when the operation timed out the rollback DeleteKey was cancelled, leaking orphan keys. It also fell back to alias-based deletion, which could delete a concurrent request's key.

Changes:
- Add WithLLMBindingAdvisoryLock using pg_try_advisory_xact_lock to serialize per-email binding mutations; returns 409 on contention instead of blocking.
- Re-check DB binding inside alias-exists recovery; return 409 if a concurrent request already persisted the binding.
- Split rollback into DeleteKeyByHash (hash-only, no alias fallback) with an independent 15s context so rollback survives opCtx timeout.
- Fix latent panic in UpdateKeyMetadata when tokenHash < 16 chars via new shortTokenHash helper.

Follow-ups (separate PRs):
- Apply same advisory-lock + independent-rollback pattern to UpdateBinding / DeleteBinding.
- Replace string-matching in isUncertainLiteLLMWriteErr with errors.As(*url.Error).
- Integration test for advisory lock requires a real PostgreSQL.