### PR TITLE
fix(setup-certs): support RHEL/CentOS trust store and self-elevate

### DIFF
--- a/Scripts/setup-certs/setup.sh
+++ b/Scripts/setup-certs/setup.sh
@@ -1,18 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+REPO_RAW="https://raw.githubusercontent.com/AMD-AGI/Primus-SaFE/main/Scripts/setup-certs"
+
 # Re-exec as root if needed, so the `curl ... | bash` one-liner still works
-# on hosts where the user is not root but has sudo.
+# for non-root users who have sudo. Handles both invocation styles:
+#   - file:  bash setup.sh        -> $0 is the script path, re-exec it
+#   - piped: curl ... | bash      -> $0 is "bash" (no file), re-fetch under sudo
 if [ "$(id -u)" -ne 0 ]; then
     if command -v sudo >/dev/null 2>&1; then
         echo "Not running as root, re-executing with sudo..."
-        exec sudo -E bash "$0" "$@"
+        if [ -f "$0" ]; then
+            exec sudo -E bash "$0" "$@"
+        fi
+        # Piped via stdin (curl ... | bash): no file to re-exec, so re-fetch
+        # the script and hand it to sudo. Guard against a failed download.
+        _self="$(curl -fsSL "$REPO_RAW/setup.sh")" || {
+            echo "ERROR: failed to re-download script for sudo re-exec." >&2
+            exit 1
+        }
+        exec sudo -E bash -c "$_self" -- "$@"
     fi
     echo "ERROR: this script must run as root, and sudo is not available." >&2
     exit 1
 fi
-
-REPO_RAW="https://raw.githubusercontent.com/AMD-AGI/Primus-SaFE/main/Scripts/setup-certs"
 
 # Detect the distro family and pick the matching trust-store layout. Debian and
 # RHEL families use different anchor dirs, update tools, and Node CA bundles.

--- a/Scripts/setup-certs/setup.sh
+++ b/Scripts/setup-certs/setup.sh
@@ -1,14 +1,53 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Re-exec as root if needed, so the `curl ... | bash` one-liner still works
+# on hosts where the user is not root but has sudo.
+if [ "$(id -u)" -ne 0 ]; then
+    if command -v sudo >/dev/null 2>&1; then
+        echo "Not running as root, re-executing with sudo..."
+        exec sudo -E bash "$0" "$@"
+    fi
+    echo "ERROR: this script must run as root, and sudo is not available." >&2
+    exit 1
+fi
+
 REPO_RAW="https://raw.githubusercontent.com/AMD-AGI/Primus-SaFE/main/Scripts/setup-certs"
 
+# Detect the distro family and pick the matching trust-store layout. Debian and
+# RHEL families use different anchor dirs, update tools, and Node CA bundles.
+ID="" ID_LIKE="" PRETTY_NAME=""
+if [ -r /etc/os-release ]; then
+    . /etc/os-release
+fi
+case " ${ID_LIKE:-} ${ID:-} " in
+    *rhel*|*fedora*|*centos*|*rocky*|*almalinux*)
+        ANCHOR_DIR=/etc/pki/ca-trust/source/anchors
+        UPDATE_CMD=(update-ca-trust extract)
+        NODE_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
+        ;;
+    *debian*|*ubuntu*)
+        ANCHOR_DIR=/usr/local/share/ca-certificates
+        UPDATE_CMD=(update-ca-certificates)
+        NODE_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+        ;;
+    *)
+        echo "ERROR: unsupported distro: ${PRETTY_NAME:-${ID:-unknown}}" >&2
+        echo "  Supported: Debian/Ubuntu and RHEL/CentOS/Rocky/Alma/Fedora families." >&2
+        exit 1
+        ;;
+esac
+
+ROOT_CA="$ANCHOR_DIR/amd-root-ca.crt"
+ISSUING_CA="$ANCHOR_DIR/amd-issuing-ca.crt"
+
 echo "[1/4] Downloading CA certificates from GitHub..."
