### PR TITLE
Add GitHub App auth for CICD runners

### DIFF
--- a/SaFE/apiserver/pkg/handlers/middleware/audit.go
+++ b/SaFE/apiserver/pkg/handlers/middleware/audit.go
@@ -321,6 +321,9 @@ func sanitizeBody(body string) string {
 		regexp.MustCompile(`"secret"\s*:\s*"[^"]*"`),
 		regexp.MustCompile(`"apiKey"\s*:\s*"[^"]*"`),
 		regexp.MustCompile(`"api_key"\s*:\s*"[^"]*"`),
+		regexp.MustCompile(`"privateKey"\s*:\s*"[^"]*"`),
+		regexp.MustCompile(`"private_key"\s*:\s*"[^"]*"`),
+		regexp.MustCompile(`"github_app_private_key"\s*:\s*"[^"]*"`),
 	}
 	for _, pattern := range jsonPatterns {
 		result = pattern.ReplaceAllString(result, `"[REDACTED]"`)
@@ -328,7 +331,7 @@ func sanitizeBody(body string) string {
 
 	// Form-urlencoded format: password=value or password=value&
 	formPatterns := []*regexp.Regexp{
-		regexp.MustCompile(`(^|&)(password|token|secret|apiKey|api_key)=[^&]*`),
+		regexp.MustCompile(`(^|&)(password|token|secret|apiKey|api_key|privateKey|private_key|github_app_private_key)=[^&]*`),
 	}
 	for _, pattern := range formPatterns {
 		result = pattern.ReplaceAllString(result, `$1$2=[REDACTED]`)

--- a/SaFE/apiserver/pkg/handlers/middleware/audit_test.go
+++ b/SaFE/apiserver/pkg/handlers/middleware/audit_test.go
@@ -85,6 +85,21 @@ func TestSanitizeBody(t *testing.T) {
 			expected: `{"name": "test", "[REDACTED]"}`,
 		},
 		{
+			name:     "privateKey_field",
+			input:    `{"githubAuth": {"type": "github_app", "appId": "123", "installationId": "456", "privateKey": "pem-data"}}`,
+			expected: `{"githubAuth": {"type": "github_app", "appId": "123", "installationId": "456", "[REDACTED]"}}`,
+		},
+		{
+			name:     "private_key_field",
+			input:    `{"name": "test", "private_key": "pem-data"}`,
+			expected: `{"name": "test", "[REDACTED]"}`,
+		},
+		{
+			name:     "github_app_private_key_field",
+			input:    `{"github_app_id": "123", "github_app_private_key": "pem-data"}`,
+			expected: `{"github_app_id": "123", "[REDACTED]"}`,
+		},
+		{
 			name:     "token_field",
 			input:    `{"userId": "123", "token": "jwt-token-here"}`,
 			expected: `{"userId": "123", "[REDACTED]"}`,
@@ -128,6 +143,11 @@ func TestSanitizeBody(t *testing.T) {
 			name:     "form_data_token",
 			input:    `userId=123&token=jwt-token&action=login`,
 			expected: `userId=123&token=[REDACTED]&action=login`,
+		},
+		{
+			name:     "form_data_privateKey",
+			input:    `type=github_app&privateKey=pem-data&appId=123`,
+			expected: `type=github_app&privateKey=[REDACTED]&appId=123`,
 		},
 	}
 

--- a/SaFE/apiserver/pkg/handlers/resources/cicd.go
+++ b/SaFE/apiserver/pkg/handlers/resources/cicd.go
@@ -7,6 +7,8 @@ package resources
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	commonconfig "github.com/AMD-AIG-AIMA/SAFE/common/pkg/config"
 	commonerrors "github.com/AMD-AIG-AIMA/SAFE/common/pkg/errors"
@@ -24,15 +26,23 @@ import (
 )
 
 const (
-	GithubPAT   = "GITHUB_PAT"
-	GitHubToken = "github_token"
+	GithubPAT               = "GITHUB_PAT"
+	GitHubAuthTypePAT       = "pat"
+	GitHubAuthTypeApp       = "github_app"
+	GitHubToken             = "github_token"
+	GitHubAppId             = "github_app_id"
+	GitHubAppInstallationId = "github_app_installation_id"
+	GitHubAppPrivateKey     = "github_app_private_key"
 )
 
 // createCICDSecret creates a new secret for CICD scaling runner workloads.
-// The secret contains the GitHub token encoded in base64 format.
+// The secret contains ARC-compatible GitHub authentication keys.
 // It returns the created secret or an error if the creation fails.
 func (h *Handler) createCICDSecret(ctx context.Context,
-	workload *v1.Workload, requestUser *v1.User, token string) (*corev1.Secret, error) {
+	workload *v1.Workload, requestUser *v1.User, auth *view.GitHubAuthRequest) (*corev1.Secret, error) {
+	if err := validateCICDGitHubAuth(auth); err != nil {
+		return nil, err
+	}
 	name := commonutils.GenerateName(v1.GetDisplayName(workload))
 	createSecretReq := &view.CreateSecretRequest{
 		Name:         name,
@@ -40,9 +50,7 @@ func (h *Handler) createCICDSecret(ctx context.Context,
 		Type:         v1.SecretGeneral,
 		Owner:        workload.Name,
 		Params: []map[view.SecretParam]string{
-			{
-				GitHubToken: stringutil.Base64Encode(token),
-			},
+			buildCICDSecretParams(auth),
 		},
 		Labels: map[string]string{
 			"secret.usage": "cicd",
@@ -57,26 +65,27 @@ func (h *Handler) createCICDSecret(ctx context.Context,
 }
 
 // updateCICDSecret updates the CICD secret by creating a new secret and deleting the old one.
-// This replaces the existing GitHub PAT secret with a new one for CICD scaling runner workloads.
+// This replaces the existing GitHub auth secret with a new one for CICD scaling runner workloads.
 func (h *Handler) updateCICDSecret(ctx context.Context,
-	workload *v1.Workload, requestUser *v1.User, newToken string) error {
-	// Get the old secret to compare tokens
+	workload *v1.Workload, requestUser *v1.User, auth *view.GitHubAuthRequest) error {
+	if err := validateCICDGitHubAuth(auth); err != nil {
+		return err
+	}
 	oldSecretId := v1.GetGithubSecretId(workload)
 	if oldSecretId != "" {
 		oldSecret, err := h.getAdminSecret(ctx, oldSecretId)
-		if err == nil && oldSecret != nil {
-			// Extract the old token from secret data
-			if oldTokenBytes, ok := oldSecret.Data[GitHubToken]; ok {
-				oldToken := string(oldTokenBytes)
-				if oldToken == newToken {
-					// Token hasn't changed, no need to update
-					return nil
-				}
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				oldSecretId = ""
+			} else {
+				return fmt.Errorf("failed to get existing CICD GitHub secret %q: %w", oldSecretId, err)
 			}
+		} else if cicdSecretDataMatchesAuth(oldSecret, auth) {
+			return nil
 		}
 	}
 
-	newSecret, err := h.createCICDSecret(ctx, workload, requestUser, newToken)
+	newSecret, err := h.createCICDSecret(ctx, workload, requestUser, auth)
 	if err != nil {
 		return err
 	}
@@ -107,20 +116,86 @@ func (h *Handler) cleanupCICDSecrets(ctx context.Context, workload *v1.Workload)
 }
 
 // generateCICDScaleRunnerSet configures a workload for CICD scaling runner set.
-// It validates CICD settings, creates a GitHub token secret.
-func (h *Handler) generateCICDScaleRunnerSet(ctx context.Context, workload *v1.Workload, requestUser *v1.User) error {
+// It validates CICD settings and creates a GitHub auth secret.
+func (h *Handler) generateCICDScaleRunnerSet(ctx context.Context, workload *v1.Workload,
+	requestUser *v1.User, auth *view.GitHubAuthRequest) error {
 	if !commonconfig.IsCICDEnable() {
 		return commonerrors.NewNotImplemented("the CICD is not enabled")
 	}
-	val, _ := workload.Spec.Env[GithubPAT]
-	if val == "" {
-		return commonerrors.NewBadRequest("the github pat(token) is empty")
+	auth = normalizeCICDGitHubAuth(auth, workload.Spec.Env)
+	if err := validateCICDGitHubAuth(auth); err != nil {
+		return err
 	}
-	secret, err := h.createCICDSecret(ctx, workload, requestUser, val)
+	secret, err := h.createCICDSecret(ctx, workload, requestUser, auth)
 	if err != nil {
 		return err
 	}
 	delete(workload.Spec.Env, GithubPAT)
 	v1.SetAnnotation(workload, v1.GithubSecretIdAnnotation, secret.Name)
 	return nil
+}
+
+func normalizeCICDGitHubAuth(auth *view.GitHubAuthRequest, env map[string]string) *view.GitHubAuthRequest {
+	if auth != nil {
+		return auth
+	}
+	if env == nil {
+		return nil
+	}
+	if token := strings.TrimSpace(env[GithubPAT]); token != "" {
+		return &view.GitHubAuthRequest{
+			Type:  GitHubAuthTypePAT,
+			Token: token,
+		}
+	}
+	return nil
+}
+
+func validateCICDGitHubAuth(auth *view.GitHubAuthRequest) error {
+	if auth == nil {
+		return commonerrors.NewBadRequest("the github authentication is empty")
+	}
+	switch strings.TrimSpace(auth.Type) {
+	case GitHubAuthTypeApp:
+		if strings.TrimSpace(auth.AppId) == "" ||
+			strings.TrimSpace(auth.InstallationId) == "" ||
+			strings.TrimSpace(auth.PrivateKey) == "" {
+			return commonerrors.NewBadRequest("github app authentication requires appId, installationId, and privateKey")
+		}
+	case GitHubAuthTypePAT:
+		if strings.TrimSpace(auth.Token) == "" {
+			return commonerrors.NewBadRequest("the github pat(token) is empty")
+		}
+	default:
+		return commonerrors.NewBadRequest("unsupported github authentication type")
+	}
+	return nil
+}
+
+func buildCICDSecretParams(auth *view.GitHubAuthRequest) map[view.SecretParam]string {
+	switch strings.TrimSpace(auth.Type) {
+	case GitHubAuthTypeApp:
+		return map[view.SecretParam]string{
+			GitHubAppId:             stringutil.Base64Encode(strings.TrimSpace(auth.AppId)),
+			GitHubAppInstallationId: stringutil.Base64Encode(strings.TrimSpace(auth.InstallationId)),
+			GitHubAppPrivateKey:     stringutil.Base64Encode(strings.TrimSpace(auth.PrivateKey)),
+		}
+	default:
+		return map[view.SecretParam]string{
+			GitHubToken: stringutil.Base64Encode(strings.TrimSpace(auth.Token)),
+		}
+	}
+}
+
+// cicdSecretDataMatchesAuth is an idempotency check that avoids rotating
+// credentials when the submitted values already match the existing ARC secret.
+func cicdSecretDataMatchesAuth(secret *corev1.Secret, auth *view.GitHubAuthRequest) bool {
+	switch strings.TrimSpace(auth.Type) {
+	case GitHubAuthTypeApp:
+		return string(secret.Data[GitHubAppId]) == strings.TrimSpace(auth.AppId) &&
+			string(secret.Data[GitHubAppInstallationId]) == strings.TrimSpace(auth.InstallationId) &&
+			string(secret.Data[GitHubAppPrivateKey]) == strings.TrimSpace(auth.PrivateKey)
+	default:
+		return string(secret.Data[GitHubToken]) == strings.TrimSpace(auth.Token)
+	}
 }

--- a/SaFE/apiserver/pkg/handlers/resources/cicd_test.go
+++ b/SaFE/apiserver/pkg/handlers/resources/cicd_test.go
@@ -7,6 +7,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
@@ -24,9 +25,26 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	k8stesting "k8s.io/client-go/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlruntimefake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+func patAuth(token string) *view.GitHubAuthRequest {
+	return &view.GitHubAuthRequest{
+		Type:  GitHubAuthTypePAT,
+		Token: token,
+	}
+}
+
+func githubAppAuth(appId, installationId, privateKey string) *view.GitHubAuthRequest {
+	return &view.GitHubAuthRequest{
+		Type:           GitHubAuthTypeApp,
+		AppId:          appId,
+		InstallationId: installationId,
+		PrivateKey:     privateKey,
+	}
+}
 
 // Test_createCICDSecret tests the createCICDSecret function with token encoding
 func Test_createCICDSecret(t *testing.T) {
@@ -105,7 +123,7 @@ func Test_updateCICDSecret_TokenUnchanged(t *testing.T) {
 	}
 
 	// Call updateCICDSecret with same token
-	err := h.updateCICDSecret(ctx, workload, user, oldToken)
+	err := h.updateCICDSecret(ctx, workload, user, patAuth(oldToken))
 
 	// Should return nil without error (optimization kicks in)
 	assert.NilError(t, err)
@@ -168,7 +186,7 @@ func Test_updateCICDSecret_TokenChanged(t *testing.T) {
 	}
 
 	// Call updateCICDSecret with new token
-	err := h.updateCICDSecret(ctx, workload, user, newToken)
+	err := h.updateCICDSecret(ctx, workload, user, patAuth(newToken))
 
 	// Should succeed
 	assert.NilError(t, err)
@@ -215,7 +233,7 @@ func Test_createCICDSecret_Success(t *testing.T) {
 	}
 
 	// Call createCICDSecret
-	secret, err := h.createCICDSecret(ctx, workload, user, token)
+	secret, err := h.createCICDSecret(ctx, workload, user, patAuth(token))
 
 	// Should succeed
 	assert.NilError(t, err)
@@ -320,6 +338,83 @@ func Test_updateWorkload_GithubPATHandling(t *testing.T) {
 	assert.Equal(t, string(newSecret.Data[GitHubToken]), newToken, "new secret should contain new token")
 
 	// Verify old secret was deleted (using clientSet, not controller-runtime client)
+	_, err = fakeClientSet.CoreV1().Secrets(common.PrimusSafeNamespace).Get(ctx, oldSecretName, metav1.GetOptions{})
+	assert.Assert(t, apierrors.IsNotFound(err), "old secret should be deleted")
+}
+
+func Test_updateWorkload_GitHubAppAuthHandling(t *testing.T) {
+	ctx := context.Background()
+	clusterId := "test-cluster"
+	workspaceId := "test-workspace"
+
+	workload := genMockWorkload(clusterId, workspaceId)
+	workload.Spec.Kind = common.CICDScaleRunnerSetKind
+	workload.Spec.Env = map[string]string{
+		"EXISTING_VAR": "existing_value",
+	}
+	user := genMockUser()
+	role := genMockRole()
+
+	oldSecretName := "old-secret-id"
+	oldSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      oldSecretName,
+			Namespace: common.PrimusSafeNamespace,
+			Labels: map[string]string{
+				v1.SecretTypeLabel: string(v1.SecretGeneral),
+				v1.UserIdLabel:     user.Name,
+				v1.OwnerLabel:      workload.Name,
+			},
+		},
+		Data: map[string][]byte{
+			GitHubToken: []byte("old_token_123"),
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
+	v1.SetAnnotation(workload, v1.GithubSecretIdAnnotation, oldSecretName)
+
+	testScheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(testScheme))
+	utilruntime.Must(scheme.AddToScheme(testScheme))
+
+	fakeCtrlClient := ctrlruntimefake.NewClientBuilder().
+		WithObjects(workload, user, role).
+		WithScheme(testScheme).
+		Build()
+
+	fakeClientSet := k8sfake.NewSimpleClientset(oldSecret)
+
+	h := Handler{
+		Client:           fakeCtrlClient,
+		clientSet:        fakeClientSet,
+		accessController: authority.NewAccessController(fakeCtrlClient),
+	}
+
+	newAuth := githubAppAuth("12345", "67890", "private-key")
+	req := &view.PatchWorkloadRequest{
+		GitHubAuth: newAuth,
+	}
+
+	err := h.updateWorkload(ctx, workload, user, req)
+
+	assert.NilError(t, err, "updateWorkload should succeed")
+
+	updatedWorkload := &v1.Workload{}
+	err = fakeCtrlClient.Get(ctx, client.ObjectKey{Name: workload.Name}, updatedWorkload)
+	assert.NilError(t, err, "should retrieve updated workload")
+
+	newSecretId := v1.GetGithubSecretId(updatedWorkload)
+	assert.Assert(t, newSecretId != "", "New secret ID should be set")
+	assert.Assert(t, newSecretId != oldSecretName, "New secret ID should be different from old")
+
+	newSecret, err := fakeClientSet.CoreV1().Secrets(common.PrimusSafeNamespace).Get(ctx, newSecretId, metav1.GetOptions{})
+	assert.NilError(t, err, "new secret should be created")
+	assert.Equal(t, string(newSecret.Data[GitHubAppId]), newAuth.AppId)
+	assert.Equal(t, string(newSecret.Data[GitHubAppInstallationId]), newAuth.InstallationId)
+	assert.Equal(t, string(newSecret.Data[GitHubAppPrivateKey]), newAuth.PrivateKey)
+	_, hasPAT := newSecret.Data[GitHubToken]
+	assert.Assert(t, !hasPAT, "GitHub App update should not contain PAT key")
+
 	_, err = fakeClientSet.CoreV1().Secrets(common.PrimusSafeNamespace).Get(ctx, oldSecretName, metav1.GetOptions{})
 	assert.Assert(t, apierrors.IsNotFound(err), "old secret should be deleted")
 }
@@ -449,7 +544,7 @@ func Test_updateCICDSecret_NoOldSecret(t *testing.T) {
 	}
 
 	// Call updateCICDSecret with new token
-	err := h.updateCICDSecret(ctx, workload, user, newToken)
+	err := h.updateCICDSecret(ctx, workload, user, patAuth(newToken))
 
 	// Should succeed
 	assert.NilError(t, err)
@@ -462,6 +557,70 @@ func Test_updateCICDSecret_NoOldSecret(t *testing.T) {
 	newSecret, err := fakeClientSet.CoreV1().Secrets(common.PrimusSafeNamespace).Get(ctx, newSecretId, metav1.GetOptions{})
 	assert.NilError(t, err, "New secret should exist")
 	assert.Equal(t, string(newSecret.Data[GitHubToken]), newToken, "New secret should contain new token")
+}
+
+func Test_updateCICDSecret_MissingAnnotatedOldSecret(t *testing.T) {
+	ctx := context.Background()
+	clusterId := "test-cluster"
+	workspaceId := "test-workspace"
+
+	workload := genMockWorkload(clusterId, workspaceId)
+	user := genMockUser()
+	role := genMockRole()
+	newToken := "new_token_123"
+	v1.SetAnnotation(workload, v1.GithubSecretIdAnnotation, "missing-secret")
+
+	fakeCtrlClient := ctrlruntimefake.NewClientBuilder().
+		WithObjects(workload, user, role).
+		WithScheme(scheme.Scheme).
+		Build()
+	fakeClientSet := k8sfake.NewSimpleClientset()
+
+	h := Handler{
+		Client:           fakeCtrlClient,
+		clientSet:        fakeClientSet,
+		accessController: authority.NewAccessController(fakeCtrlClient),
+	}
+
+	err := h.updateCICDSecret(ctx, workload, user, patAuth(newToken))
+	assert.NilError(t, err)
+
+	newSecretId := v1.GetGithubSecretId(workload)
+	assert.Assert(t, newSecretId != "", "New secret ID should be set")
+	assert.Assert(t, newSecretId != "missing-secret", "New secret ID should replace stale annotation")
+	newSecret, err := fakeClientSet.CoreV1().Secrets(common.PrimusSafeNamespace).Get(ctx, newSecretId, metav1.GetOptions{})
+	assert.NilError(t, err, "New secret should exist")
+	assert.Equal(t, string(newSecret.Data[GitHubToken]), newToken, "New secret should contain new token")
+}
+
+func Test_updateCICDSecret_OldSecretLookupError(t *testing.T) {
+	ctx := context.Background()
+	clusterId := "test-cluster"
+	workspaceId := "test-workspace"
+
+	workload := genMockWorkload(clusterId, workspaceId)
+	user := genMockUser()
+	role := genMockRole()
+	v1.SetAnnotation(workload, v1.GithubSecretIdAnnotation, "old-secret-id")
+
+	fakeCtrlClient := ctrlruntimefake.NewClientBuilder().
+		WithObjects(workload, user, role).
+		WithScheme(scheme.Scheme).
+		Build()
+	fakeClientSet := k8sfake.NewSimpleClientset()
+	fakeClientSet.Fake.PrependReactor("get", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("api unavailable")
+	})
+
+	h := Handler{
+		Client:           fakeCtrlClient,
+		clientSet:        fakeClientSet,
+		accessController: authority.NewAccessController(fakeCtrlClient),
+	}
+
+	err := h.updateCICDSecret(ctx, workload, user, patAuth("new_token_123"))
+	assert.ErrorContains(t, err, "failed to get existing CICD GitHub secret")
+	assert.Equal(t, v1.GetGithubSecretId(workload), "old-secret-id")
 }
 
 // Test_generateCICDScaleRunnerSet tests generating CICD scale runner set configuration
@@ -497,7 +656,7 @@ func Test_generateCICDScaleRunnerSet(t *testing.T) {
 	}
 
 	// Call generateCICDScaleRunnerSet
-	err := h.generateCICDScaleRunnerSet(ctx, workload, user)
+	err := h.generateCICDScaleRunnerSet(ctx, workload, user, nil)
 
 	// Should succeed
 	assert.NilError(t, err)
@@ -515,6 +674,53 @@ func Test_generateCICDScaleRunnerSet(t *testing.T) {
 	secret, err := fakeClientSet.CoreV1().Secrets(common.PrimusSafeNamespace).Get(ctx, secretId, metav1.GetOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, secret != nil, "Secret should be created")
+}
+
+func Test_generateCICDScaleRunnerSet_GitHubApp(t *testing.T) {
+	commonconfig.SetValue("cicd.enable", "true")
+	defer commonconfig.SetValue("cicd.enable", "")
+
+	ctx := context.Background()
+	clusterId := "test-cluster"
+	workspaceId := "test-workspace"
+	auth := githubAppAuth("12345", "67890", "private-key")
+
+	workload := genMockWorkload(clusterId, workspaceId)
+	workload.Spec.Env = map[string]string{
+		"OTHER_VAR": "other_value",
+	}
+
+	user := genMockUser()
+	role := genMockRole()
+
+	fakeCtrlClient := ctrlruntimefake.NewClientBuilder().
+		WithObjects(workload, user, role).
+		WithScheme(scheme.Scheme).
+		Build()
+
+	fakeClientSet := k8sfake.NewSimpleClientset()
+
+	h := Handler{
+		Client:           fakeCtrlClient,
+		clientSet:        fakeClientSet,
+		accessController: authority.NewAccessController(fakeCtrlClient),
+	}
+
+	err := h.generateCICDScaleRunnerSet(ctx, workload, user, auth)
+
+	assert.NilError(t, err)
+	assert.Equal(t, workload.Spec.Env["OTHER_VAR"], "other_value", "Other env vars should remain")
+
+	secretId := v1.GetGithubSecretId(workload)
+	assert.Assert(t, secretId != "", "Secret ID annotation should be set")
+
+	secret, err := fakeClientSet.CoreV1().Secrets(common.PrimusSafeNamespace).Get(ctx, secretId, metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, string(secret.Data[GitHubAppId]), auth.AppId)
+	assert.Equal(t, string(secret.Data[GitHubAppInstallationId]), auth.InstallationId)
+	assert.Equal(t, string(secret.Data[GitHubAppPrivateKey]), auth.PrivateKey)
+	_, hasPAT := secret.Data[GitHubToken]
+	assert.Assert(t, !hasPAT, "GitHub App secret should not contain PAT key")
 }
 
 // Test_cleanupCICDSecrets_CICDWorkload tests cleanup deletes secret for CICD workload

--- a/SaFE/apiserver/pkg/handlers/resources/view/workload_view.go
+++ b/SaFE/apiserver/pkg/handlers/resources/view/workload_view.go
@@ -14,6 +14,9 @@ import (
 
 type CreateWorkloadRequest struct {
 	v1.WorkloadSpec
+	// GitHubAuth carries CICD runner authentication material. It is used to create
+	// the ARC githubConfigSecret and must not be persisted on the workload env.
+	GitHubAuth *GitHubAuthRequest `json:"githubAuth,omitempty"`
 	// SpecifiedNodes defines the list of node names where the workload should run.
 	SpecifiedNodes []string `json:"specifiedNodes,omitempty"`
 	// NodesAffinity controls how strictly the workload adheres to SpecifiedNodes.
@@ -50,6 +53,14 @@ type CreateWorkloadRequest struct {
 	ForceHostNetwork *bool `json:"forceHostNetwork,omitempty"`
 	// The owner workload ID
 	OwnerId string `json:"ownerId,omitempty"`
+}
+
+type GitHubAuthRequest struct {
+	Type           string `json:"type,omitempty"`
+	Token          string `json:"token,omitempty"`
+	AppId          string `json:"appId,omitempty"`
+	InstallationId string `json:"installationId,omitempty"`
+	PrivateKey     string `json:"privateKey,omitempty"`
 }
 
 func (req *CreateWorkloadRequest) GetNodesAffinity() string {
@@ -224,6 +235,8 @@ type WorkloadPodWrapper struct {
 }
 
 type PatchWorkloadRequest struct {
+	// GitHubAuth carries updated CICD runner authentication material.
+	GitHubAuth *GitHubAuthRequest `json:"githubAuth,omitempty"`
 	// Workload scheduling Priority (0-2), default 0
 	Priority *int `json:"priority,omitempty"`
 	// Workload resource requirements

--- a/SaFE/apiserver/pkg/handlers/resources/workload.go
+++ b/SaFE/apiserver/pkg/handlers/resources/workload.go
@@ -533,7 +533,7 @@ func (h *Handler) patchWorkload(c *gin.Context) (interface{}, error) {
 		return nil, err
 	}
 	klog.Infof("update workload, name: %s, request: %s, request.user: %s",
-		name, string(jsonutils.MarshalSilently(*req)), c.GetString(common.UserId))
+		name, string(jsonutils.MarshalSilently(sanitizePatchWorkloadRequestForLog(req))), c.GetString(common.UserId))
 	return nil, nil
 }
 
@@ -567,8 +567,7 @@ func (h *Handler) authWorkloadUpdate(c *gin.Context, adminWorkload *v1.Workload,
 	return nil
 }
 
-// updateWorkload updates the workload in the system and handles CICD secret updates
-// if a new GitHub PAT token is provided in the request
+// updateWorkload updates the workload in the system and handles CICD auth secret updates.
 func (h *Handler) updateWorkload(ctx context.Context,
 	adminWorkload *v1.Workload, requestUser *v1.User, req *view.PatchWorkloadRequest) error {
 	err := h.Update(ctx, adminWorkload)
@@ -576,10 +575,10 @@ func (h *Handler) updateWorkload(ctx context.Context,
 		return err
 	}
 
-	if req.Env != nil && commonworkload.IsCICDScalingRunnerSet(adminWorkload) {
-		if newToken := (*req.Env)[GithubPAT]; newToken != "" {
+	if commonworkload.IsCICDScalingRunnerSet(adminWorkload) {
+		if auth := normalizeCICDGitHubAuth(req.GitHubAuth, requestEnv(req)); auth != nil {
 			patch := client.MergeFrom(adminWorkload.DeepCopy())
-			if err = h.updateCICDSecret(ctx, adminWorkload, requestUser, newToken); err != nil {
+			if err = h.updateCICDSecret(ctx, adminWorkload, requestUser, auth); err != nil {
 				klog.ErrorS(err, "failed to update cicd secret")
 				return err
 			}
@@ -815,7 +814,7 @@ func (h *Handler) generateWorkload(ctx context.Context,
 		}
 	}
 	if commonworkload.IsCICDScalingRunnerSet(workload) {
-		if err = h.generateCICDScaleRunnerSet(ctx, workload, requestUser); err != nil {
+		if err = h.generateCICDScaleRunnerSet(ctx, workload, requestUser, req.GitHubAuth); err != nil {
 			return nil, err
 		}
 	}
@@ -1207,6 +1206,31 @@ func applyWorkloadPatch(adminWorkload *v1.Workload, req *view.PatchWorkloadReque
 		adminWorkload.Spec.Service = req.Service
 	}
 	return nil
+}
+
+func requestEnv(req *view.PatchWorkloadRequest) map[string]string {
+	if req.Env == nil {
+		return nil
+	}
+	return *req.Env
+}
+
+func sanitizePatchWorkloadRequestForLog(req *view.PatchWorkloadRequest) view.PatchWorkloadRequest {
+	if req == nil {
+		return view.PatchWorkloadRequest{}
+	}
+	sanitized := *req
+	if sanitized.GitHubAuth != nil {
+		auth := *sanitized.GitHubAuth
+		auth.Token = ""
+		auth.PrivateKey = ""
+		sanitized.GitHubAuth = &auth
+	}
+	if sanitized.Env != nil {
+		env := maputil.Copy(*sanitized.Env, GithubPAT)
+		sanitized.Env = &env
+	}
+	return sanitized
 }
 
 // cvtDBWorkloadToResponseItem converts a database workload record to a response item format.

--- a/SaFE/resource-manager/pkg/github/credential_resolver.go
+++ b/SaFE/resource-manager/pkg/github/credential_resolver.go
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+package github
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
+	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/common"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	gitHubAuthTypePAT = "pat"
+	gitHubAuthTypeApp = "github_app"
+
+	gitHubTokenKey             = "github_token"
+	gitHubAppIDKey             = "github_app_id"
+	gitHubAppInstallationIDKey = "github_app_installation_id"
+	gitHubAppPrivateKeyKey     = "github_app_private_key"
+)
+
+var gitHubPATSecretKeys = []string{gitHubTokenKey, "token", "GITHUB_TOKEN"}
+
+type GitHubCredential struct {
+	Type           string
+	Token          string
+	AppID          string
+	InstallationID string
+	PrivateKey     string
+}
+
+type GitHubCredentialResolver struct {
+	client client.Client
+}
+
+func NewGitHubCredentialResolver(client client.Client) *GitHubCredentialResolver {
+	return &GitHubCredentialResolver{client: client}
+}
+
+func (r *GitHubCredentialResolver) Resolve(ctx context.Context, run *WorkflowRunRecord) (*GitHubCredential, error) {
+	if r == nil || r.client == nil {
+		return nil, fmt.Errorf("github credential resolver is not configured")
+	}
+	if run == nil || strings.TrimSpace(run.WorkloadID) == "" {
+		return nil, fmt.Errorf("workflow run has no workload id")
+	}
+
+	workload := &v1.Workload{}
+	if err := r.client.Get(ctx, client.ObjectKey{Name: run.WorkloadID}, workload); err != nil {
+		return nil, fmt.Errorf("get workload %q: %w", run.WorkloadID, err)
+	}
+
+	secretName := strings.TrimSpace(v1.GetGithubSecretId(workload))
+	if secretName == "" {
+		return nil, fmt.Errorf("workload %q has no github secret annotation", run.WorkloadID)
+	}
+
+	secret := &corev1.Secret{}
+	if err := r.client.Get(ctx, client.ObjectKey{Namespace: common.PrimusSafeNamespace, Name: secretName}, secret); err != nil {
+		return nil, fmt.Errorf("get github secret %q: %w", secretName, err)
+	}
+
+	return credentialFromSecret(secret)
+}
+
+func credentialFromSecret(secret *corev1.Secret) (*GitHubCredential, error) {
+	for _, key := range gitHubPATSecretKeys {
+		if token := strings.TrimSpace(string(secret.Data[key])); token != "" {
+			return &GitHubCredential{
+				Type:  gitHubAuthTypePAT,
+				Token: token,
+			}, nil
+		}
+	}
+
+	appID := strings.TrimSpace(string(secret.Data[gitHubAppIDKey]))
+	installationID := strings.TrimSpace(string(secret.Data[gitHubAppInstallationIDKey]))
+	privateKey := strings.TrimSpace(string(secret.Data[gitHubAppPrivateKeyKey]))
+	if appID != "" && installationID != "" && privateKey != "" {
+		return &GitHubCredential{
+			Type:           gitHubAuthTypeApp,
+			AppID:          appID,
+			InstallationID: installationID,
+			PrivateKey:     privateKey,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("github secret %q does not contain a supported credential", secret.Name)
+}

--- a/SaFE/resource-manager/pkg/github/credential_resolver_test.go
+++ b/SaFE/resource-manager/pkg/github/credential_resolver_test.go
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+package github
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
+	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/common"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestGitHubCredentialResolverResolvePATSecret(t *testing.T) {
+	resolver := newTestCredentialResolver(t,
+		testWorkload("runner-workload", "github-secret"),
+		testSecret("github-secret", map[string][]byte{
+			gitHubTokenKey: []byte("pat-token"),
+		}),
+	)
+
+	credential, err := resolver.Resolve(context.Background(), &WorkflowRunRecord{WorkloadID: "runner-workload"})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if credential.Type != gitHubAuthTypePAT || credential.Token != "pat-token" {
+		t.Fatalf("Resolve() credential = %#v, want PAT token", credential)
+	}
+}
+
+func TestGitHubCredentialResolverResolveAppSecret(t *testing.T) {
+	resolver := newTestCredentialResolver(t,
+		testWorkload("runner-workload", "github-app-secret"),
+		testSecret("github-app-secret", map[string][]byte{
+			gitHubAppIDKey:             []byte("123"),
+			gitHubAppInstallationIDKey: []byte("456"),
+			gitHubAppPrivateKeyKey:     []byte("private-key"),
+		}),
+	)
+
+	credential, err := resolver.Resolve(context.Background(), &WorkflowRunRecord{WorkloadID: "runner-workload"})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if credential.Type != gitHubAuthTypeApp ||
+		credential.AppID != "123" ||
+		credential.InstallationID != "456" ||
+		credential.PrivateKey != "private-key" {
+		t.Fatalf("Resolve() credential = %#v, want GitHub App credential", credential)
+	}
+}
+
+func TestGitHubCredentialResolverMissingAnnotationDoesNotUseArbitrarySecret(t *testing.T) {
+	resolver := newTestCredentialResolver(t,
+		&v1.Workload{
+			ObjectMeta: metav1.ObjectMeta{Name: "runner-workload"},
+		},
+		testSecret("unrelated-secret", map[string][]byte{
+			gitHubTokenKey: []byte("wrong-token"),
+		}),
+	)
+
+	_, err := resolver.Resolve(context.Background(), &WorkflowRunRecord{WorkloadID: "runner-workload"})
+	if err == nil {
+		t.Fatal("Resolve() error = nil, want missing annotation error")
+	}
+	if !strings.Contains(err.Error(), "no github secret annotation") {
+		t.Fatalf("Resolve() error = %v, want missing annotation error", err)
+	}
+}
+
+func TestGitHubTokenSourcePAT(t *testing.T) {
+	token, err := NewGitHubTokenSource().Token(context.Background(), &GitHubCredential{
+		Type:  gitHubAuthTypePAT,
+		Token: "pat-token",
+	})
+	if err != nil {
+		t.Fatalf("Token() error = %v", err)
+	}
+	if token != "pat-token" {
+		t.Fatalf("Token() = %q, want pat-token", token)
+	}
+}
+
+func TestGitHubTokenSourceGitHubApp(t *testing.T) {
+	privateKey := testRSAPrivateKeyPEM(t)
+	requestSeen := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestSeen = true
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/app/installations/456/access_tokens" {
+			t.Fatalf("path = %s, want installation token path", r.URL.Path)
+		}
+		if auth := r.Header.Get("Authorization"); !strings.HasPrefix(auth, "Bearer ") {
+			t.Fatalf("Authorization = %q, want bearer JWT", auth)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"token":"installation-token"}`))
+	}))
+	defer server.Close()
+
+	source := NewGitHubTokenSource()
+	source.baseURL = server.URL
+	source.httpClient = server.Client()
+	source.now = func() time.Time {
+		return time.Unix(1700000000, 0)
+	}
+
+	token, err := source.Token(context.Background(), &GitHubCredential{
+		Type:           gitHubAuthTypeApp,
+		AppID:          "123",
+		InstallationID: "456",
+		PrivateKey:     privateKey,
+	})
+	if err != nil {
+		t.Fatalf("Token() error = %v", err)
+	}
+	if !requestSeen {
+		t.Fatal("Token() did not call installation token endpoint")
+	}
+	if token != "installation-token" {
+		t.Fatalf("Token() = %q, want installation-token", token)
+	}
+}
+
+func newTestCredentialResolver(t *testing.T, objects ...client.Object) *GitHubCredentialResolver {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("corev1.AddToScheme() error = %v", err)
+	}
+	if err := v1.AddToScheme(scheme); err != nil {
+		t.Fatalf("v1.AddToScheme() error = %v", err)
+	}
+
+	return NewGitHubCredentialResolver(fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		Build())
+}
+
+func testWorkload(name, secretName string) *v1.Workload {
+	return &v1.Workload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Annotations: map[string]string{
+				v1.GithubSecretIdAnnotation: secretName,
+			},
+		},
+	}
+}
+
+func testSecret(name string, data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: common.PrimusSafeNamespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: data,
+	}
+}
+
+func testRSAPrivateKeyPEM(t *testing.T) string {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey() error = %v", err)
+	}
+	block := &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}
+	return string(pem.EncodeToMemory(block))
+}

--- a/SaFE/resource-manager/pkg/github/sync_job.go
+++ b/SaFE/resource-manager/pkg/github/sync_job.go
@@ -10,22 +10,21 @@ import (
 	"encoding/json"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // SyncJob fetches GitHub API data for unsynced workflow runs and stores it in SaFE DB.
 // It runs periodically in job-manager.
 type SyncJob struct {
-	store       *Store
-	k8sClients  map[string]kubernetes.Interface
-	batchSize   int
-	interval    time.Duration
+	store              *Store
+	credentialResolver *GitHubCredentialResolver
+	tokenSource        gitHubTokenProvider
+	batchSize          int
+	interval           time.Duration
 }
 
-func NewSyncJob(store *Store, batchSize int, interval time.Duration) *SyncJob {
+func NewSyncJob(store *Store, k8sClient client.Client, batchSize int, interval time.Duration) *SyncJob {
 	if batchSize <= 0 {
 		batchSize = 20
 	}
@@ -33,15 +32,12 @@ func NewSyncJob(store *Store, batchSize int, interval time.Duration) *SyncJob {
 		interval = 30 * time.Second
 	}
 	return &SyncJob{
-		store:      store,
-		k8sClients: make(map[string]kubernetes.Interface),
-		batchSize:  batchSize,
-		interval:   interval,
+		store:              store,
+		credentialResolver: NewGitHubCredentialResolver(k8sClient),
+		tokenSource:        NewGitHubTokenSource(),
+		batchSize:          batchSize,
+		interval:           interval,
 	}
-}
-
-func (j *SyncJob) RegisterK8sClient(cluster string, client kubernetes.Interface) {
-	j.k8sClients[cluster] = client
 }
 
 func (j *SyncJob) Start(ctx context.Context) {
@@ -78,7 +74,7 @@ func (j *SyncJob) syncBatch(ctx context.Context) {
 			continue
 		}
 
-		token := j.getGitHubToken(ctx, run.Cluster, run.GithubOwner, run.GithubRepo)
+		token := j.getGitHubToken(ctx, &run)
 		client := NewGitHubClient(token)
 
 		synced := true
@@ -170,27 +166,23 @@ func (j *SyncJob) syncJobs(ctx context.Context, client *GitHubClient, run *Workf
 	return nil
 }
 
-// getGitHubToken retrieves the GitHub token from K8s Secret in the target cluster.
-func (j *SyncJob) getGitHubToken(ctx context.Context, cluster, owner, repo string) string {
-	k8sClient, ok := j.k8sClients[cluster]
-	if !ok {
-		return ""
+// getGitHubToken resolves the token for the workload that produced this GitHub run.
+func (j *SyncJob) getGitHubToken(ctx context.Context, run *WorkflowRunRecord) string {
+	workloadID := ""
+	if run != nil {
+		workloadID = run.WorkloadID
 	}
 
-	secrets, err := k8sClient.CoreV1().Secrets("").List(ctx, metav1.ListOptions{})
+	credential, err := j.credentialResolver.Resolve(ctx, run)
 	if err != nil {
+		klog.V(1).Infof("[github-sync] resolve github credential for workload %s: %v", workloadID, err)
 		return ""
 	}
 
-	for _, secret := range secrets.Items {
-		if secret.Type != corev1.SecretTypeOpaque {
-			continue
-		}
-		for _, key := range []string{"github_token", "token", "GITHUB_TOKEN"} {
-			if v, ok := secret.Data[key]; ok {
-				return string(v)
-			}
-		}
+	token, err := j.tokenSource.Token(ctx, credential)
+	if err != nil {
+		klog.V(1).Infof("[github-sync] create github token for workload %s: %v", workloadID, err)
+		return ""
 	}
-	return ""
+	return token
 }

--- a/SaFE/resource-manager/pkg/github/token_source.go
+++ b/SaFE/resource-manager/pkg/github/token_source.go
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+package github
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const gitHubAPIBaseURL = "https://api.github.com"
+
+type gitHubTokenProvider interface {
+	Token(ctx context.Context, credential *GitHubCredential) (string, error)
+}
+
+type GitHubTokenSource struct {
+	baseURL    string
+	httpClient *http.Client
+	now        func() time.Time
+}
+
+func NewGitHubTokenSource() *GitHubTokenSource {
+	return &GitHubTokenSource{
+		baseURL:    gitHubAPIBaseURL,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		now:        time.Now,
+	}
+}
+
+func (s *GitHubTokenSource) Token(ctx context.Context, credential *GitHubCredential) (string, error) {
+	if credential == nil {
+		return "", fmt.Errorf("github credential is nil")
+	}
+
+	switch credential.Type {
+	case gitHubAuthTypePAT:
+		if strings.TrimSpace(credential.Token) == "" {
+			return "", fmt.Errorf("github PAT credential is empty")
+		}
+		return strings.TrimSpace(credential.Token), nil
+	case gitHubAuthTypeApp:
+		return s.createInstallationToken(ctx, credential)
+	default:
+		return "", fmt.Errorf("unsupported github credential type %q", credential.Type)
+	}
+}
+
+func (s *GitHubTokenSource) createInstallationToken(ctx context.Context, credential *GitHubCredential) (string, error) {
+	if strings.TrimSpace(credential.AppID) == "" ||
+		strings.TrimSpace(credential.InstallationID) == "" ||
+		strings.TrimSpace(credential.PrivateKey) == "" {
+		return "", fmt.Errorf("github app credential is incomplete")
+	}
+
+	jwt, err := s.createAppJWT(credential)
+	if err != nil {
+		return "", err
+	}
+
+	url := strings.TrimRight(s.baseURL, "/") + "/app/installations/" + credential.InstallationID + "/access_tokens"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(nil))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("Authorization", "Bearer "+jwt)
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("github app installation token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("github app installation token: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var result struct {
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", fmt.Errorf("github app installation token response: %w", err)
+	}
+	if strings.TrimSpace(result.Token) == "" {
+		return "", fmt.Errorf("github app installation token response has no token")
+	}
+	return strings.TrimSpace(result.Token), nil
+}
+
+func (s *GitHubTokenSource) createAppJWT(credential *GitHubCredential) (string, error) {
+	key, err := parseRSAPrivateKey(credential.PrivateKey)
+	if err != nil {
+		return "", err
+	}
+
+	now := s.now()
+	claims := map[string]interface{}{
+		"iat": now.Add(-time.Minute).Unix(),
+		"exp": now.Add(10 * time.Minute).Unix(),
+		"iss": strings.TrimSpace(credential.AppID),
+	}
+	header := map[string]string{
+		"alg": "RS256",
+		"typ": "JWT",
+	}
+
+	headerJSON, err := json.Marshal(header)
+	if err != nil {
+		return "", err
+	}
+	claimsJSON, err := json.Marshal(claims)
+	if err != nil {
+		return "", err
+	}
+
+	encodedHeader := base64.RawURLEncoding.EncodeToString(headerJSON)
+	encodedClaims := base64.RawURLEncoding.EncodeToString(claimsJSON)
+	signingInput := encodedHeader + "." + encodedClaims
+
+	hashed := sha256.Sum256([]byte(signingInput))
+	signature, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, hashed[:])
+	if err != nil {
+		return "", fmt.Errorf("sign github app jwt: %w", err)
+	}
+
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(signature), nil
+}
+
+func parseRSAPrivateKey(raw string) (*rsa.PrivateKey, error) {
+	pemText := strings.TrimSpace(raw)
+	if !strings.Contains(pemText, "\n") {
+		pemText = strings.ReplaceAll(pemText, `\n`, "\n")
+	}
+
+	block, _ := pem.Decode([]byte(pemText))
+	if block == nil {
+		return nil, fmt.Errorf("decode github app private key PEM")
+	}
+
+	if key, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return key, nil
+	}
+
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse github app private key: %w", err)
+	}
+	key, ok := parsed.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("github app private key is not RSA")
+	}
+	return key, nil
+}

--- a/SaFE/resource-manager/pkg/resource/github_workflow_controller.go
+++ b/SaFE/resource-manager/pkg/resource/github_workflow_controller.go
@@ -54,7 +54,7 @@ func SetupGitHubWorkflowController(mgr manager.Manager) error {
 	store := githubpkg.NewStore(sqlDB)
 	tracker := githubpkg.NewWorkflowTracker(store)
 
-	syncJob := githubpkg.NewSyncJob(store, 20, 30*time.Second)
+	syncJob := githubpkg.NewSyncJob(store, mgr.GetClient(), 20, 30*time.Second)
 	go syncJob.Start(context.Background())
 
 	r := &GitHubWorkflowReconciler{

--- a/Web/apps/safe/src/pages/CICD/Components/AddDialog.vue
+++ b/Web/apps/safe/src/pages/CICD/Components/AddDialog.vue
@@ -38,7 +38,12 @@
             <el-input v-model="form.description" :rows="2" type="textarea" />
           </el-form-item>
           <el-form-item label="entryPoint" prop="entryPoint">
-            <el-input v-model="form.entryPoint" :rows="2" type="textarea" placeholder="If multi-line, it is best to save them in a file on NFS, and then execute it. e.g. bash run.sh" />
+            <el-input
+              v-model="form.entryPoint"
+              :rows="2"
+              type="textarea"
+              placeholder="If multi-line, it is best to save them in a file on NFS, and then execute it. e.g. bash run.sh"
+            />
           </el-form-item>
           <el-form-item label="image" prop="image">
             <ImageInput v-model="form.image" />
@@ -47,7 +52,11 @@
             <el-select v-model="form.priority" placeholder="please select priority">
               <el-option label="Low" :value="0" />
               <el-option label="Medium" :value="1" />
-              <el-option label="High" :value="2" v-if="isManager || store.isCurrentWorkspaceAdmin()" />
+              <el-option
+                label="High"
+                :value="2"
+                v-if="isManager || store.isCurrentWorkspaceAdmin()"
+              />
             </el-select>
           </el-form-item>
         </div>
@@ -106,7 +115,11 @@
                           ({{ n.internalIP }})
                         </span>
                       </div>
-                      <el-tag :type="n.available ? 'success' : 'danger'" size="small" effect="plain">
+                      <el-tag
+                        :type="n.available ? 'success' : 'danger'"
+                        size="small"
+                        effect="plain"
+                      >
                         {{ n.available ? 'Available' : 'Unavailable' }}
                       </el-tag>
                     </div>
@@ -204,7 +217,12 @@
                 </el-col>
                 <el-col :span="12">
                   <el-form-item label="secret" prop="secretIds">
-                    <el-select v-model="form.secretIds" multiple :disabled="isEdit" placeholder="Please select secrets">
+                    <el-select
+                      v-model="form.secretIds"
+                      multiple
+                      :disabled="isEdit"
+                      placeholder="Please select secrets"
+                    >
                       <el-option
                         v-for="item in secretOptions"
                         :key="item.value"
@@ -226,7 +244,6 @@
                     </el-select>
                   </el-form-item>
                 </el-col>
-
               </el-row>
 
               <el-form-item label="GitHubConfigURL" prop="githubConfigUrl">
@@ -237,34 +254,64 @@
                 />
               </el-form-item>
 
-              <el-form-item label="GitHubPAT" prop="githubPAT" v-if="!isEdit">
-                <div class="flex items-center gap-2 w-full">
-                  <el-input
-                    v-model="form.githubPAT"
-                    placeholder="Enter GitHub PAT"
-                    type="password"
-                    class="flex-1"
-                  />
-                  <el-tooltip placement="top" raw-content>
-                    <template #content>
-                      <div>
-                        To create a PAT, visit
-                        <a
-                          href="https://app.docker.com/settings"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          style="color: #409eff; text-decoration: underline"
-                        >
-                          https://app.docker.com/settings
-                        </a>
-                      </div>
-                    </template>
-                    <el-icon class="text-gray-500 cursor-help">
-                      <InfoFilled />
-                    </el-icon>
-                  </el-tooltip>
-                </div>
-              </el-form-item>
+              <template v-if="!isEdit">
+                <el-form-item label="GitHubAuth" prop="githubAuthType">
+                  <el-radio-group v-model="form.githubAuthType">
+                    <el-radio-button label="github_app">GitHub App (recommended)</el-radio-button>
+                    <el-radio-button label="pat">Personal Access Token (legacy)</el-radio-button>
+                  </el-radio-group>
+                </el-form-item>
+
+                <template v-if="form.githubAuthType === 'github_app'">
+                  <el-form-item label="App ID" prop="githubAppId">
+                    <el-input v-model="form.githubAppId" placeholder="Enter GitHub App ID" />
+                  </el-form-item>
+                  <el-form-item label="Installation ID" prop="githubAppInstallationId">
+                    <el-input
+                      v-model="form.githubAppInstallationId"
+                      placeholder="Enter GitHub App installation ID"
+                    />
+                  </el-form-item>
+                  <el-form-item label="Private Key" prop="githubAppPrivateKey">
+                    <div class="w-full">
+                      <el-input
+                        v-model="form.githubAppPrivateKey"
+                        :rows="5"
+                        type="textarea"
+                        placeholder="Paste the GitHub App private key PEM"
+                        show-word-limit
+                      />
+                      <input
+                        class="pem-file-input"
+                        type="file"
+                        accept=".pem,.key,text/plain"
+                        @change="onPrivateKeyFileChange"
+                      />
+                    </div>
+                  </el-form-item>
+                </template>
+
+                <el-form-item label="GitHubPAT" prop="githubPAT" v-else>
+                  <div class="flex items-center gap-2 w-full">
+                    <el-input
+                      v-model="form.githubPAT"
+                      placeholder="Enter legacy GitHub PAT"
+                      type="password"
+                      class="flex-1"
+                    />
+                    <el-tooltip placement="top" raw-content>
+                      <template #content>
+                        <div>
+                          Legacy PAT authentication is still supported for existing workflows.
+                        </div>
+                      </template>
+                      <el-icon class="text-gray-500 cursor-help">
+                        <InfoFilled />
+                      </el-icon>
+                    </el-tooltip>
+                  </div>
+                </el-form-item>
+              </template>
             </div>
           </transition>
         </div>
@@ -300,6 +347,7 @@ import { debounce } from 'lodash'
 import { useUserStore } from '@/stores/user'
 import { InfoFilled, CopyDocument, ArrowRight } from '@element-plus/icons-vue'
 import ImageInput from '@/components/Base/ImageInput.vue'
+import { buildGitHubAuthPayload, validateGitHubAuthForm, type GitHubAuthType } from './githubAuth'
 
 const props = defineProps<{
   visible: boolean
@@ -357,6 +405,10 @@ const initialForm = () => ({
   priority: 1,
   unifiedJobEnable: false,
   githubConfigUrl: '',
+  githubAuthType: 'github_app' as GitHubAuthType,
+  githubAppId: '',
+  githubAppInstallationId: '',
+  githubAppPrivateKey: '',
   githubPAT: '',
   resource: {
     replica: 1,
@@ -411,7 +463,42 @@ const rules: Record<string, FormItemRule[]> = reactive({
     { required: true, message: 'Please input ephemeral storage', trigger: 'blur' },
   ],
   githubConfigUrl: [{ required: true, message: 'Please input GitHub config URL', trigger: 'blur' }],
-  githubPAT: [{ required: true, message: 'Please input GitHub PAT', trigger: 'blur' }],
+  githubAppId: [
+    {
+      validator: (_rule, _value, callback) => {
+        const [message] = validateGitHubAuthForm(form).filter((msg) => msg.includes('App ID'))
+        callback(message ? new Error(message) : undefined)
+      },
+      trigger: 'blur',
+    },
+  ],
+  githubAppInstallationId: [
+    {
+      validator: (_rule, _value, callback) => {
+        const [message] = validateGitHubAuthForm(form).filter((msg) => msg.includes('installation'))
+        callback(message ? new Error(message) : undefined)
+      },
+      trigger: 'blur',
+    },
+  ],
+  githubAppPrivateKey: [
+    {
+      validator: (_rule, _value, callback) => {
+        const [message] = validateGitHubAuthForm(form).filter((msg) => msg.includes('private key'))
+        callback(message ? new Error(message) : undefined)
+      },
+      trigger: 'blur',
+    },
+  ],
+  githubPAT: [
+    {
+      validator: (_rule, _value, callback) => {
+        const [message] = validateGitHubAuthForm(form)
+        callback(message ? new Error(message) : undefined)
+      },
+      trigger: 'blur',
+    },
+  ],
 })
 
 const onSubmit = async (formEl: FormInstance | undefined) => {
@@ -426,6 +513,10 @@ const onSubmit = async (formEl: FormInstance | undefined) => {
       timeout,
       unifiedJobEnable,
       githubConfigUrl,
+      githubAuthType,
+      githubAppId,
+      githubAppInstallationId,
+      githubAppPrivateKey,
       githubPAT,
       image,
       ...addPayload
@@ -461,12 +552,6 @@ const onSubmit = async (formEl: FormInstance | undefined) => {
       ENTRYPOINT: encodeToBase64String(entryPoint),
     }
 
-    // Handle GitHubPAT
-    // During Create/Clone, add PAT directly to env; backend will auto-create secret
-    if (!isEdit.value && githubPAT) {
-      envMap.GITHUB_PAT = githubPAT
-    }
-
     // Build secrets array
     const secrets = form.secretIds.map((id) => ({ id }))
 
@@ -482,10 +567,19 @@ const onSubmit = async (formEl: FormInstance | undefined) => {
         resources: [fixedResource],
         workspace: props.action === 'Clone' ? pendingWorkspaceId.value : store.currentWorkspaceId!,
         env: envMap,
+        githubAuth: buildGitHubAuthPayload({
+          githubAuthType,
+          githubAppId,
+          githubAppInstallationId,
+          githubAppPrivateKey,
+          githubPAT,
+        }),
         ...(excludedNodesPayload ? { excludedNodes: excludedNodesPayload } : {}),
         ...(secrets.length > 0 ? { secrets: secrets } : {}),
         ...(props.action === 'Resume' ? { workloadId: props.wlid } : {}),
-        ...(cachedUseWorkspaceStorage.value !== undefined ? { useWorkspaceStorage: cachedUseWorkspaceStorage.value } : {}),
+        ...(cachedUseWorkspaceStorage.value !== undefined
+          ? { useWorkspaceStorage: cachedUseWorkspaceStorage.value }
+          : {}),
       }
 
       await addWorkload(payload)
@@ -542,6 +636,15 @@ const cancelAdd = () => {
   })
 }
 
+const onPrivateKeyFileChange = async (event: Event) => {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
+  if (!file) return
+  form.githubAppPrivateKey = await file.text()
+  input.value = ''
+  ruleFormRef.value?.validateField('githubAppPrivateKey')
+}
+
 function createBetweenRule(min: number, max: number, unit?: string): FormItemRule {
   return {
     validator: (_rule: unknown, value: unknown, callback: (err?: Error) => void) => {
@@ -563,6 +666,18 @@ watch(
     }
   },
   { immediate: true },
+)
+
+watch(
+  () => form.githubAuthType,
+  () => {
+    ruleFormRef.value?.clearValidate([
+      'githubAppId',
+      'githubAppInstallationId',
+      'githubAppPrivateKey',
+      'githubPAT',
+    ])
+  },
 )
 
 const fetchFlavorAvail = async () => {
@@ -667,6 +782,9 @@ const setInitialFormValues = async () => {
     // Clear sensitive info during Clone/Resume so users can re-select
     form.secretIds = []
     form.githubPAT = ''
+    form.githubAppId = ''
+    form.githubAppInstallationId = ''
+    form.githubAppPrivateKey = ''
   }
 
   if (props.action === 'Clone') {
@@ -857,6 +975,11 @@ html.dark .section-card:hover {
 /* Leave some space at the top of advanced expanded content */
 .advanced-body {
   margin-top: 4px;
+}
+
+.pem-file-input {
+  margin-top: 8px;
+  font-size: 12px;
 }
 
 /* Drawer footer */

--- a/Web/apps/safe/src/pages/CICD/Components/__tests__/githubAuth.test.ts
+++ b/Web/apps/safe/src/pages/CICD/Components/__tests__/githubAuth.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { buildGitHubAuthPayload, validateGitHubAuthForm, type GitHubAuthForm } from '../githubAuth'
+
+const baseForm = (overrides: Partial<GitHubAuthForm>): GitHubAuthForm => ({
+  githubAuthType: 'github_app',
+  githubAppId: '',
+  githubAppInstallationId: '',
+  githubAppPrivateKey: '',
+  githubPAT: '',
+  ...overrides,
+})
+
+describe('CICD GitHub auth payload', () => {
+  it('builds a GitHub App payload', () => {
+    expect(
+      buildGitHubAuthPayload(
+        baseForm({
+          githubAppId: ' 12345 ',
+          githubAppInstallationId: ' 67890 ',
+          githubAppPrivateKey: ' private-key ',
+        }),
+      ),
+    ).toEqual({
+      type: 'github_app',
+      appId: '12345',
+      installationId: '67890',
+      privateKey: 'private-key',
+    })
+  })
+
+  it('builds a legacy PAT payload', () => {
+    expect(
+      buildGitHubAuthPayload(
+        baseForm({
+          githubAuthType: 'pat',
+          githubPAT: ' ghp_test ',
+        }),
+      ),
+    ).toEqual({
+      type: 'pat',
+      token: 'ghp_test',
+    })
+  })
+
+  it('validates required GitHub App fields', () => {
+    expect(validateGitHubAuthForm(baseForm({ githubAppId: '12345' }))).toEqual([
+      'Please input GitHub App installation ID',
+      'Please input GitHub App private key',
+    ])
+  })
+
+  it('validates legacy PAT field', () => {
+    expect(validateGitHubAuthForm(baseForm({ githubAuthType: 'pat' }))).toEqual([
+      'Please input GitHub PAT',
+    ])
+  })
+})

--- a/Web/apps/safe/src/pages/CICD/Components/githubAuth.ts
+++ b/Web/apps/safe/src/pages/CICD/Components/githubAuth.ts
@@ -1,0 +1,51 @@
+export type GitHubAuthType = 'github_app' | 'pat'
+
+export interface GitHubAuthForm {
+  githubAuthType: GitHubAuthType
+  githubAppId: string
+  githubAppInstallationId: string
+  githubAppPrivateKey: string
+  githubPAT: string
+}
+
+export type GitHubAuthPayload =
+  | {
+      type: 'github_app'
+      appId: string
+      installationId: string
+      privateKey: string
+    }
+  | {
+      type: 'pat'
+      token: string
+    }
+
+const clean = (value: string) => value.trim()
+
+export const validateGitHubAuthForm = (form: GitHubAuthForm): string[] => {
+  if (form.githubAuthType === 'pat') {
+    return clean(form.githubPAT) ? [] : ['Please input GitHub PAT']
+  }
+
+  const missing: string[] = []
+  if (!clean(form.githubAppId)) missing.push('Please input GitHub App ID')
+  if (!clean(form.githubAppInstallationId)) missing.push('Please input GitHub App installation ID')
+  if (!clean(form.githubAppPrivateKey)) missing.push('Please input GitHub App private key')
+  return missing
+}
+
+export const buildGitHubAuthPayload = (form: GitHubAuthForm): GitHubAuthPayload => {
+  if (form.githubAuthType === 'pat') {
+    return {
+      type: 'pat',
+      token: clean(form.githubPAT),
+    }
+  }
+
+  return {
+    type: 'github_app',
+    appId: clean(form.githubAppId),
+    installationId: clean(form.githubAppInstallationId),
+    privateKey: clean(form.githubAppPrivateKey),
+  }
+}

--- a/Web/apps/safe/src/pages/CICD/index.vue
+++ b/Web/apps/safe/src/pages/CICD/index.vue
@@ -62,12 +62,12 @@
           :icon="ResetIcon"
           size="default"
           @click="
-          () => {
-            const { onlyMyself, userId } = searchParams
-            Object.assign(searchParams, initialSearchParams, { onlyMyself, userId })
-            pagination.page = 1
-            onSearch({ resetPage: true })
-          }
+            () => {
+              const { onlyMyself, userId } = searchParams
+              Object.assign(searchParams, initialSearchParams, { onlyMyself, userId })
+              pagination.page = 1
+              onSearch({ resetPage: true })
+            }
           "
         ></el-button>
       </el-tooltip>
@@ -108,7 +108,10 @@
               <el-table :data="subTableDataMap[row.workloadId] || []" size="small">
                 <el-table-column prop="workloadId" label="Name/ID" min-width="180">
                   <template #default="{ row: subRow }">
-                    <el-link type="primary" v-route="{ path: '/cicd/detail', query: { id: subRow.workloadId } }">
+                    <el-link
+                      type="primary"
+                      v-route="{ path: '/cicd/detail', query: { id: subRow.workloadId } }"
+                    >
                       {{ subRow.displayName }}
                     </el-link>
                     <div class="text-[12px] text-gray-400">
@@ -235,9 +238,11 @@
         <el-table-column prop="workloadId" label="Name/ID" min-width="200" :fixed="true">
           <template #default="{ row }">
             <div class="flex flex-col items-start">
-              <el-link type="primary" v-route="{ path: '/cicd/detail', query: { id: row.workloadId } }">{{
-                row.displayName
-              }}</el-link>
+              <el-link
+                type="primary"
+                v-route="{ path: '/cicd/detail', query: { id: row.workloadId } }"
+                >{{ row.displayName }}</el-link
+              >
               <div class="text-[13px] text-gray-400">
                 {{ row.workloadId }}
                 <el-icon
@@ -374,7 +379,9 @@
           </div>
 
           <div class="right">
-            <el-button type="danger" plain :disabled="!canWrite" @click="onBatchDelete">Delete</el-button>
+            <el-button type="danger" plain :disabled="!canWrite" @click="onBatchDelete"
+              >Delete</el-button
+            >
           </div>
         </div>
       </transition>
@@ -453,7 +460,10 @@
     >
       <el-table-column prop="workloadId" label="Name/ID" min-width="180">
         <template #default="{ row: subRow }">
-          <el-link type="primary" v-route="{ path: '/cicd/detail', query: { id: subRow.workloadId } }">
+          <el-link
+            type="primary"
+            v-route="{ path: '/cicd/detail', query: { id: subRow.workloadId } }"
+          >
             {{ subRow.displayName }}
           </el-link>
           <div class="text-[12px] text-gray-400">
@@ -608,7 +618,15 @@ import { useRoute, useRouter } from 'vue-router'
 import { useRouteAction, ROUTE_ACTIONS } from '@/composables/useRouteAction'
 import AddDialog from './Components/AddDialog.vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
-import { Delete, DocumentCopy, MoreFilled, Close, Edit, Key, VideoPlay } from '@element-plus/icons-vue'
+import {
+  Delete,
+  DocumentCopy,
+  MoreFilled,
+  Close,
+  Edit,
+  Key,
+  VideoPlay,
+} from '@element-plus/icons-vue'
 import { type WorkloadParams, PRIORITY_LABEL_MAP, type PriorityValue } from '@/services'
 import { encodeToBase64String } from '@/utils'
 import { useUserStore } from '@/stores/user'
@@ -782,9 +800,6 @@ type Row = { workloadId: string; phase: string; pods: { podId?: string }[]; disp
 
 const handleUpdatePAT = async (row: Row) => {
   try {
-    // First get the current workload details
-    const workloadDetail = await getWorkloadDetail(row.workloadId)
-
     // Show dialog to input new PAT
     const messageBox = ElMessageBox.prompt('', 'Update PAT', {
       confirmButtonText: 'Update',
@@ -806,15 +821,12 @@ const handleUpdatePAT = async (row: Row) => {
 
     const { value } = (await messageBox) as { value: string }
 
-    // Get all existing env vars and update GITHUB_PAT
-    const updatedEnv = {
-      ...workloadDetail.env,
-      GITHUB_PAT: value,
-    }
-
     // Call workload edit API
     await editWorkload(row.workloadId, {
-      env: updatedEnv,
+      githubAuth: {
+        type: 'pat',
+        token: value,
+      },
     })
 
     ElMessage.success('GitHub PAT updated successfully')
@@ -1304,7 +1316,9 @@ const onAnyPointerDown = (e: Event) => {
   if (!inMenu && !inRefBtn) closeMore()
 }
 useRouteAction({
-  [ROUTE_ACTIONS.CREATE]: () => { addVisible.value = true },
+  [ROUTE_ACTIONS.CREATE]: () => {
+    addVisible.value = true
+  },
 })
 
 onMounted(() => {

--- a/Web/apps/safe/src/services/workload/type.ts
+++ b/Web/apps/safe/src/services/workload/type.ts
@@ -36,7 +36,7 @@ export enum WorkloadKind {
 
   AutoscalingRunnerSet = 'AutoscalingRunnerSet',
   EphemeralRunner = 'EphemeralRunner',
-  UnifiedJob='UnifiedJob',
+  UnifiedJob = 'UnifiedJob',
 
   PyTorchJob = 'PyTorchJob',
   Authoring = 'Authoring',
@@ -97,6 +97,7 @@ export interface GetWorkloadPodLogResponse {
 }
 // Edit + Create
 export interface EditWorkloadRequest {
+  githubAuth?: GitHubAuthPayload
   description?: string
   entryPoint?: string
   entryPoints?: string[]
@@ -116,8 +117,21 @@ export interface EditWorkloadRequest {
   privileged?: boolean
 }
 
+export type GitHubAuthPayload =
+  | {
+      type: 'github_app'
+      appId: string
+      installationId: string
+      privateKey: string
+    }
+  | {
+      type: 'pat'
+      token: string
+    }
+
 export interface SubmitWorkloadRequest {
   workspace: string
+  githubAuth?: GitHubAuthPayload
   displayName: string
   groupVersionKind: {
     kind: string


### PR DESCRIPTION
## Summary
- Add GitHub App authentication for CICD runner scale sets while preserving legacy PAT support.
- Create ARC-compatible GitHub credential secrets from a structured `githubAuth` payload and keep credential material out of persisted workload env/log output.
- Update the CICD create/update UI to default to GitHub App auth, with PAT available as a legacy option.

Addresses #573 

## Screenshot
The updated CICD in UI 
<img width="1212" height="753" alt="Screenshot 2026-05-21 151832" src="https://github.com/user-attachments/assets/c87e42d8-6e26-4ce8-96bd-bc1a8f072d55" />

## Test plan
- ✅ Local Go tests: `go test ./pkg/handlers/resources -run 'Test_(createCICDSecret|updateCICDSecret|updateWorkload_GithubPATHandling|updateWorkload_GitHubAppAuthHandling|applyWorkloadPatch_GithubPATFiltered|generateCICDScaleRunnerSet)'`
- ✅ Local Go tests: `go test ./pkg/handlers/resources -run 'Test_updateCICDSecret_(TokenUnchanged|TokenChanged|NoOldSecret|MissingAnnotatedOldSecret|OldSecretLookupError)'`
- ❓Not yet run: rebuild and deploy the apiserver and web images into a cluster.
- ❓ Not yet run: end-to-end GitHub App CICD creation

Made with [Cursor](https://cursor.com)