### PR TITLE
feat(cicd): add GitHub App auth UI

### DIFF
--- a/Web/apps/safe/src/pages/CICD/Components/AddDialog.vue
+++ b/Web/apps/safe/src/pages/CICD/Components/AddDialog.vue
@@ -38,7 +38,12 @@
             <el-input v-model="form.description" :rows="2" type="textarea" />
           </el-form-item>
           <el-form-item label="entryPoint" prop="entryPoint">
-            <el-input v-model="form.entryPoint" :rows="2" type="textarea" placeholder="If multi-line, it is best to save them in a file on NFS, and then execute it. e.g. bash run.sh" />
+            <el-input
+              v-model="form.entryPoint"
+              :rows="2"
+              type="textarea"
+              placeholder="If multi-line, it is best to save them in a file on NFS, and then execute it. e.g. bash run.sh"
+            />
           </el-form-item>
           <el-form-item label="image" prop="image">
             <ImageInput v-model="form.image" />
@@ -47,7 +52,11 @@
             <el-select v-model="form.priority" placeholder="please select priority">
               <el-option label="Low" :value="0" />
               <el-option label="Medium" :value="1" />
-              <el-option label="High" :value="2" v-if="isManager || store.isCurrentWorkspaceAdmin()" />
+              <el-option
+                label="High"
+                :value="2"
+                v-if="isManager || store.isCurrentWorkspaceAdmin()"
+              />
             </el-select>
           </el-form-item>
         </div>
@@ -106,7 +115,11 @@
                           ({{ n.internalIP }})
                         </span>
                       </div>
-                      <el-tag :type="n.available ? 'success' : 'danger'" size="small" effect="plain">
+                      <el-tag
+                        :type="n.available ? 'success' : 'danger'"
+                        size="small"
+                        effect="plain"
+                      >
                         {{ n.available ? 'Available' : 'Unavailable' }}
                       </el-tag>
                     </div>
@@ -204,7 +217,12 @@
                 </el-col>
                 <el-col :span="12">
                   <el-form-item label="secret" prop="secretIds">
-                    <el-select v-model="form.secretIds" multiple :disabled="isEdit" placeholder="Please select secrets">
+                    <el-select
+                      v-model="form.secretIds"
+                      multiple
+                      :disabled="isEdit"
+                      placeholder="Please select secrets"
+                    >
                       <el-option
                         v-for="item in secretOptions"
                         :key="item.value"
@@ -226,7 +244,6 @@
                     </el-select>
                   </el-form-item>
                 </el-col>
-
               </el-row>
 
               <el-form-item label="GitHubConfigURL" prop="githubConfigUrl">
@@ -237,34 +254,64 @@
                 />
               </el-form-item>
 
