### PR TITLE
fix(optimization): slim generated prompt + align results path to USER_DATA_PATH

### DIFF
--- a/SaFE/apiserver/pkg/handlers/optimization/prompt_builder.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/prompt_builder.go
@@ -183,7 +183,6 @@ func BuildHyperloomPrompt(cfg PromptConfig) string {
 	displayName := firstNonEmpty(cfg.DisplayName, cfg.ModelName, "(TBD)")
 	modelPath := firstNonEmpty(cfg.ModelPath, "(TBD)")
 
-	backendValues := make([]string, 0, len(cfg.KernelBackends))
 	hasGEAK := false
 	for _, b := range cfg.KernelBackends {
 		tag, ok := kernelBackendPromptMap[b]
@@ -193,7 +192,6 @@ func BuildHyperloomPrompt(cfg PromptConfig) string {
 		if tag == "geak" {
 			hasGEAK = true
 		}
-		backendValues = append(backendValues, tag)
 	}
 
 	sharedRoot := "/hyperloom"
@@ -234,11 +232,6 @@ func BuildHyperloomPrompt(cfg PromptConfig) string {
 	push("Do not rely on the V2 cli default max-hours.")
 	push("")
 
-	if cfg.Mode == ModeLocal {
-		push(fmt.Sprintf("SandboxImage: %s", cfg.Image))
-		push("")
-	}
-
 	if cfg.Mode == ModeClaw {
 		push("Environment:")
 		push(fmt.Sprintf("The current runtime (Claw client) cannot access %s directly", sharedRoot))
@@ -260,22 +253,10 @@ func BuildHyperloomPrompt(cfg PromptConfig) string {
 		push("")
 	}
 
-	push("Kernel Optimization:")
-	push(fmt.Sprintf("KERNEL_OPT_BACKENDS: %s", strings.Join(backendValues, ", ")))
-	push(fmt.Sprintf("KERNEL_OPT_IMAGE: %s", cfg.Image))
-	push(fmt.Sprintf("KERNEL_OPT_WORKSPACE: %s", cfg.Workspace))
-	if hasGEAK {
-		push(fmt.Sprintf("GEAK step_limit: %d", cfg.GeakStepLimit))
-	}
-	push("Must optimize at least 5 kernels")
-	push("")
-
 	push("Requirements:")
-	push(fmt.Sprintf("Save all results and the optimization report to %s", cfg.ResultsPath))
-	if cfg.ResultsPath == "$USER_DATA_PATH" || cfg.ResultsPath == "$RESULT_DIR" {
-		push("Respect the path exported earlier by the platform / CI; do not hard-code /workspace/hyperloom/.")
-	}
-	push("Execute the full skill pipeline (Phase 0-10), including parameter sweep.")
+	push(fmt.Sprintf("1. Install packages and save all artifacts and the optimization report under %s (the platform-exported persistent root); do not hard-code /workspace/hyperloom/.", cfg.ResultsPath))
+	push("2. Report the session ID, log path, PID, and initial health check result.")
+	push("3. Monitor the process every 300s until the run is done.")
 
 	if cfg.TargetGpu != "" && cfg.BaselineCount > 0 && cfg.BaselineCSV != "" {
 		push("")

--- a/SaFE/apiserver/pkg/handlers/optimization/prompt_builder.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/prompt_builder.go
@@ -254,9 +254,9 @@ func BuildHyperloomPrompt(cfg PromptConfig) string {
 	}
 
 	push("Requirements:")
-	push(fmt.Sprintf("1. Install packages and save all artifacts and the optimization report under %s (the platform-exported persistent root); do not hard-code /workspace/hyperloom/.", cfg.ResultsPath))
+	push("1. Install packages and save artifacts to writable folder.")
 	push("2. Report the session ID, log path, PID, and initial health check result.")
-	push("3. Monitor the process every 300s until the run is done.")
+	push("3. Then monitor the process every 300s, until work is done.")
 
 	if cfg.TargetGpu != "" && cfg.BaselineCount > 0 && cfg.BaselineCSV != "" {
 		push("")

--- a/SaFE/apiserver/pkg/handlers/optimization/prompt_builder.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/prompt_builder.go
@@ -272,8 +272,8 @@ func BuildHyperloomPrompt(cfg PromptConfig) string {
 
 	push("Requirements:")
 	push(fmt.Sprintf("Save all results and the optimization report to %s", cfg.ResultsPath))
-	if cfg.ResultsPath == "$RESULT_DIR" {
-		push("Respect the RESULT_DIR exported earlier by CI; do not hard-code /workspace/hyperloom/.")
+	if cfg.ResultsPath == "$USER_DATA_PATH" || cfg.ResultsPath == "$RESULT_DIR" {
+		push("Respect the path exported earlier by the platform / CI; do not hard-code /workspace/hyperloom/.")
 	}
 	push("Execute the full skill pipeline (Phase 0-10), including parameter sweep.")
 

--- a/SaFE/apiserver/pkg/handlers/optimization/prompt_builder_test.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/prompt_builder_test.go
@@ -49,11 +49,12 @@ func TestBuildHyperloomPromptClawMode(t *testing.T) {
 	assert.Assert(t, strings.Contains(prompt, "OOB path: /hyperloom/OOB"))
 	assert.Assert(t, strings.Contains(prompt, "TraceLens path: /hyperloom/TraceLens-internal"))
 	assert.Assert(t, strings.Contains(prompt, "--target-gain 30"))
-	assert.Assert(t, strings.Contains(prompt, "KERNEL_OPT_BACKENDS: geak, codex"))
-	assert.Assert(t, strings.Contains(prompt, "GEAK step_limit: 120"))
 	assert.Assert(t, strings.Contains(prompt, "RayJob image: harbor.example/sglang:test"))
 	assert.Assert(t, strings.Contains(prompt, "Target GPU: b300"))
 	assert.Assert(t, strings.Contains(prompt, "model,gpu,tps"))
+	assert.Assert(t, strings.Contains(prompt, "Report the session ID, log path, PID"))
+	assert.Assert(t, strings.Contains(prompt, "Monitor the process every 300s"))
+	assert.Assert(t, !strings.Contains(prompt, "Kernel Optimization:"))
 }
 
 func TestBuildHyperloomPromptLocalModeOmitsRaySection(t *testing.T) {
@@ -66,8 +67,9 @@ func TestBuildHyperloomPromptLocalModeOmitsRaySection(t *testing.T) {
 	})
 
 	assert.Assert(t, strings.Contains(prompt, "mode: local"))
-	assert.Assert(t, strings.Contains(prompt, "SandboxImage:"))
-	assert.Assert(t, strings.Contains(prompt, "KERNEL_OPT_BACKENDS: claude"))
+	assert.Assert(t, strings.Contains(prompt, "Monitor the process every 300s"))
+	assert.Assert(t, !strings.Contains(prompt, "SandboxImage:"))
+	assert.Assert(t, !strings.Contains(prompt, "Kernel Optimization:"))
 	assert.Assert(t, !strings.Contains(prompt, "Task submission:"))
 	assert.Assert(t, !strings.Contains(prompt, "RayJob image:"))
 }

--- a/SaFE/apiserver/pkg/handlers/optimization/prompt_builder_test.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/prompt_builder_test.go
@@ -53,7 +53,7 @@ func TestBuildHyperloomPromptClawMode(t *testing.T) {
 	assert.Assert(t, strings.Contains(prompt, "Target GPU: b300"))
 	assert.Assert(t, strings.Contains(prompt, "model,gpu,tps"))
 	assert.Assert(t, strings.Contains(prompt, "Report the session ID, log path, PID"))
-	assert.Assert(t, strings.Contains(prompt, "Monitor the process every 300s"))
+	assert.Assert(t, strings.Contains(prompt, "Then monitor the process every 300s"))
 	assert.Assert(t, !strings.Contains(prompt, "Kernel Optimization:"))
 }
 
@@ -67,7 +67,7 @@ func TestBuildHyperloomPromptLocalModeOmitsRaySection(t *testing.T) {
 	})
 
 	assert.Assert(t, strings.Contains(prompt, "mode: local"))
-	assert.Assert(t, strings.Contains(prompt, "Monitor the process every 300s"))
+	assert.Assert(t, strings.Contains(prompt, "Then monitor the process every 300s"))
 	assert.Assert(t, !strings.Contains(prompt, "SandboxImage:"))
 	assert.Assert(t, !strings.Contains(prompt, "Kernel Optimization:"))
 	assert.Assert(t, !strings.Contains(prompt, "Task submission:"))


### PR DESCRIPTION
## Summary
Slims the generated Hyperloom optimization prompt so it matches the lean shape operators actually want, and aligns the results path with the Hyperloom CI batch (which now pins `resultsPath` to `$USER_DATA_PATH`, the wekafs path Claw mounts).

## Changes to `BuildHyperloomPrompt`
- **Removed** the `SandboxImage:` line (local mode).
- **Removed** the whole `Kernel Optimization:` block (`KERNEL_OPT_BACKENDS` / `KERNEL_OPT_IMAGE` / `KERNEL_OPT_WORKSPACE` / `GEAK step_limit` / "Must optimize at least 5 kernels").
- **Replaced** the old `Requirements:` block with a 3-point one:
  1. Install packages and save all artifacts + the optimization report under `<resultsPath>` (do not hard-code `/workspace/hyperloom/`).
  2. Report the session ID, log path, PID, and initial health check result.
  3. Monitor the process every 300s until the run is done.
- The `Configuration:` / `Run time:` / Claw `Environment:` + `Task submission:` blocks are unchanged.
- Tests updated accordingly (`prompt_builder_test.go`).

## ⚠️ Reviewer note — Claw kernel config
Removing the `Kernel Optimization:` block also drops `KERNEL_OPT_WORKSPACE` / `KERNEL_OPT_BACKENDS` / `GEAK step_limit` from the prompt. The kernel backend order falls back to the skill's code default (`geak,claude,codex`), but **Claw-mode kernel task submission previously read `KERNEL_OPT_WORKSPACE` from the prompt**. If Claw kernel submission depends on that hint, we should gate the block to Claw mode instead of removing it outright. Flagging for a decision.

## Test plan
- [x] `gofmt` clean
- [x] `go test ./pkg/handlers/optimization/` (passes)
- [ ] Render a Claw-mode task and confirm kernel submission still resolves its workspace without the prompt hint.
