### PR TITLE
feat(cicd): support GitHub App auth secrets

### DIFF
--- a/SaFE/apiserver/pkg/handlers/resources/cicd.go
+++ b/SaFE/apiserver/pkg/handlers/resources/cicd.go
@@ -7,6 +7,8 @@ package resources
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	commonconfig "github.com/AMD-AIG-AIMA/SAFE/common/pkg/config"
 	commonerrors "github.com/AMD-AIG-AIMA/SAFE/common/pkg/errors"
@@ -24,15 +26,23 @@ import (
 )
 
 const (
-	GithubPAT   = "GITHUB_PAT"
-	GitHubToken = "github_token"
+	GithubPAT               = "GITHUB_PAT"
+	GitHubAuthTypePAT       = "pat"
+	GitHubAuthTypeApp       = "github_app"
+	GitHubToken             = "github_token"
+	GitHubAppId             = "github_app_id"
+	GitHubAppInstallationId = "github_app_installation_id"
+	GitHubAppPrivateKey     = "github_app_private_key"
 )
 
 // createCICDSecret creates a new secret for CICD scaling runner workloads.
-// The secret contains the GitHub token encoded in base64 format.
+// The secret contains ARC-compatible GitHub authentication keys.
 // It returns the created secret or an error if the creation fails.
 func (h *Handler) createCICDSecret(ctx context.Context,
-	workload *v1.Workload, requestUser *v1.User, token string) (*corev1.Secret, error) {
+	workload *v1.Workload, requestUser *v1.User, auth *view.GitHubAuthRequest) (*corev1.Secret, error) {
+	if err := validateCICDGitHubAuth(auth); err != nil {
+		return nil, err
+	}
 	name := commonutils.GenerateName(v1.GetDisplayName(workload))
 	createSecretReq := &view.CreateSecretRequest{
 		Name:         name,
@@ -40,9 +50,7 @@ func (h *Handler) createCICDSecret(ctx context.Context,
 		Type:         v1.SecretGeneral,
 		Owner:        workload.Name,
 		Params: []map[view.SecretParam]string{
-			{
-				GitHubToken: stringutil.Base64Encode(token),
-			},
+			buildCICDSecretParams(auth),
 		},
 		Labels: map[string]string{
 			"secret.usage": "cicd",
@@ -57,26 +65,27 @@ func (h *Handler) createCICDSecret(ctx context.Context,
 }
 
 // updateCICDSecret updates the CICD secret by creating a new secret and deleting the old one.
-// This replaces the existing GitHub PAT secret with a new one for CICD scaling runner workloads.
+// This replaces the existing GitHub auth secret with a new one for CICD scaling runner workloads.
 func (h *Handler) updateCICDSecret(ctx context.Context,
-	workload *v1.Workload, requestUser *v1.User, newToken string) error {
-	// Get the old secret to compare tokens
+	workload *v1.Workload, requestUser *v1.User, auth *view.GitHubAuthRequest) error {
+	if err := validateCICDGitHubAuth(auth); err != nil {
+		return err
+	}
 	oldSecretId := v1.GetGithubSecretId(workload)
 	if oldSecretId != "" {
 		oldSecret, err := h.getAdminSecret(ctx, oldSecretId)
-		if err == nil && oldSecret != nil {
-			// Extract the old token from secret data
-			if oldTokenBytes, ok := oldSecret.Data[GitHubToken]; ok {
-				oldToken := string(oldTokenBytes)
-				if oldToken == newToken {
-					// Token hasn't changed, no need to update
-					return nil
-				}
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				oldSecretId = ""
+			} else {
+				return fmt.Errorf("failed to get existing CICD GitHub secret %q: %w", oldSecretId, err)
 			}
+		} else if cicdSecretDataMatchesAuth(oldSecret, auth) {
+			return nil
 		}
 	}
 
-	newSecret, err := h.createCICDSecret(ctx, workload, requestUser, newToken)
+	newSecret, err := h.createCICDSecret(ctx, workload, requestUser, auth)
 	if err != nil {
 		return err
 	}
@@ -107,20 +116,86 @@ func (h *Handler) cleanupCICDSecrets(ctx context.Context, workload *v1.Workload)
 }
 
 // generateCICDScaleRunnerSet configures a workload for CICD scaling runner set.
-// It validates CICD settings, creates a GitHub token secret.
-func (h *Handler) generateCICDScaleRunnerSet(ctx context.Context, workload *v1.Workload, requestUser *v1.User) error {
+// It validates CICD settings and creates a GitHub auth secret.
+func (h *Handler) generateCICDScaleRunnerSet(ctx context.Context, workload *v1.Workload,
+	requestUser *v1.User, auth *view.GitHubAuthRequest) error {
 	if !commonconfig.IsCICDEnable() {
 		return commonerrors.NewNotImplemented("the CICD is not enabled")
 	}
-	val, _ := workload.Spec.Env[GithubPAT]
-	if val == "" {
-		return commonerrors.NewBadRequest("the github pat(token) is empty")
+	auth = normalizeCICDGitHubAuth(auth, workload.Spec.Env)
+	if err := validateCICDGitHubAuth(auth); err != nil {
+		return err
 	}
-	secret, err := h.createCICDSecret(ctx, workload, requestUser, val)
+	secret, err := h.createCICDSecret(ctx, workload, requestUser, auth)
 	if err != nil {
 		return err
 	}
 	delete(workload.Spec.Env, GithubPAT)
 	v1.SetAnnotation(workload, v1.GithubSecretIdAnnotation, secret.Name)
 	return nil
+}
+
+func normalizeCICDGitHubAuth(auth *view.GitHubAuthRequest, env map[string]string) *view.GitHubAuthRequest {
+	if auth != nil {
+		return auth
+	}
+	if env == nil {
+		return nil
+	}
+	if token := strings.TrimSpace(env[GithubPAT]); token != "" {
+		return &view.GitHubAuthRequest{
+			Type:  GitHubAuthTypePAT,
+			Token: token,
+		}
+	}
+	return nil
+}
+
+func validateCICDGitHubAuth(auth *view.GitHubAuthRequest) error {
+	if auth == nil {
+		return commonerrors.NewBadRequest("the github authentication is empty")
+	}
+	switch strings.TrimSpace(auth.Type) {
+	case GitHubAuthTypeApp:
+		if strings.TrimSpace(auth.AppId) == "" ||
+			strings.TrimSpace(auth.InstallationId) == "" ||
+			strings.TrimSpace(auth.PrivateKey) == "" {
+			return commonerrors.NewBadRequest("github app authentication requires appId, installationId, and privateKey")
+		}
+	case GitHubAuthTypePAT:
+		if strings.TrimSpace(auth.Token) == "" {
+			return commonerrors.NewBadRequest("the github pat(token) is empty")
+		}
+	default:
+		return commonerrors.NewBadRequest("unsupported github authentication type")
+	}
+	return nil
+}
+
+func buildCICDSecretParams(auth *view.GitHubAuthRequest) map[view.SecretParam]string {
+	switch strings.TrimSpace(auth.Type) {
+	case GitHubAuthTypeApp:
+		return map[view.SecretParam]string{
+			GitHubAppId:             stringutil.Base64Encode(strings.TrimSpace(auth.AppId)),
+			GitHubAppInstallationId: stringutil.Base64Encode(strings.TrimSpace(auth.InstallationId)),
+			GitHubAppPrivateKey:     stringutil.Base64Encode(strings.TrimSpace(auth.PrivateKey)),
+		}
+	default:
+		return map[view.SecretParam]string{
+			GitHubToken: stringutil.Base64Encode(strings.TrimSpace(auth.Token)),
+		}
+	}
+}
+
+// cicdSecretDataMatchesAuth is an idempotency check that avoids rotating
+// credentials when the submitted values already match the existing ARC secret.
+func cicdSecretDataMatchesAuth(secret *corev1.Secret, auth *view.GitHubAuthRequest) bool {
+	switch strings.TrimSpace(auth.Type) {
+	case GitHubAuthTypeApp:
+		return string(secret.Data[GitHubAppId]) == strings.TrimSpace(auth.AppId) &&
+			string(secret.Data[GitHubAppInstallationId]) == strings.TrimSpace(auth.InstallationId) &&
+			string(secret.Data[GitHubAppPrivateKey]) == strings.TrimSpace(auth.PrivateKey)
+	default:
+		return string(secret.Data[GitHubToken]) == strings.TrimSpace(auth.Token)
+	}
 }

--- a/SaFE/apiserver/pkg/handlers/resources/cicd_test.go
+++ b/SaFE/apiserver/pkg/handlers/resources/cicd_test.go
@@ -7,6 +7,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
@@ -24,9 +25,26 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	k8stesting "k8s.io/client-go/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlruntimefake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+func patAuth(token string) *view.GitHubAuthRequest {
+	return &view.GitHubAuthRequest{
+		Type:  GitHubAuthTypePAT,
+		Token: token,
+	}
+}
+
+func githubAppAuth(appId, installationId, privateKey string) *view.GitHubAuthRequest {
+	return &view.GitHubAuthRequest{
+		Type:           GitHubAuthTypeApp,
+		AppId:          appId,
+		InstallationId: installationId,
+		PrivateKey:     privateKey,
+	}
+}
 
 // Test_createCICDSecret tests the createCICDSecret function with token encoding
 func Test_createCICDSecret(t *testing.T) {
@@ -105,7 +123,7 @@ func Test_updateCICDSecret_TokenUnchanged(t *testing.T) {
 	}
 
 	// Call updateCICDSecret with same token
-	err := h.updateCICDSecret(ctx, workload, user, oldToken)
+	err := h.updateCICDSecret(ctx, workload, user, patAuth(oldToken))
 
 	// Should return nil without error (optimization kicks in)
 	assert.NilError(t, err)
@@ -168,7 +186,7 @@ func Test_updateCICDSecret_TokenChanged(t *testing.T) {
 	}
 
 	// Call updateCICDSecret with new token
-	err := h.updateCICDSecret(ctx, workload, user, newToken)
+	err := h.updateCICDSecret(ctx, workload, user, patAuth(newToken))
 
 	// Should succeed
 	assert.NilError(t, err)
@@ -215,7 +233,7 @@ func Test_createCICDSecret_Success(t *testing.T) {
 	}
 
 	// Call createCICDSecret
-	secret, err := h.createCICDSecret(ctx, workload, user, token)
+	secret, err := h.createCICDSecret(ctx, workload, user, patAuth(token))
 
 	// Should succeed
 	assert.NilError(t, err)
@@ -320,6 +338,83 @@ func Test_updateWorkload_GithubPATHandling(t *testing.T) {
 	assert.Equal(t, string(newSecret.Data[GitHubToken]), newToken, "new secret should contain new token")
 
 	// Verify old secret was deleted (using clientSet, not controller-runtime client)
+	_, err = fakeClientSet.CoreV1().Secrets(common.PrimusSafeNamespace).Get(ctx, oldSecretName, metav1.GetOptions{})
+	assert.Assert(t, apierrors.IsNotFound(err), "old secret should be deleted")
+}
+
+func Test_updateWorkload_GitHubAppAuthHandling(t *testing.T) {
+	ctx := context.Background()
+	clusterId := "test-cluster"
+	workspaceId := "test-workspace"
+
+	workload := genMockWorkload(clusterId, workspaceId)
+	workload.Spec.Kind = common.CICDScaleRunnerSetKind
+	workload.Spec.Env = map[string]string{
+		"EXISTING_VAR": "existing_value",
+	}
+	user := genMockUser()
+	role := genMockRole()
+
+	oldSecretName := "old-secret-id"
+	oldSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      oldSecretName,
+			Namespace: common.PrimusSafeNamespace,
+			Labels: map[string]string{
+				v1.SecretTypeLabel: string(v1.SecretGeneral),
+				v1.UserIdLabel:     user.Name,
+				v1.OwnerLabel:      workload.Name,
+			},
+		},
+		Data: map[string][]byte{
+			GitHubToken: []byte("old_token_123"),
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
+	v1.SetAnnotation(workload, v1.GithubSecretIdAnnotation, oldSecretName)
+
+	testScheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(testScheme))
+	utilruntime.Must(scheme.AddToScheme(testScheme))
+
+	fakeCtrlClient := ctrlruntimefake.NewClientBuilder().
+		WithObjects(workload, user, role).
+		WithScheme(testScheme).
+		Build()
+
+	fakeClientSet := k8sfake.NewSimpleClientset(oldSecret)
+
+	h := Handler{
+		Client:           fakeCtrlClient,
+		clientSet:        fakeClientSet,
+		accessController: authority.NewAccessController(fakeCtrlClient),
+	}
+
+	newAuth := githubAppAuth("12345", "67890", "private-key")
+	req := &view.PatchWorkloadRequest{
+		GitHubAuth: newAuth,
+	}
+
+	err := h.updateWorkload(ctx, workload, user, req)
+
+	assert.NilError(t, err, "updateWorkload should succeed")
+
+	updatedWorkload := &v1.Workload{}
+	err = fakeCtrlClient.Get(ctx, client.ObjectKey{Name: workload.Name}, updatedWorkload)
+	assert.NilError(t, err, "should retrieve updated workload")
+
+	newSecretId := v1.GetGithubSecretId(updatedWorkload)
+	assert.Assert(t, newSecretId != "", "New secret ID should be set")
+	assert.Assert(t, newSecretId != oldSecretName, "New secret ID should be different from old")
+
+	newSecret, err := fakeClientSet.CoreV1().Secrets(common.PrimusSafeNamespace).Get(ctx, newSecretId, metav1.GetOptions{})
+	assert.NilError(t, err, "new secret should be created")
+	assert.Equal(t, string(newSecret.Data[GitHubAppId]), newAuth.AppId)
+	assert.Equal(t, string(newSecret.Data[GitHubAppInstallationId]), newAuth.InstallationId)
+	assert.Equal(t, string(newSecret.Data[GitHubAppPrivateKey]), newAuth.PrivateKey)
+	_, hasPAT := newSecret.Data[GitHubToken]
+	assert.Assert(t, !hasPAT, "GitHub App update should not contain PAT key")
+
 	_, err = fakeClientSet.CoreV1().Secrets(common.PrimusSafeNamespace).Get(ctx, oldSecretName, metav1.GetOptions{})
 	assert.Assert(t, apierrors.IsNotFound(err), "old secret should be deleted")
 }
@@ -449,7 +544,7 @@ func Test_updateCICDSecret_NoOldSecret(t *testing.T) {
 	}
 
 	// Call updateCICDSecret with new token
-	err := h.updateCICDSecret(ctx, workload, user, newToken)
+	err := h.updateCICDSecret(ctx, workload, user, patAuth(newToken))
 
 	// Should succeed
 	assert.NilError(t, err)
@@ -462,6 +557,70 @@ func Test_updateCICDSecret_NoOldSecret(t *testing.T) {
 	newSecret, err := fakeClientSet.CoreV1().Secrets(common.PrimusSafeNamespace).Get(ctx, newSecretId, metav1.GetOptions{})
 	assert.NilError(t, err, "New secret should exist")
 	assert.Equal(t, string(newSecret.Data[GitHubToken]), newToken, "New secret should contain new token")
+}
+
+func Test_updateCICDSecret_MissingAnnotatedOldSecret(t *testing.T) {
+	ctx := context.Background()
+	clusterId := "test-cluster"
+	workspaceId := "test-workspace"
+
+	workload := genMockWorkload(clusterId, workspaceId)
+	user := genMockUser()
+	role := genMockRole()
+	newToken := "new_token_123"
+	v1.SetAnnotation(workload, v1.GithubSecretIdAnnotation, "missing-secret")
+
+	fakeCtrlClient := ctrlruntimefake.NewClientBuilder().
+		WithObjects(workload, user, role).
+		WithScheme(scheme.Scheme).
+		Build()
+	fakeClientSet := k8sfake.NewSimpleClientset()
+
+	h := Handler{
+		Client:           fakeCtrlClient,
+		clientSet:        fakeClientSet,
+		accessController: authority.NewAccessController(fakeCtrlClient),
+	}
+
+	err := h.updateCICDSecret(ctx, workload, user, patAuth(newToken))
+	assert.NilError(t, err)
+
+	newSecretId := v1.GetGithubSecretId(workload)
+	assert.Assert(t, newSecretId != "", "New secret ID should be set")
+	assert.Assert(t, newSecretId != "missing-secret", "New secret ID should replace stale annotation")
+	newSecret, err := fakeClientSet.CoreV1().Secrets(common.PrimusSafeNamespace).Get(ctx, newSecretId, metav1.GetOptions{})
+	assert.NilError(t, err, "New secret should exist")
+	assert.Equal(t, string(newSecret.Data[GitHubToken]), newToken, "New secret should contain new token")
+}
+
+func Test_updateCICDSecret_OldSecretLookupError(t *testing.T) {
+	ctx := context.Background()
+	clusterId := "test-cluster"
+	workspaceId := "test-workspace"
+
+	workload := genMockWorkload(clusterId, workspaceId)
+	user := genMockUser()
+	role := genMockRole()
+	v1.SetAnnotation(workload, v1.GithubSecretIdAnnotation, "old-secret-id")
+
+	fakeCtrlClient := ctrlruntimefake.NewClientBuilder().
+		WithObjects(workload, user, role).
+		WithScheme(scheme.Scheme).
+		Build()
+	fakeClientSet := k8sfake.NewSimpleClientset()
+	fakeClientSet.Fake.PrependReactor("get", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("api unavailable")
+	})
+
+	h := Handler{
+		Client:           fakeCtrlClient,
+		clientSet:        fakeClientSet,
+		accessController: authority.NewAccessController(fakeCtrlClient),
+	}
+
+	err := h.updateCICDSecret(ctx, workload, user, patAuth("new_token_123"))
+	assert.ErrorContains(t, err, "failed to get existing CICD GitHub secret")
+	assert.Equal(t, v1.GetGithubSecretId(workload), "old-secret-id")
 }
 
 // Test_generateCICDScaleRunnerSet tests generating CICD scale runner set configuration
@@ -497,7 +656,7 @@ func Test_generateCICDScaleRunnerSet(t *testing.T) {
 	}
 
 	// Call generateCICDScaleRunnerSet
-	err := h.generateCICDScaleRunnerSet(ctx, workload, user)
+	err := h.generateCICDScaleRunnerSet(ctx, workload, user, nil)
 
 	// Should succeed
 	assert.NilError(t, err)
@@ -515,6 +674,53 @@ func Test_generateCICDScaleRunnerSet(t *testing.T) {
 	secret, err := fakeClientSet.CoreV1().Secrets(common.PrimusSafeNamespace).Get(ctx, secretId, metav1.GetOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, secret != nil, "Secret should be created")
+}
+
+func Test_generateCICDScaleRunnerSet_GitHubApp(t *testing.T) {
+	commonconfig.SetValue("cicd.enable", "true")
+	defer commonconfig.SetValue("cicd.enable", "")
+
+	ctx := context.Background()
+	clusterId := "test-cluster"
+	workspaceId := "test-workspace"
+	auth := githubAppAuth("12345", "67890", "private-key")
+
+	workload := genMockWorkload(clusterId, workspaceId)
+	workload.Spec.Env = map[string]string{
+		"OTHER_VAR": "other_value",
+	}
+
+	user := genMockUser()
+	role := genMockRole()
+
+	fakeCtrlClient := ctrlruntimefake.NewClientBuilder().
+		WithObjects(workload, user, role).
+		WithScheme(scheme.Scheme).
+		Build()
+
+	fakeClientSet := k8sfake.NewSimpleClientset()
+
+	h := Handler{
+		Client:           fakeCtrlClient,
+		clientSet:        fakeClientSet,
+		accessController: authority.NewAccessController(fakeCtrlClient),
+	}
+
+	err := h.generateCICDScaleRunnerSet(ctx, workload, user, auth)
+
+	assert.NilError(t, err)
+	assert.Equal(t, workload.Spec.Env["OTHER_VAR"], "other_value", "Other env vars should remain")
+
+	secretId := v1.GetGithubSecretId(workload)
+	assert.Assert(t, secretId != "", "Secret ID annotation should be set")
+
+	secret, err := fakeClientSet.CoreV1().Secrets(common.PrimusSafeNamespace).Get(ctx, secretId, metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, string(secret.Data[GitHubAppId]), auth.AppId)
+	assert.Equal(t, string(secret.Data[GitHubAppInstallationId]), auth.InstallationId)
+	assert.Equal(t, string(secret.Data[GitHubAppPrivateKey]), auth.PrivateKey)
+	_, hasPAT := secret.Data[GitHubToken]
+	assert.Assert(t, !hasPAT, "GitHub App secret should not contain PAT key")
 }
 
 // Test_cleanupCICDSecrets_CICDWorkload tests cleanup deletes secret for CICD workload

--- a/SaFE/apiserver/pkg/handlers/resources/view/workload_view.go
+++ b/SaFE/apiserver/pkg/handlers/resources/view/workload_view.go
@@ -14,6 +14,9 @@ import (
 
 type CreateWorkloadRequest struct {
 	v1.WorkloadSpec
+	// GitHubAuth carries CICD runner authentication material. It is used to create
+	// the ARC githubConfigSecret and must not be persisted on the workload env.
+	GitHubAuth *GitHubAuthRequest `json:"githubAuth,omitempty"`
 	// SpecifiedNodes defines the list of node names where the workload should run.
 	SpecifiedNodes []string `json:"specifiedNodes,omitempty"`
 	// NodesAffinity controls how strictly the workload adheres to SpecifiedNodes.
@@ -50,6 +53,14 @@ type CreateWorkloadRequest struct {
 	ForceHostNetwork *bool `json:"forceHostNetwork,omitempty"`
 	// The owner workload ID
 	OwnerId string `json:"ownerId,omitempty"`
+}
+
+type GitHubAuthRequest struct {
+	Type           string `json:"type,omitempty"`
+	Token          string `json:"token,omitempty"`
+	AppId          string `json:"appId,omitempty"`
+	InstallationId string `json:"installationId,omitempty"`
+	PrivateKey     string `json:"privateKey,omitempty"`
 }
 
 func (req *CreateWorkloadRequest) GetNodesAffinity() string {
@@ -224,6 +235,8 @@ type WorkloadPodWrapper struct {
 }
 
 type PatchWorkloadRequest struct {
+	// GitHubAuth carries updated CICD runner authentication material.
+	GitHubAuth *GitHubAuthRequest `json:"githubAuth,omitempty"`
 	// Workload scheduling Priority (0-2), default 0
 	Priority *int `json:"priority,omitempty"`
 	// Workload resource requirements

--- a/SaFE/apiserver/pkg/handlers/resources/workload.go
+++ b/SaFE/apiserver/pkg/handlers/resources/workload.go
@@ -533,7 +533,7 @@ func (h *Handler) patchWorkload(c *gin.Context) (interface{}, error) {
 		return nil, err
 	}
 	klog.Infof("update workload, name: %s, request: %s, request.user: %s",
-		name, string(jsonutils.MarshalSilently(*req)), c.GetString(common.UserId))
+		name, string(jsonutils.MarshalSilently(sanitizePatchWorkloadRequestForLog(req))), c.GetString(common.UserId))
 	return nil, nil
 }
 
@@ -567,8 +567,7 @@ func (h *Handler) authWorkloadUpdate(c *gin.Context, adminWorkload *v1.Workload,
 	return nil
 }
 
-// updateWorkload updates the workload in the system and handles CICD secret updates
-// if a new GitHub PAT token is provided in the request
+// updateWorkload updates the workload in the system and handles CICD auth secret updates.
 func (h *Handler) updateWorkload(ctx context.Context,
 	adminWorkload *v1.Workload, requestUser *v1.User, req *view.PatchWorkloadRequest) error {
 	err := h.Update(ctx, adminWorkload)
@@ -576,10 +575,10 @@ func (h *Handler) updateWorkload(ctx context.Context,
 		return err
 	}
 
-	if req.Env != nil && commonworkload.IsCICDScalingRunnerSet(adminWorkload) {
-		if newToken := (*req.Env)[GithubPAT]; newToken != "" {
+	if commonworkload.IsCICDScalingRunnerSet(adminWorkload) {
+		if auth := normalizeCICDGitHubAuth(req.GitHubAuth, requestEnv(req)); auth != nil {
 			patch := client.MergeFrom(adminWorkload.DeepCopy())
-			if err = h.updateCICDSecret(ctx, adminWorkload, requestUser, newToken); err != nil {
+			if err = h.updateCICDSecret(ctx, adminWorkload, requestUser, auth); err != nil {
 				klog.ErrorS(err, "failed to update cicd secret")
 				return err
 			}
@@ -815,7 +814,7 @@ func (h *Handler) generateWorkload(ctx context.Context,
 		}
 	}
 	if commonworkload.IsCICDScalingRunnerSet(workload) {
-		if err = h.generateCICDScaleRunnerSet(ctx, workload, requestUser); err != nil {
+		if err = h.generateCICDScaleRunnerSet(ctx, workload, requestUser, req.GitHubAuth); err != nil {
 			return nil, err
 		}
 	}
@@ -1207,6 +1206,31 @@ func applyWorkloadPatch(adminWorkload *v1.Workload, req *view.PatchWorkloadReque
 		adminWorkload.Spec.Service = req.Service
 	}
 	return nil
+}
+
+func requestEnv(req *view.PatchWorkloadRequest) map[string]string {
+	if req.Env == nil {
+		return nil
+	}
+	return *req.Env
+}
+
+func sanitizePatchWorkloadRequestForLog(req *view.PatchWorkloadRequest) view.PatchWorkloadRequest {
+	if req == nil {
+		return view.PatchWorkloadRequest{}
+	}
+	sanitized := *req
+	if sanitized.GitHubAuth != nil {
+		auth := *sanitized.GitHubAuth
+		auth.Token = ""
+		auth.PrivateKey = ""
+		sanitized.GitHubAuth = &auth
+	}
+	if sanitized.Env != nil {
+		env := maputil.Copy(*sanitized.Env, GithubPAT)
+		sanitized.Env = &env
+	}
+	return sanitized
 }
 
 // cvtDBWorkloadToResponseItem converts a database workload record to a response item format.


### PR DESCRIPTION
## Larger Feature
This is PR 2 of 4 in the split work to enable GitHub App support for CI/CD runner workloads. The 4 PRs together address #573 

## Merge Order
```mermaid
flowchart LR
  Audit["PR 1: Redact GitHub App private keys"]
  Backend["PR 2: Add GitHub App auth to CICD API"]
  Resolver["PR 3: Resolve GitHub credentials per workload"]
  Frontend["PR 4: Add GitHub App auth UI"]

  Backend --> Frontend
  Backend --> Resolver
```

- #579 can merge independently and is recommended first.
- #580 is the backend foundation and should merge before #582 and before full end-to-end GitHub App usage.
- #581 can merge after or alongside #580; it is needed for multiple CI/CD workloads and GitHub App scoped credentials.
- #582 should merge after #580.

## Summary
- Backend API accepts PAT or GitHub App auth.
- Writes ARC-compatible secret keys for the selected auth method.

## Test Plan
- `cd SaFE/apiserver && go test ./pkg/handlers/resources -run 'CICD|Cicd|CiCd|Github|GitHub'`
- `cd SaFE/apiserver && go test ./pkg/handlers/resources` was attempted but failed in `Test_cvtDBWorkloadToResponseItem` on a workload duration assertion outside this slice.

Made with [Cursor](https://cursor.com)