### PR TITLE
fix(optimization): stop prompting default tool paths

### DIFF
--- a/SaFE/apiserver/pkg/handlers/optimization/handler.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/handler.go
@@ -868,7 +868,6 @@ func promptConfigFromRequest(req *CreateTaskRequest, m *ResolvedModel, workspace
 		MaxHours:       req.MaxHours,
 		TargetGain:     req.TargetGain,
 		Image:          req.Image,
-		InferenceXPath: req.InferenceXPath,
 		OOBPath:        req.OOBPath,
 		TraceLensRoot:  req.TraceLensRoot,
 		Workspace:      workspace,

--- a/SaFE/apiserver/pkg/handlers/optimization/prompt_builder.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/prompt_builder.go
@@ -15,25 +15,24 @@ import (
 // so that a task created via SaFE produces the same prompt as the same form
 // submitted through the Hyperloom UI.
 const (
-	defaultMode           = ModeClaw
-	defaultFramework      = FrameworkSGLang
-	defaultPrecision      = "FP4"
-	defaultGPUType        = "MI355X"
-	defaultISL            = 1024
-	defaultOSL            = 1024
-	defaultConcurrency    = 64
-	defaultTP             = 1
-	defaultEP             = 1
-	defaultInferenceXPath = "/hyperloom/InferenceX"
-	defaultResultsPath    = "/workspace/hyperloom/"
-	defaultGeakStepLimit  = 100
-	defaultMaxHours       = 3.0
-	defaultTargetGain     = 30.0
-	defaultRayReplica     = 1
-	defaultRayGpu         = 1
-	defaultRayCPU         = 12
-	defaultRayMemoryGi    = 128
-	raySharedMemoryGi     = 500
+	defaultMode          = ModeClaw
+	defaultFramework     = FrameworkSGLang
+	defaultPrecision     = "FP4"
+	defaultGPUType       = "MI355X"
+	defaultISL           = 1024
+	defaultOSL           = 1024
+	defaultConcurrency   = 64
+	defaultTP            = 1
+	defaultEP            = 1
+	defaultResultsPath   = "/workspace/hyperloom/"
+	defaultGeakStepLimit = 100
+	defaultMaxHours      = 3.0
+	defaultTargetGain    = 30.0
+	defaultRayReplica    = 1
+	defaultRayGpu        = 1
+	defaultRayCPU        = 12
+	defaultRayMemoryGi   = 128
+	raySharedMemoryGi    = 500
 
 	defaultSGLangImage = "harbor.core42.primus-safe.amd.com/sync/sglang:v0.5.11-rocm720-mi30x"
 	defaultVLLMImage   = "harbor.core42.primus-safe.amd.com/proxy/vllm/vllm-openai-rocm:v0.19.0"
@@ -67,7 +66,6 @@ type PromptConfig struct {
 	MaxHours       float64
 	TargetGain     float64
 	Image          string
-	InferenceXPath string
 	OOBPath        string
 	TraceLensRoot  string
 	Workspace      string
@@ -129,9 +127,6 @@ func NormalizePromptConfig(cfg PromptConfig) PromptConfig {
 	}
 	if cfg.TargetGain <= 0 {
 		cfg.TargetGain = defaultTargetGain
-	}
-	if cfg.InferenceXPath == "" {
-		cfg.InferenceXPath = defaultInferenceXPath
 	}
 	if cfg.ResultsPath == "" {
 		cfg.ResultsPath = defaultResultsPath
@@ -214,7 +209,6 @@ func BuildHyperloomPrompt(cfg PromptConfig) string {
 	push(fmt.Sprintf("Inference params: ISL=%d, OSL=%d, CONC=%d", cfg.ISL, cfg.OSL, cfg.Concurrency))
 	push(fmt.Sprintf("TP=%d, EP=%d", cfg.TP, cfg.EP))
 	push(fmt.Sprintf("GPU type: %s", cfg.GPUType))
-	push(fmt.Sprintf("InferenceX path: %s", cfg.InferenceXPath))
 	push("")
 
 	push("Run time:")

--- a/SaFE/apiserver/pkg/handlers/optimization/prompt_builder.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/prompt_builder.go
@@ -25,8 +25,6 @@ const (
 	defaultTP             = 1
 	defaultEP             = 1
 	defaultInferenceXPath = "/hyperloom/InferenceX"
-	defaultOOBPath        = "/hyperloom/OOB"
-	defaultTraceLensRoot  = "/hyperloom/TraceLens-internal"
 	defaultResultsPath    = "/workspace/hyperloom/"
 	defaultGeakStepLimit  = 100
 	defaultMaxHours       = 3.0
@@ -135,12 +133,6 @@ func NormalizePromptConfig(cfg PromptConfig) PromptConfig {
 	if cfg.InferenceXPath == "" {
 		cfg.InferenceXPath = defaultInferenceXPath
 	}
-	if cfg.OOBPath == "" {
-		cfg.OOBPath = defaultOOBPath
-	}
-	if cfg.TraceLensRoot == "" {
-		cfg.TraceLensRoot = defaultTraceLensRoot
-	}
 	if cfg.ResultsPath == "" {
 		cfg.ResultsPath = defaultResultsPath
 	}
@@ -223,8 +215,6 @@ func BuildHyperloomPrompt(cfg PromptConfig) string {
 	push(fmt.Sprintf("TP=%d, EP=%d", cfg.TP, cfg.EP))
 	push(fmt.Sprintf("GPU type: %s", cfg.GPUType))
 	push(fmt.Sprintf("InferenceX path: %s", cfg.InferenceXPath))
-	push(fmt.Sprintf("OOB path: %s", cfg.OOBPath))
-	push(fmt.Sprintf("TraceLens path: %s", cfg.TraceLensRoot))
 	push("")
 
 	push("Run time:")
@@ -269,6 +259,13 @@ func BuildHyperloomPrompt(cfg PromptConfig) string {
 			cfg.TargetGpu, cfg.Framework, strings.ToLower(cfg.GPUType),
 		))
 	}
+
+	push("")
+	push("4. One session only. After the first launch, NEVER start a new `optimize`")
+	push("   (no `--model`, no \"Launch a New Optimization\") — that spawns a new <UTC_ts>")
+	push("   session and is forbidden. A `stop_reason` in state.json (e.g.")
+	push("   `baseline_failed`) is final: stop and exit. To recover an unexpected crash,")
+	push("   ONLY `optimize --resume` (same session dir).")
 
 	body := strings.Join(lines, "\n")
 

--- a/SaFE/apiserver/pkg/handlers/optimization/prompt_builder_test.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/prompt_builder_test.go
@@ -28,7 +28,6 @@ func TestBuildHyperloomPromptClawMode(t *testing.T) {
 		KernelBackends: []string{KernelBackendGEAK, KernelBackendCodex},
 		GeakStepLimit:  120,
 		Image:          "harbor.example/sglang:test",
-		InferenceXPath: "/hyperloom/InferenceX",
 		Workspace:      "control-plane-sandbox",
 		ResultsPath:    "/workspace/hyperloom/",
 		RayReplica:     1,
@@ -45,7 +44,6 @@ func TestBuildHyperloomPromptClawMode(t *testing.T) {
 	assert.Assert(t, strings.Contains(prompt, "mode: claw"))
 	assert.Assert(t, strings.Contains(prompt, "Model path: /shared_nfs/models/Qwen3-30B-A3B"))
 	assert.Assert(t, strings.Contains(prompt, "Framework: sglang"))
-	assert.Assert(t, strings.Contains(prompt, "InferenceX path: /hyperloom/InferenceX"))
 	assert.Assert(t, !strings.Contains(prompt, "OOB path:"))
 	assert.Assert(t, !strings.Contains(prompt, "TraceLens path:"))
 	assert.Assert(t, strings.Contains(prompt, "--target-gain 30"))

--- a/SaFE/apiserver/pkg/handlers/optimization/prompt_builder_test.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/prompt_builder_test.go
@@ -46,14 +46,16 @@ func TestBuildHyperloomPromptClawMode(t *testing.T) {
 	assert.Assert(t, strings.Contains(prompt, "Model path: /shared_nfs/models/Qwen3-30B-A3B"))
 	assert.Assert(t, strings.Contains(prompt, "Framework: sglang"))
 	assert.Assert(t, strings.Contains(prompt, "InferenceX path: /hyperloom/InferenceX"))
-	assert.Assert(t, strings.Contains(prompt, "OOB path: /hyperloom/OOB"))
-	assert.Assert(t, strings.Contains(prompt, "TraceLens path: /hyperloom/TraceLens-internal"))
+	assert.Assert(t, !strings.Contains(prompt, "OOB path:"))
+	assert.Assert(t, !strings.Contains(prompt, "TraceLens path:"))
 	assert.Assert(t, strings.Contains(prompt, "--target-gain 30"))
 	assert.Assert(t, strings.Contains(prompt, "RayJob image: harbor.example/sglang:test"))
 	assert.Assert(t, strings.Contains(prompt, "Target GPU: b300"))
 	assert.Assert(t, strings.Contains(prompt, "model,gpu,tps"))
 	assert.Assert(t, strings.Contains(prompt, "Report the session ID, log path, PID"))
 	assert.Assert(t, strings.Contains(prompt, "Then monitor the process every 300s"))
+	assert.Assert(t, strings.Contains(prompt, "One session only. After the first launch"))
+	assert.Assert(t, strings.Contains(prompt, "ONLY `optimize --resume` (same session dir)."))
 	assert.Assert(t, !strings.Contains(prompt, "Kernel Optimization:"))
 }
 
@@ -68,6 +70,7 @@ func TestBuildHyperloomPromptLocalModeOmitsRaySection(t *testing.T) {
 
 	assert.Assert(t, strings.Contains(prompt, "mode: local"))
 	assert.Assert(t, strings.Contains(prompt, "Then monitor the process every 300s"))
+	assert.Assert(t, strings.Contains(prompt, "One session only. After the first launch"))
 	assert.Assert(t, !strings.Contains(prompt, "SandboxImage:"))
 	assert.Assert(t, !strings.Contains(prompt, "Kernel Optimization:"))
 	assert.Assert(t, !strings.Contains(prompt, "Task submission:"))

--- a/SaFE/apiserver/pkg/handlers/optimization/types.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/types.go
@@ -73,10 +73,17 @@ type CreateTaskRequest struct {
 	TargetGain     float64  `json:"targetGain"`
 
 	// Sandbox / framework image used for the benchmark and kernel opt runs.
-	Image         string `json:"image"`
-	OOBPath       string `json:"oobPath"`
-	TraceLensRoot string `json:"tracelensRoot"`
-	ResultsPath   string `json:"resultsPath"`
+	Image string `json:"image"`
+	// InferenceXPath is accepted for backward compatibility with older
+	// Hyperloom CI clients that still send it, but it is intentionally
+	// ignored: the sandbox-side Hyperloom runtime owns the InferenceX
+	// checkout path, so SaFE no longer injects it into the generated prompt.
+	// Kept here only so strict JSON decoding (DisallowUnknownFields) does
+	// not reject those requests.
+	InferenceXPath string `json:"inferencexPath"`
+	OOBPath        string `json:"oobPath"`
+	TraceLensRoot  string `json:"tracelensRoot"`
+	ResultsPath    string `json:"resultsPath"`
 
 	// RayJob resource sizing (only used in claw mode).
 	RayReplica int `json:"rayReplica"`

--- a/SaFE/apiserver/pkg/handlers/optimization/types.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/types.go
@@ -73,11 +73,10 @@ type CreateTaskRequest struct {
 	TargetGain     float64  `json:"targetGain"`
 
 	// Sandbox / framework image used for the benchmark and kernel opt runs.
-	Image          string `json:"image"`
-	InferenceXPath string `json:"inferencexPath"`
-	OOBPath        string `json:"oobPath"`
-	TraceLensRoot  string `json:"tracelensRoot"`
-	ResultsPath    string `json:"resultsPath"`
+	Image         string `json:"image"`
+	OOBPath       string `json:"oobPath"`
+	TraceLensRoot string `json:"tracelensRoot"`
+	ResultsPath   string `json:"resultsPath"`
 
 	// RayJob resource sizing (only used in claw mode).
 	RayReplica int `json:"rayReplica"`

--- a/SaFE/docs/apis/model-optimization.md
+++ b/SaFE/docs/apis/model-optimization.md
@@ -36,7 +36,6 @@ Base path: `/api/v1/optimization`
   "kernelBackends": ["GEAK", "Codex"],
   "geakStepLimit": 100,
   "image": "harbor.example/sglang:latest",
-  "inferencexPath": "/hyperloom/InferenceX",
   "resultsPath": "/workspace/hyperloom/"
 }
 ```


### PR DESCRIPTION
## Summary
- Stop generated optimization prompts from defaulting OOB and TraceLens tool paths.
- Add a single-session safety constraint so recovery uses `optimize --resume` instead of launching a new session.

## Test plan
- `gofmt -w SaFE/apiserver/pkg/handlers/optimization/prompt_builder.go SaFE/apiserver/pkg/handlers/optimization/prompt_builder_test.go`
- `go test ./SaFE/apiserver/pkg/handlers/optimization` was attempted, but the local dependency graph fails before package tests with `k8s.io/apimachinery` / `structured-merge-diff` v4-v6 type mismatch.