-              <el-form-item label="GitHubPAT" prop="githubPAT" v-if="!isEdit">
-                <div class="flex items-center gap-2 w-full">
-                  <el-input
-                    v-model="form.githubPAT"
-                    placeholder="Enter GitHub PAT"
-                    type="password"
-                    class="flex-1"
-                  />
-                  <el-tooltip placement="top" raw-content>
-                    <template #content>
-                      <div>
-                        To create a PAT, visit
-                        <a
-                          href="https://app.docker.com/settings"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          style="color: #409eff; text-decoration: underline"
-                        >
-                          https://app.docker.com/settings
-                        </a>
-                      </div>
-                    </template>
-                    <el-icon class="text-gray-500 cursor-help">
-                      <InfoFilled />
-                    </el-icon>
-                  </el-tooltip>
-                </div>
-              </el-form-item>
+              <template v-if="!isEdit">
+                <el-form-item label="GitHubAuth" prop="githubAuthType">
+                  <el-radio-group v-model="form.githubAuthType">
+                    <el-radio-button label="github_app">GitHub App (recommended)</el-radio-button>
+                    <el-radio-button label="pat">Personal Access Token (legacy)</el-radio-button>
+                  </el-radio-group>
+                </el-form-item>
+
+                <template v-if="form.githubAuthType === 'github_app'">
+                  <el-form-item label="App ID" prop="githubAppId">
+                    <el-input v-model="form.githubAppId" placeholder="Enter GitHub App ID" />
+                  </el-form-item>
+                  <el-form-item label="Installation ID" prop="githubAppInstallationId">
+                    <el-input
+                      v-model="form.githubAppInstallationId"
+                      placeholder="Enter GitHub App installation ID"
+                    />
+                  </el-form-item>
+                  <el-form-item label="Private Key" prop="githubAppPrivateKey">
+                    <div class="w-full">
+                      <el-input
+                        v-model="form.githubAppPrivateKey"
+                        :rows="5"
+                        type="textarea"
+                        placeholder="Paste the GitHub App private key PEM"
+                        show-word-limit
+                      />
+                      <input
+                        class="pem-file-input"
+                        type="file"
+                        accept=".pem,.key,text/plain"
+                        @change="onPrivateKeyFileChange"
+                      />
+                    </div>
+                  </el-form-item>
+                </template>
+
+                <el-form-item label="GitHubPAT" prop="githubPAT" v-else>
+                  <div class="flex items-center gap-2 w-full">
+                    <el-input
+                      v-model="form.githubPAT"
+                      placeholder="Enter legacy GitHub PAT"
+                      type="password"
+                      class="flex-1"
+                    />
+                    <el-tooltip placement="top" raw-content>
+                      <template #content>
+                        <div>
+                          Legacy PAT authentication is still supported for existing workflows.
+                        </div>
+                      </template>
+                      <el-icon class="text-gray-500 cursor-help">
+                        <InfoFilled />
+                      </el-icon>
+                    </el-tooltip>
+                  </div>
+                </el-form-item>
+              </template>
             </div>
           </transition>
         </div>
@@ -300,6 +347,7 @@ import { debounce } from 'lodash'
 import { useUserStore } from '@/stores/user'
 import { InfoFilled, CopyDocument, ArrowRight } from '@element-plus/icons-vue'
 import ImageInput from '@/components/Base/ImageInput.vue'
