### PR TITLE
fix(github): resolve workflow credentials from workload secret

### DIFF
--- a/SaFE/resource-manager/pkg/github/credential_resolver.go
+++ b/SaFE/resource-manager/pkg/github/credential_resolver.go
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+package github
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
+	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/common"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	gitHubAuthTypePAT = "pat"
+	gitHubAuthTypeApp = "github_app"
+
+	gitHubTokenKey             = "github_token"
+	gitHubAppIDKey             = "github_app_id"
+	gitHubAppInstallationIDKey = "github_app_installation_id"
+	gitHubAppPrivateKeyKey     = "github_app_private_key"
+)
+
+var gitHubPATSecretKeys = []string{gitHubTokenKey, "token", "GITHUB_TOKEN"}
+
+type GitHubCredential struct {
+	Type           string
+	Token          string
+	AppID          string
+	InstallationID string
+	PrivateKey     string
+}
+
+type GitHubCredentialResolver struct {
+	client client.Client
+}
+
+func NewGitHubCredentialResolver(client client.Client) *GitHubCredentialResolver {
+	return &GitHubCredentialResolver{client: client}
+}
+
+func (r *GitHubCredentialResolver) Resolve(ctx context.Context, run *WorkflowRunRecord) (*GitHubCredential, error) {
+	if r == nil || r.client == nil {
+		return nil, fmt.Errorf("github credential resolver is not configured")
+	}
+	if run == nil || strings.TrimSpace(run.WorkloadID) == "" {
+		return nil, fmt.Errorf("workflow run has no workload id")
+	}
+
+	workload := &v1.Workload{}
+	if err := r.client.Get(ctx, client.ObjectKey{Name: run.WorkloadID}, workload); err != nil {
+		return nil, fmt.Errorf("get workload %q: %w", run.WorkloadID, err)
+	}
+
+	secretName := strings.TrimSpace(v1.GetGithubSecretId(workload))
+	if secretName == "" {
+		return nil, fmt.Errorf("workload %q has no github secret annotation", run.WorkloadID)
+	}
+
+	secret := &corev1.Secret{}
+	if err := r.client.Get(ctx, client.ObjectKey{Namespace: common.PrimusSafeNamespace, Name: secretName}, secret); err != nil {
+		return nil, fmt.Errorf("get github secret %q: %w", secretName, err)
+	}
+
+	return credentialFromSecret(secret)
+}
+
+func credentialFromSecret(secret *corev1.Secret) (*GitHubCredential, error) {
+	for _, key := range gitHubPATSecretKeys {
+		if token := strings.TrimSpace(string(secret.Data[key])); token != "" {
+			return &GitHubCredential{
+				Type:  gitHubAuthTypePAT,
+				Token: token,
+			}, nil
+		}
+	}
+
+	appID := strings.TrimSpace(string(secret.Data[gitHubAppIDKey]))
+	installationID := strings.TrimSpace(string(secret.Data[gitHubAppInstallationIDKey]))
+	privateKey := strings.TrimSpace(string(secret.Data[gitHubAppPrivateKeyKey]))
+	if appID != "" && installationID != "" && privateKey != "" {
+		return &GitHubCredential{
+			Type:           gitHubAuthTypeApp,
+			AppID:          appID,
+			InstallationID: installationID,
+			PrivateKey:     privateKey,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("github secret %q does not contain a supported credential", secret.Name)
+}

--- a/SaFE/resource-manager/pkg/github/credential_resolver_test.go
+++ b/SaFE/resource-manager/pkg/github/credential_resolver_test.go
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+package github
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
+	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/common"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestGitHubCredentialResolverResolvePATSecret(t *testing.T) {
+	resolver := newTestCredentialResolver(t,
+		testWorkload("runner-workload", "github-secret"),
+		testSecret("github-secret", map[string][]byte{
+			gitHubTokenKey: []byte("pat-token"),
+		}),
+	)
+
+	credential, err := resolver.Resolve(context.Background(), &WorkflowRunRecord{WorkloadID: "runner-workload"})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if credential.Type != gitHubAuthTypePAT || credential.Token != "pat-token" {
+		t.Fatalf("Resolve() credential = %#v, want PAT token", credential)
+	}
+}
+
+func TestGitHubCredentialResolverResolveAppSecret(t *testing.T) {
+	resolver := newTestCredentialResolver(t,
+		testWorkload("runner-workload", "github-app-secret"),
+		testSecret("github-app-secret", map[string][]byte{
+			gitHubAppIDKey:             []byte("123"),
+			gitHubAppInstallationIDKey: []byte("456"),
+			gitHubAppPrivateKeyKey:     []byte("private-key"),
+		}),
+	)
+
+	credential, err := resolver.Resolve(context.Background(), &WorkflowRunRecord{WorkloadID: "runner-workload"})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if credential.Type != gitHubAuthTypeApp ||
+		credential.AppID != "123" ||
+		credential.InstallationID != "456" ||
+		credential.PrivateKey != "private-key" {
+		t.Fatalf("Resolve() credential = %#v, want GitHub App credential", credential)
+	}
+}
+
+func TestGitHubCredentialResolverMissingAnnotationDoesNotUseArbitrarySecret(t *testing.T) {
+	resolver := newTestCredentialResolver(t,
+		&v1.Workload{
+			ObjectMeta: metav1.ObjectMeta{Name: "runner-workload"},
+		},
+		testSecret("unrelated-secret", map[string][]byte{
+			gitHubTokenKey: []byte("wrong-token"),
+		}),
+	)
+
+	_, err := resolver.Resolve(context.Background(), &WorkflowRunRecord{WorkloadID: "runner-workload"})
+	if err == nil {
+		t.Fatal("Resolve() error = nil, want missing annotation error")
+	}
+	if !strings.Contains(err.Error(), "no github secret annotation") {
+		t.Fatalf("Resolve() error = %v, want missing annotation error", err)
+	}
+}
+
+func TestGitHubTokenSourcePAT(t *testing.T) {
+	token, err := NewGitHubTokenSource().Token(context.Background(), &GitHubCredential{
+		Type:  gitHubAuthTypePAT,
+		Token: "pat-token",
+	})
+	if err != nil {
+		t.Fatalf("Token() error = %v", err)
+	}
+	if token != "pat-token" {
+		t.Fatalf("Token() = %q, want pat-token", token)
+	}
+}
+
+func TestGitHubTokenSourceGitHubApp(t *testing.T) {
+	privateKey := testRSAPrivateKeyPEM(t)
+	requestSeen := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestSeen = true
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/app/installations/456/access_tokens" {
+			t.Fatalf("path = %s, want installation token path", r.URL.Path)
+		}
+		if auth := r.Header.Get("Authorization"); !strings.HasPrefix(auth, "Bearer ") {
+			t.Fatalf("Authorization = %q, want bearer JWT", auth)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"token":"installation-token"}`))
+	}))
+	defer server.Close()
+
+	source := NewGitHubTokenSource()
+	source.baseURL = server.URL
+	source.httpClient = server.Client()
+	source.now = func() time.Time {
+		return time.Unix(1700000000, 0)
+	}
+
+	token, err := source.Token(context.Background(), &GitHubCredential{
+		Type:           gitHubAuthTypeApp,
+		AppID:          "123",
+		InstallationID: "456",
+		PrivateKey:     privateKey,
+	})
+	if err != nil {
+		t.Fatalf("Token() error = %v", err)
+	}
+	if !requestSeen {
+		t.Fatal("Token() did not call installation token endpoint")
+	}
+	if token != "installation-token" {
+		t.Fatalf("Token() = %q, want installation-token", token)
+	}
+}
+
+func newTestCredentialResolver(t *testing.T, objects ...client.Object) *GitHubCredentialResolver {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("corev1.AddToScheme() error = %v", err)
+	}
+	if err := v1.AddToScheme(scheme); err != nil {
+		t.Fatalf("v1.AddToScheme() error = %v", err)
+	}
+
+	return NewGitHubCredentialResolver(fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		Build())
+}
+
+func testWorkload(name, secretName string) *v1.Workload {
+	return &v1.Workload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Annotations: map[string]string{
+				v1.GithubSecretIdAnnotation: secretName,
+			},
+		},
+	}
+}
+
+func testSecret(name string, data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: common.PrimusSafeNamespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: data,
+	}
+}
+
+func testRSAPrivateKeyPEM(t *testing.T) string {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey() error = %v", err)
+	}
+	block := &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}
+	return string(pem.EncodeToMemory(block))
+}

--- a/SaFE/resource-manager/pkg/github/credential_resolver_test.go
+++ b/SaFE/resource-manager/pkg/github/credential_resolver_test.go
@@ -99,17 +99,32 @@ func TestGitHubTokenSourcePAT(t *testing.T) {
 
 func TestGitHubTokenSourceGitHubApp(t *testing.T) {
 	privateKey := testRSAPrivateKeyPEM(t)
-	requestSeen := false
+	requestSeen := make(chan struct{}, 1)
+	handlerErr := make(chan string, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestSeen = true
+		select {
+		case requestSeen <- struct{}{}:
+		default:
+		}
+		recordHandlerError := func(message string) {
+			select {
+			case handlerErr <- message:
+			default:
+			}
+			http.Error(w, message, http.StatusBadRequest)
+		}
+
 		if r.Method != http.MethodPost {
-			t.Fatalf("method = %s, want POST", r.Method)
+			recordHandlerError("method = " + r.Method + ", want POST")
+			return
 		}
 		if r.URL.Path != "/app/installations/456/access_tokens" {
-			t.Fatalf("path = %s, want installation token path", r.URL.Path)
+			recordHandlerError("path = " + r.URL.Path + ", want installation token path")
+			return
 		}
 		if auth := r.Header.Get("Authorization"); !strings.HasPrefix(auth, "Bearer ") {
-			t.Fatalf("Authorization = %q, want bearer JWT", auth)
+			recordHandlerError("Authorization header does not contain bearer JWT")
+			return
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"token":"installation-token"}`))
@@ -132,7 +147,14 @@ func TestGitHubTokenSourceGitHubApp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Token() error = %v", err)
 	}