-curl -fsSL "$REPO_RAW/amd-root-ca.crt"    -o /usr/local/share/ca-certificates/amd-root-ca.crt
-curl -fsSL "$REPO_RAW/amd-issuing-ca.crt" -o /usr/local/share/ca-certificates/amd-issuing-ca.crt
+mkdir -p "$ANCHOR_DIR"
+curl -fsSL "$REPO_RAW/amd-root-ca.crt"    -o "$ROOT_CA"
+curl -fsSL "$REPO_RAW/amd-issuing-ca.crt" -o "$ISSUING_CA"
 
 echo "[2/4] Updating system trust store..."
-update-ca-certificates
+"${UPDATE_CMD[@]}"
 
 echo "[3/5] Appending CA certs to Python certifi bundle..."
 BUNDLE=""
@@ -20,8 +59,7 @@ if [ -n "$BUNDLE" ]; then
     if grep -q 'AMD Corporate Root CA' "$BUNDLE" 2>/dev/null; then
         echo "  certifi bundle already contains AMD certs ($BUNDLE), skipping."
     else
-        cat /usr/local/share/ca-certificates/amd-root-ca.crt \
-            /usr/local/share/ca-certificates/amd-issuing-ca.crt >> "$BUNDLE"
+        cat "$ROOT_CA" "$ISSUING_CA" >> "$BUNDLE"
         echo "  Appended AMD certs to $BUNDLE"
     fi
 else
@@ -32,7 +70,7 @@ echo "[4/5] Configuring Node.js to use system CA store..."
 if grep -q 'NODE_EXTRA_CA_CERTS' /etc/environment 2>/dev/null; then
     echo "  NODE_EXTRA_CA_CERTS already set in /etc/environment, skipping."
 else
-    echo 'NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt' >> /etc/environment
+    echo "NODE_EXTRA_CA_CERTS=$NODE_BUNDLE" >> /etc/environment
     echo "  Added NODE_EXTRA_CA_CERTS to /etc/environment."
 fi
 


### PR DESCRIPTION
## Summary

`Scripts/setup-certs/setup.sh` was hard-coded to the Debian/Ubuntu trust-store
layout and assumed it always ran as root, so the README `curl ... | bash`
one-liner silently failed on RHEL-family hosts (CentOS / RHEL / Rocky / Alma /
Fedora). See AMD-AGI/Hyperloom#328.

- **Distro-aware**: detect the family via `/etc/os-release` (`ID` / `ID_LIKE`)
  and branch on anchor dir, update tool, and Node CA bundle:
  - RHEL family → `/etc/pki/ca-trust/source/anchors` + `update-ca-trust extract` + `/etc/pki/tls/certs/ca-bundle.crt`
  - Debian family → `/usr/local/share/ca-certificates` + `update-ca-certificates` + `/etc/ssl/certs/ca-certificates.crt`
- **Self-elevating**: re-exec via `sudo -E bash` when not root, so the piped
  one-liner works for non-root users; fail clearly when neither root nor sudo
  is available.
- **Fail loud**: error out on unsupported distros instead of pretending to
  succeed.

## Test plan

Ran the branch script inside throwaway mount namespaces (fake `/etc/os-release`
+ stubbed trust tools) on an Ubuntu 22.04 host, so the host trust store was
never modified:

- [x] `bash -n` syntax check passes
- [x] Debian/Ubuntu: certs → `/usr/local/share/ca-certificates`, `update-ca-certificates`, `NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt` (no regression)
- [x] RHEL/CentOS: certs → `/etc/pki/ca-trust/source/anchors`, `update-ca-trust extract`, `NODE_EXTRA_CA_CERTS=/etc/pki/tls/certs/ca-bundle.crt`
- [x] Unsupported distro (alpine): prints error and exits 1
- [x] Non-root: prints "re-executing with sudo" and re-execs via `sudo -E bash`

Fixes AMD-AGI/Hyperloom#328