+import { buildGitHubAuthPayload, validateGitHubAuthForm, type GitHubAuthType } from './githubAuth'
 
 const props = defineProps<{
   visible: boolean
@@ -357,6 +405,10 @@ const initialForm = () => ({
   priority: 1,
   unifiedJobEnable: false,
   githubConfigUrl: '',
+  githubAuthType: 'github_app' as GitHubAuthType,
+  githubAppId: '',
+  githubAppInstallationId: '',
+  githubAppPrivateKey: '',
   githubPAT: '',
   resource: {
     replica: 1,
@@ -411,7 +463,42 @@ const rules: Record<string, FormItemRule[]> = reactive({
     { required: true, message: 'Please input ephemeral storage', trigger: 'blur' },
   ],
   githubConfigUrl: [{ required: true, message: 'Please input GitHub config URL', trigger: 'blur' }],
-  githubPAT: [{ required: true, message: 'Please input GitHub PAT', trigger: 'blur' }],
+  githubAppId: [
+    {
+      validator: (_rule, _value, callback) => {
+        const [message] = validateGitHubAuthForm(form).filter((msg) => msg.includes('App ID'))
+        callback(message ? new Error(message) : undefined)
+      },
+      trigger: 'blur',
+    },
+  ],
+  githubAppInstallationId: [
+    {
+      validator: (_rule, _value, callback) => {
+        const [message] = validateGitHubAuthForm(form).filter((msg) => msg.includes('installation'))
+        callback(message ? new Error(message) : undefined)
+      },
+      trigger: 'blur',
+    },
+  ],
+  githubAppPrivateKey: [
+    {
+      validator: (_rule, _value, callback) => {
+        const [message] = validateGitHubAuthForm(form).filter((msg) => msg.includes('private key'))
+        callback(message ? new Error(message) : undefined)
+      },
+      trigger: 'blur',
+    },
+  ],
+  githubPAT: [
+    {
+      validator: (_rule, _value, callback) => {
+        const [message] = validateGitHubAuthForm(form)
+        callback(message ? new Error(message) : undefined)
+      },
+      trigger: 'blur',
+    },
+  ],
 })
 
 const onSubmit = async (formEl: FormInstance | undefined) => {
@@ -426,6 +513,10 @@ const onSubmit = async (formEl: FormInstance | undefined) => {
       timeout,
       unifiedJobEnable,
       githubConfigUrl,
+      githubAuthType,
+      githubAppId,
+      githubAppInstallationId,
+      githubAppPrivateKey,
       githubPAT,
       image,
       ...addPayload
@@ -461,12 +552,6 @@ const onSubmit = async (formEl: FormInstance | undefined) => {
       ENTRYPOINT: encodeToBase64String(entryPoint),
     }
 
-    // Handle GitHubPAT
-    // During Create/Clone, add PAT directly to env; backend will auto-create secret
-    if (!isEdit.value && githubPAT) {
-      envMap.GITHUB_PAT = githubPAT
-    }
-
     // Build secrets array
     const secrets = form.secretIds.map((id) => ({ id }))
 
@@ -482,10 +567,19 @@ const onSubmit = async (formEl: FormInstance | undefined) => {
         resources: [fixedResource],
         workspace: props.action === 'Clone' ? pendingWorkspaceId.value : store.currentWorkspaceId!,
         env: envMap,
+        githubAuth: buildGitHubAuthPayload({
+          githubAuthType,
+          githubAppId,
+          githubAppInstallationId,
+          githubAppPrivateKey,
+          githubPAT,
+        }),
         ...(excludedNodesPayload ? { excludedNodes: excludedNodesPayload } : {}),
         ...(secrets.length > 0 ? { secrets: secrets } : {}),
         ...(props.action === 'Resume' ? { workloadId: props.wlid } : {}),
-        ...(cachedUseWorkspaceStorage.value !== undefined ? { useWorkspaceStorage: cachedUseWorkspaceStorage.value } : {}),
+        ...(cachedUseWorkspaceStorage.value !== undefined
+          ? { useWorkspaceStorage: cachedUseWorkspaceStorage.value }
+          : {}),
       }
 
       await addWorkload(payload)
@@ -542,6 +636,15 @@ const cancelAdd = () => {
   })
 }
 
+const onPrivateKeyFileChange = async (event: Event) => {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
+  if (!file) return
+  form.githubAppPrivateKey = await file.text()
+  input.value = ''
+  ruleFormRef.value?.validateField('githubAppPrivateKey')
+}
+
 function createBetweenRule(min: number, max: number, unit?: string): FormItemRule {
   return {
     validator: (_rule: unknown, value: unknown, callback: (err?: Error) => void) => {
@@ -563,6 +666,18 @@ watch(
     }
   },
   { immediate: true },
+)
+
+watch(
+  () => form.githubAuthType,
+  () => {
+    ruleFormRef.value?.clearValidate([
+      'githubAppId',
+      'githubAppInstallationId',
+      'githubAppPrivateKey',
+      'githubPAT',
+    ])
+  },
 )
 
 const fetchFlavorAvail = async () => {
@@ -667,6 +782,9 @@ const setInitialFormValues = async () => {
     // Clear sensitive info during Clone/Resume so users can re-select
     form.secretIds = []
     form.githubPAT = ''
+    form.githubAppId = ''
+    form.githubAppInstallationId = ''
+    form.githubAppPrivateKey = ''
   }
 
   if (props.action === 'Clone') {
@@ -857,6 +975,11 @@ html.dark .section-card:hover {
 /* Leave some space at the top of advanced expanded content */
 .advanced-body {
   margin-top: 4px;
+}
+
+.pem-file-input {
+  margin-top: 8px;
+  font-size: 12px;
 }
 
 /* Drawer footer */

--- a/Web/apps/safe/src/pages/CICD/Components/__tests__/githubAuth.test.ts
+++ b/Web/apps/safe/src/pages/CICD/Components/__tests__/githubAuth.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { buildGitHubAuthPayload, validateGitHubAuthForm, type GitHubAuthForm } from '../githubAuth'
+
+const baseForm = (overrides: Partial<GitHubAuthForm>): GitHubAuthForm => ({
+  githubAuthType: 'github_app',
+  githubAppId: '',
+  githubAppInstallationId: '',
+  githubAppPrivateKey: '',
+  githubPAT: '',
+  ...overrides,
+})
+
+describe('CICD GitHub auth payload', () => {
+  it('builds a GitHub App payload', () => {
+    expect(
+      buildGitHubAuthPayload(
+        baseForm({
+          githubAppId: ' 12345 ',
+          githubAppInstallationId: ' 67890 ',
+          githubAppPrivateKey: ' private-key ',
+        }),
+      ),
+    ).toEqual({
+      type: 'github_app',
+      appId: '12345',
+      installationId: '67890',
+      privateKey: 'private-key',
+    })
+  })
+
+  it('builds a legacy PAT payload', () => {
+    expect(
+      buildGitHubAuthPayload(
+        baseForm({
+          githubAuthType: 'pat',
+          githubPAT: ' ghp_test ',
+        }),
+      ),
+    ).toEqual({
+      type: 'pat',
+      token: 'ghp_test',
+    })
+  })
+
+  it('validates required GitHub App fields', () => {
+    expect(validateGitHubAuthForm(baseForm({ githubAppId: '12345' }))).toEqual([
+      'Please input GitHub App installation ID',
+      'Please input GitHub App private key',
+    ])
+  })
+
+  it('validates legacy PAT field', () => {
+    expect(validateGitHubAuthForm(baseForm({ githubAuthType: 'pat' }))).toEqual([
+      'Please input GitHub PAT',
+    ])
+  })
+})

--- a/Web/apps/safe/src/pages/CICD/Components/githubAuth.ts
+++ b/Web/apps/safe/src/pages/CICD/Components/githubAuth.ts
@@ -1,0 +1,51 @@
+export type GitHubAuthType = 'github_app' | 'pat'
+
+export interface GitHubAuthForm {
+  githubAuthType: GitHubAuthType
+  githubAppId: string
+  githubAppInstallationId: string
+  githubAppPrivateKey: string
+  githubPAT: string
+}
+
+export type GitHubAuthPayload =
+  | {
+      type: 'github_app'
+      appId: string
+      installationId: string
+      privateKey: string
+    }
+  | {
+      type: 'pat'
+      token: string
+    }
+
+const clean = (value: string) => value.trim()
+
+export const validateGitHubAuthForm = (form: GitHubAuthForm): string[] => {
+  if (form.githubAuthType === 'pat') {
+    return clean(form.githubPAT) ? [] : ['Please input GitHub PAT']
+  }
+
+  const missing: string[] = []
+  if (!clean(form.githubAppId)) missing.push('Please input GitHub App ID')
+  if (!clean(form.githubAppInstallationId)) missing.push('Please input GitHub App installation ID')
+  if (!clean(form.githubAppPrivateKey)) missing.push('Please input GitHub App private key')
+  return missing
+}
+
+export const buildGitHubAuthPayload = (form: GitHubAuthForm): GitHubAuthPayload => {
+  if (form.githubAuthType === 'pat') {
+    return {
+      type: 'pat',
+      token: clean(form.githubPAT),
+    }
+  }
+
+  return {
+    type: 'github_app',
+    appId: clean(form.githubAppId),
+    installationId: clean(form.githubAppInstallationId),
+    privateKey: clean(form.githubAppPrivateKey),
+  }
+}

--- a/Web/apps/safe/src/pages/CICD/index.vue
+++ b/Web/apps/safe/src/pages/CICD/index.vue
@@ -62,12 +62,12 @@
           :icon="ResetIcon"
           size="default"
           @click="
-          () => {
-            const { onlyMyself, userId } = searchParams
-            Object.assign(searchParams, initialSearchParams, { onlyMyself, userId })
-            pagination.page = 1
-            onSearch({ resetPage: true })
-          }
+            () => {
+              const { onlyMyself, userId } = searchParams
+              Object.assign(searchParams, initialSearchParams, { onlyMyself, userId })
+              pagination.page = 1
+              onSearch({ resetPage: true })
+            }
           "
         ></el-button>
       </el-tooltip>
@@ -108,7 +108,10 @@
               <el-table :data="subTableDataMap[row.workloadId] || []" size="small">
                 <el-table-column prop="workloadId" label="Name/ID" min-width="180">
                   <template #default="{ row: subRow }">
-                    <el-link type="primary" v-route="{ path: '/cicd/detail', query: { id: subRow.workloadId } }">
+                    <el-link
+                      type="primary"
+                      v-route="{ path: '/cicd/detail', query: { id: subRow.workloadId } }"
+                    >
                       {{ subRow.displayName }}
                     </el-link>
                     <div class="text-[12px] text-gray-400">
@@ -235,9 +238,11 @@
         <el-table-column prop="workloadId" label="Name/ID" min-width="200" :fixed="true">
           <template #default="{ row }">
             <div class="flex flex-col items-start">
-              <el-link type="primary" v-route="{ path: '/cicd/detail', query: { id: row.workloadId } }">{{
-                row.displayName
-              }}</el-link>
+              <el-link
+                type="primary"
+                v-route="{ path: '/cicd/detail', query: { id: row.workloadId } }"
+                >{{ row.displayName }}</el-link
+              >
               <div class="text-[13px] text-gray-400">
                 {{ row.workloadId }}
                 <el-icon
@@ -374,7 +379,9 @@
           </div>
 
           <div class="right">
-            <el-button type="danger" plain :disabled="!canWrite" @click="onBatchDelete">Delete</el-button>
+            <el-button type="danger" plain :disabled="!canWrite" @click="onBatchDelete"
+              >Delete</el-button
+            >
           </div>
         </div>
       </transition>
@@ -453,7 +460,10 @@
     >
       <el-table-column prop="workloadId" label="Name/ID" min-width="180">
         <template #default="{ row: subRow }">
-          <el-link type="primary" v-route="{ path: '/cicd/detail', query: { id: subRow.workloadId } }">
+          <el-link
+            type="primary"
+            v-route="{ path: '/cicd/detail', query: { id: subRow.workloadId } }"
+          >
             {{ subRow.displayName }}
           </el-link>
           <div class="text-[12px] text-gray-400">
@@ -608,7 +618,15 @@ import { useRoute, useRouter } from 'vue-router'
 import { useRouteAction, ROUTE_ACTIONS } from '@/composables/useRouteAction'
 import AddDialog from './Components/AddDialog.vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
-import { Delete, DocumentCopy, MoreFilled, Close, Edit, Key, VideoPlay } from '@element-plus/icons-vue'
+import {
+  Delete,
+  DocumentCopy,
+  MoreFilled,
+  Close,
+  Edit,
+  Key,
+  VideoPlay,
+} from '@element-plus/icons-vue'
 import { type WorkloadParams, PRIORITY_LABEL_MAP, type PriorityValue } from '@/services'
 import { encodeToBase64String } from '@/utils'
 import { useUserStore } from '@/stores/user'
@@ -782,9 +800,6 @@ type Row = { workloadId: string; phase: string; pods: { podId?: string }[]; disp
 
 const handleUpdatePAT = async (row: Row) => {
   try {
-    // First get the current workload details
-    const workloadDetail = await getWorkloadDetail(row.workloadId)
-
     // Show dialog to input new PAT
     const messageBox = ElMessageBox.prompt('', 'Update PAT', {
       confirmButtonText: 'Update',
@@ -806,15 +821,12 @@ const handleUpdatePAT = async (row: Row) => {
 
     const { value } = (await messageBox) as { value: string }
 
-    // Get all existing env vars and update GITHUB_PAT
-    const updatedEnv = {
-      ...workloadDetail.env,
-      GITHUB_PAT: value,
-    }
-
     // Call workload edit API
     await editWorkload(row.workloadId, {
-      env: updatedEnv,
+      githubAuth: {
+        type: 'pat',
+        token: value,
+      },
     })
 
     ElMessage.success('GitHub PAT updated successfully')
@@ -1304,7 +1316,9 @@ const onAnyPointerDown = (e: Event) => {
   if (!inMenu && !inRefBtn) closeMore()
 }
 useRouteAction({
-  [ROUTE_ACTIONS.CREATE]: () => { addVisible.value = true },
+  [ROUTE_ACTIONS.CREATE]: () => {
+    addVisible.value = true
+  },
 })
 
 onMounted(() => {

--- a/Web/apps/safe/src/pages/CICD/index.vue
+++ b/Web/apps/safe/src/pages/CICD/index.vue
@@ -820,12 +820,17 @@ const handleUpdatePAT = async (row: Row) => {
     })
 
     const { value } = (await messageBox) as { value: string }
+    const token = value.trim()
+    if (!token) {
+      ElMessage.error('PAT cannot be empty')
+      return
+    }
 
     // Call workload edit API
     await editWorkload(row.workloadId, {
       githubAuth: {
         type: 'pat',
-        token: value,
+        token,
       },
     })
 

--- a/Web/apps/safe/src/services/workload/type.ts
+++ b/Web/apps/safe/src/services/workload/type.ts
@@ -36,7 +36,7 @@ export enum WorkloadKind {
 
   AutoscalingRunnerSet = 'AutoscalingRunnerSet',
   EphemeralRunner = 'EphemeralRunner',
-  UnifiedJob='UnifiedJob',
+  UnifiedJob = 'UnifiedJob',
 
   PyTorchJob = 'PyTorchJob',
   Authoring = 'Authoring',
@@ -97,6 +97,7 @@ export interface GetWorkloadPodLogResponse {
 }
 // Edit + Create
 export interface EditWorkloadRequest {
+  githubAuth?: GitHubAuthPayload
   description?: string
   entryPoint?: string
   entryPoints?: string[]
@@ -116,8 +117,21 @@ export interface EditWorkloadRequest {
   privileged?: boolean
 }
 
+export type GitHubAuthPayload =
+  | {
+      type: 'github_app'
+      appId: string
+      installationId: string
+      privateKey: string
+    }
+  | {
+      type: 'pat'
+      token: string
+    }
+
 export interface SubmitWorkloadRequest {
   workspace: string
+  githubAuth?: GitHubAuthPayload
   displayName: string
   groupVersionKind: {
     kind: string


### PR DESCRIPTION
## Larger Feature
This is PR 4 of 4 in the split work to enable GitHub App support for CI/CD runner workloads. The 4 PRs together address #573 

## Merge Order
```mermaid
flowchart LR
  Audit["PR 1: Redact GitHub App private keys"]
  Backend["PR 2: Add GitHub App auth to CICD API"]
  Resolver["PR 3: Resolve GitHub credentials per workload"]
  Frontend["PR 4: Add GitHub App auth UI"]

  Backend --> Frontend
  Backend --> Resolver
```

- #579 can merge independently and is recommended first.
- #580 is the backend foundation and should merge before #582 and before full end-to-end GitHub App usage.
- #581 can merge after or alongside #580; it is needed for multiple CI/CD workloads and GitHub App scoped credentials.
- #582 should merge after #580.

## Summary
- UI supports choosing PAT or GitHub App auth.
- Submits the new backend request shape.

## Test Plan
- `cd Web/apps/safe && pnpm test src/pages/CICD/Components/__tests__/githubAuth.test.ts`

## Screenshot
The updated CICD UI
<img width="1212" height="753" alt="Screenshot 2026-05-21 151832" src="https://github.com/user-attachments/assets/9e25df12-bf65-4b05-b621-be73cc758681" />

Made with [Cursor](https://cursor.com)