-	if !requestSeen {
+	select {
+	case message := <-handlerErr:
+		t.Fatal(message)
+	default:
+	}
+	select {
+	case <-requestSeen:
+	default:
 		t.Fatal("Token() did not call installation token endpoint")
 	}
 	if token != "installation-token" {

--- a/SaFE/resource-manager/pkg/github/sync_job.go
+++ b/SaFE/resource-manager/pkg/github/sync_job.go
@@ -10,22 +10,21 @@ import (
 	"encoding/json"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // SyncJob fetches GitHub API data for unsynced workflow runs and stores it in SaFE DB.
 // It runs periodically in job-manager.
 type SyncJob struct {
-	store       *Store
-	k8sClients  map[string]kubernetes.Interface
-	batchSize   int
-	interval    time.Duration
+	store              *Store
+	credentialResolver *GitHubCredentialResolver
+	tokenSource        gitHubTokenProvider
+	batchSize          int
+	interval           time.Duration
 }
 
-func NewSyncJob(store *Store, batchSize int, interval time.Duration) *SyncJob {
+func NewSyncJob(store *Store, k8sClient client.Client, batchSize int, interval time.Duration) *SyncJob {
 	if batchSize <= 0 {
 		batchSize = 20
 	}
@@ -33,15 +32,12 @@ func NewSyncJob(store *Store, batchSize int, interval time.Duration) *SyncJob {
 		interval = 30 * time.Second
 	}
 	return &SyncJob{
-		store:      store,
-		k8sClients: make(map[string]kubernetes.Interface),
-		batchSize:  batchSize,
-		interval:   interval,
+		store:              store,
+		credentialResolver: NewGitHubCredentialResolver(k8sClient),
+		tokenSource:        NewGitHubTokenSource(),
+		batchSize:          batchSize,
+		interval:           interval,
 	}
-}
-
-func (j *SyncJob) RegisterK8sClient(cluster string, client kubernetes.Interface) {
-	j.k8sClients[cluster] = client
 }
 
 func (j *SyncJob) Start(ctx context.Context) {
@@ -78,7 +74,7 @@ func (j *SyncJob) syncBatch(ctx context.Context) {
 			continue
 		}
 
-		token := j.getGitHubToken(ctx, run.Cluster, run.GithubOwner, run.GithubRepo)
+		token := j.getGitHubToken(ctx, &run)
 		client := NewGitHubClient(token)
 
 		synced := true
@@ -170,27 +166,23 @@ func (j *SyncJob) syncJobs(ctx context.Context, client *GitHubClient, run *Workf
 	return nil
 }
 
-// getGitHubToken retrieves the GitHub token from K8s Secret in the target cluster.
-func (j *SyncJob) getGitHubToken(ctx context.Context, cluster, owner, repo string) string {
-	k8sClient, ok := j.k8sClients[cluster]
-	if !ok {
-		return ""
+// getGitHubToken resolves the token for the workload that produced this GitHub run.
+func (j *SyncJob) getGitHubToken(ctx context.Context, run *WorkflowRunRecord) string {
+	workloadID := ""
+	if run != nil {
+		workloadID = run.WorkloadID
 	}
 
-	secrets, err := k8sClient.CoreV1().Secrets("").List(ctx, metav1.ListOptions{})
+	credential, err := j.credentialResolver.Resolve(ctx, run)
 	if err != nil {
+		klog.V(1).Infof("[github-sync] resolve github credential for workload %s: %v", workloadID, err)
 		return ""
 	}
 
-	for _, secret := range secrets.Items {
-		if secret.Type != corev1.SecretTypeOpaque {
-			continue
-		}
-		for _, key := range []string{"github_token", "token", "GITHUB_TOKEN"} {
-			if v, ok := secret.Data[key]; ok {
-				return string(v)
-			}
-		}
+	token, err := j.tokenSource.Token(ctx, credential)
+	if err != nil {
+		klog.V(1).Infof("[github-sync] create github token for workload %s: %v", workloadID, err)
+		return ""
 	}
-	return ""
+	return token
 }

--- a/SaFE/resource-manager/pkg/github/token_source.go
+++ b/SaFE/resource-manager/pkg/github/token_source.go
@@ -88,7 +88,14 @@ func (s *GitHubTokenSource) createInstallationToken(ctx context.Context, credent
 	}
 	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if err != nil {
+		partialBody := strings.TrimSpace(string(body))
+		if partialBody != "" {
+			return "", fmt.Errorf("github app installation token response read: %w: %s", err, partialBody)
+		}
+		return "", fmt.Errorf("github app installation token response read: %w", err)
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return "", fmt.Errorf("github app installation token: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}

--- a/SaFE/resource-manager/pkg/github/token_source.go
+++ b/SaFE/resource-manager/pkg/github/token_source.go
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+package github
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const gitHubAPIBaseURL = "https://api.github.com"
+
+type gitHubTokenProvider interface {
+	Token(ctx context.Context, credential *GitHubCredential) (string, error)
+}
+
+type GitHubTokenSource struct {
+	baseURL    string
+	httpClient *http.Client
+	now        func() time.Time
+}
+
+func NewGitHubTokenSource() *GitHubTokenSource {
+	return &GitHubTokenSource{
+		baseURL:    gitHubAPIBaseURL,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		now:        time.Now,
+	}
+}
+
+func (s *GitHubTokenSource) Token(ctx context.Context, credential *GitHubCredential) (string, error) {
+	if credential == nil {
+		return "", fmt.Errorf("github credential is nil")
+	}
+
+	switch credential.Type {
+	case gitHubAuthTypePAT:
+		if strings.TrimSpace(credential.Token) == "" {
+			return "", fmt.Errorf("github PAT credential is empty")
+		}
+		return strings.TrimSpace(credential.Token), nil
+	case gitHubAuthTypeApp:
+		return s.createInstallationToken(ctx, credential)
+	default:
+		return "", fmt.Errorf("unsupported github credential type %q", credential.Type)
+	}
+}
+
+func (s *GitHubTokenSource) createInstallationToken(ctx context.Context, credential *GitHubCredential) (string, error) {
+	if strings.TrimSpace(credential.AppID) == "" ||
+		strings.TrimSpace(credential.InstallationID) == "" ||
+		strings.TrimSpace(credential.PrivateKey) == "" {
+		return "", fmt.Errorf("github app credential is incomplete")
+	}
+
+	jwt, err := s.createAppJWT(credential)
+	if err != nil {
+		return "", err
+	}
+
+	url := strings.TrimRight(s.baseURL, "/") + "/app/installations/" + credential.InstallationID + "/access_tokens"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(nil))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("Authorization", "Bearer "+jwt)
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("github app installation token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("github app installation token: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var result struct {
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", fmt.Errorf("github app installation token response: %w", err)
+	}
+	if strings.TrimSpace(result.Token) == "" {
+		return "", fmt.Errorf("github app installation token response has no token")
+	}
+	return strings.TrimSpace(result.Token), nil
+}
+
+func (s *GitHubTokenSource) createAppJWT(credential *GitHubCredential) (string, error) {
+	key, err := parseRSAPrivateKey(credential.PrivateKey)
+	if err != nil {
+		return "", err
+	}
+
+	now := s.now()
+	claims := map[string]interface{}{
+		"iat": now.Add(-time.Minute).Unix(),
+		"exp": now.Add(10 * time.Minute).Unix(),
+		"iss": strings.TrimSpace(credential.AppID),
+	}
+	header := map[string]string{
+		"alg": "RS256",
+		"typ": "JWT",
+	}
+
+	headerJSON, err := json.Marshal(header)
+	if err != nil {
+		return "", err
+	}
+	claimsJSON, err := json.Marshal(claims)
+	if err != nil {
+		return "", err
+	}
+
+	encodedHeader := base64.RawURLEncoding.EncodeToString(headerJSON)
+	encodedClaims := base64.RawURLEncoding.EncodeToString(claimsJSON)
+	signingInput := encodedHeader + "." + encodedClaims
+
+	hashed := sha256.Sum256([]byte(signingInput))
+	signature, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, hashed[:])
+	if err != nil {
+		return "", fmt.Errorf("sign github app jwt: %w", err)
+	}
+
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(signature), nil
+}
+
+func parseRSAPrivateKey(raw string) (*rsa.PrivateKey, error) {
+	pemText := strings.TrimSpace(raw)
+	if !strings.Contains(pemText, "\n") {
+		pemText = strings.ReplaceAll(pemText, `\n`, "\n")
+	}
+
+	block, _ := pem.Decode([]byte(pemText))
+	if block == nil {
+		return nil, fmt.Errorf("decode github app private key PEM")
+	}
+
+	if key, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return key, nil
+	}
+
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse github app private key: %w", err)
+	}
+	key, ok := parsed.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("github app private key is not RSA")
+	}
+	return key, nil
+}

--- a/SaFE/resource-manager/pkg/resource/github_workflow_controller.go
+++ b/SaFE/resource-manager/pkg/resource/github_workflow_controller.go
@@ -54,7 +54,7 @@ func SetupGitHubWorkflowController(mgr manager.Manager) error {
 	store := githubpkg.NewStore(sqlDB)
 	tracker := githubpkg.NewWorkflowTracker(store)
 
-	syncJob := githubpkg.NewSyncJob(store, 20, 30*time.Second)
+	syncJob := githubpkg.NewSyncJob(store, mgr.GetClient(), 20, 30*time.Second)
 	go syncJob.Start(context.Background())
 
 	r := &GitHubWorkflowReconciler{


### PR DESCRIPTION
## Larger Feature
This is PR 3 of 4 in the split work to enable GitHub App support for CI/CD runner workloads. The 4 PRs together address #573 

## Merge Order
```mermaid
flowchart LR
  Audit["PR 1: Redact GitHub App private keys"]
  Backend["PR 2: Add GitHub App auth to CICD API"]
  Resolver["PR 3: Resolve GitHub credentials per workload"]
  Frontend["PR 4: Add GitHub App auth UI"]

  Backend --> Frontend
  Backend --> Resolver
```

- #579 can merge independently and is recommended first.
- #580 is the backend foundation and should merge before #582 and before full end-to-end GitHub App usage.
- #581 can merge after or alongside #580; it is needed for multiple CI/CD workloads and GitHub App scoped credentials.
- #582 should merge after #580.

## Summary
- Sync job fetches the exact GitHub secret referenced by the workload.
- Supports PAT and GitHub App token generation.

## Test Plan
- `cd SaFE/resource-manager && go test ./pkg/github ./pkg/resource`

Made with [Cursor](https://cursor.com)