### PR TITLE
Propagate runner node name through HOSTNAME in CICD

### DIFF
--- a/SaFE/charts/primus-safe/templates/configmap/github_runner_template.yaml
+++ b/SaFE/charts/primus-safe/templates/configmap/github_runner_template.yaml
@@ -89,6 +89,10 @@ data:
             value: unix:///var/run/docker.sock
           - name: RUNNER_WAIT_FOR_DOCKER_IN_SECONDS
             value: "120"
+          - name: HOSTNAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
         securityContext:
           privileged: true
           runAsGroup: 0

--- a/SaFE/charts/primus-safe/templates/configmap/github_scale_set_template.yaml
+++ b/SaFE/charts/primus-safe/templates/configmap/github_scale_set_template.yaml
@@ -46,6 +46,10 @@ data:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           volumeMounts:
           - name: podinfo
             mountPath: /etc/podinfo

--- a/SaFE/job-manager/pkg/dispatcher/dispatcher_help_test.go
+++ b/SaFE/job-manager/pkg/dispatcher/dispatcher_help_test.go
@@ -182,6 +182,25 @@ func findEnv(envs []interface{}, name, val string) bool {
 	return false
 }
 
+func findEnvFieldRef(envs []interface{}, name, fieldPath string) bool {
+	for _, env := range envs {
+		obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&env)
+		if err != nil {
+			continue
+		}
+		name2, ok := obj["name"]
+		if !ok || name != name2 {
+			continue
+		}
+		fieldPath2, found, err := jobutils.NestedString(obj, []string{"valueFrom", "fieldRef", "fieldPath"})
+		if err != nil || !found {
+			continue
+		}
+		return fieldPath2 == fieldPath
+	}
+	return false
+}
+
 func checkVolumeMounts(t *testing.T, obj *unstructured.Unstructured, workload *v1.Workload, resourceSpec *v1.ResourceSpec) {
 	templatePath := append(resourceSpec.PrePaths, resourceSpec.TemplatePaths...)
 	podSpec := getPodSpec(workload)

--- a/SaFE/job-manager/pkg/dispatcher/dispatcher_test.go
+++ b/SaFE/job-manager/pkg/dispatcher/dispatcher_test.go
@@ -574,6 +574,7 @@ func TestCreateCICDScaleSet(t *testing.T) {
 	checkHostNetwork(t, obj, workload, &templates[0], 0)
 	envs := getEnvs(t, obj, workload, &templates[0])
 	checkCICDEnvs(t, envs, workload)
+	checkCICDRunnerEnvFieldRefs(t, envs)
 
 	assert.Equal(t, getContainer(obj, "runner", workload, &templates[0]) != nil, true)
 	assert.Equal(t, getContainer(obj, "unified_job", workload, &templates[0]) != nil, false)
@@ -646,6 +647,9 @@ func checkCICDContainer(t *testing.T, obj *unstructured.Unstructured, workload *
 	assert.NilError(t, err)
 	assert.Equal(t, found, true)
 	checkCICDEnvs(t, envs, workload)
+	if containerName == "runner" {
+		checkCICDRunnerEnvFieldRefs(t, envs)
+	}
 }
 
 func checkCICDEnvs(t *testing.T, envs []interface{}, workload *v1.Workload) {
@@ -666,6 +670,13 @@ func checkCICDEnvs(t *testing.T, envs []interface{}, workload *v1.Workload) {
 		ok = findEnv(envs, jobutils.NfsOutputEnv, UnifiedJobOutput)
 		assert.Equal(t, ok, true)
 	}
+}
+
+func checkCICDRunnerEnvFieldRefs(t *testing.T, envs []interface{}) {
+	ok := findEnvFieldRef(envs, "POD_NAME", "metadata.name")
+	assert.Equal(t, ok, true)
+	ok = findEnvFieldRef(envs, "HOSTNAME", "spec.nodeName")
+	assert.Equal(t, ok, true)
 }
 
 func TestUpdateContainerEnv(t *testing.T) {

--- a/SaFE/job-manager/pkg/dispatcher/test_data.go
+++ b/SaFE/job-manager/pkg/dispatcher/test_data.go
@@ -344,6 +344,14 @@ data:
               value: "1"
             - name: APISERVER_NODE_PORT
               value: "32495"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           image: docker.io/primussafe/cicd-runner-proxy:latest
           name: runner
           resources:


### PR DESCRIPTION
## Summary

GitHub Actions runner pods were relying on Kubernetes’ default `HOSTNAME` behavior, which sets `HOSTNAME` to the pod hostname, typically the pod name. 

Some CI/CD workflows expected `HOSTNAME` to identify the Kubernetes node running the runner, so this drift caused runner jobs to see the pod name instead of the node name.

This PR explicitly injects `HOSTNAME` into CI/CD runner containers using the Kubernetes downward API:

- `HOSTNAME` now comes from `spec.nodeName`

The change is intentionally scoped to the runner templates and related test coverage, avoiding broader dispatcher/env handling changes.

## Testing

- ✅ Ran `go test ./job-manager/pkg/dispatcher`
- ✅ Verified generated runner envs preserve `POD_NAME -> metadata.name` and add `HOSTNAME -> spec.nodeName`
- ❌ Have not tested this in a real deployment