### PR TITLE
feat(playground): add phase filter to list models API

### DIFF
--- a/SaFE/apiserver/pkg/handlers/model-handlers/models.go
+++ b/SaFE/apiserver/pkg/handlers/model-handlers/models.go
@@ -837,6 +837,9 @@ func (h *Handler) listModels(c *gin.Context) (interface{}, error) {
 				if queryArgs.Origin != "" && !matchModelOrigin(normalizeModelOrigin(dbModel.Origin), queryArgs.Origin) {
 					continue
 				}
+				if queryArgs.Phase != "" && !strings.EqualFold(dbModel.Phase, queryArgs.Phase) {
+					continue
+				}
 				info := cvtDBModelToInfo(dbModel)
 				if queryArgs.Search != "" && !strings.Contains(strings.ToLower(info.DisplayName), strings.ToLower(queryArgs.Search)) {
 					continue
@@ -893,6 +896,9 @@ func (h *Handler) listModels(c *gin.Context) (interface{}, error) {
 			}
 		}
 		if queryArgs.Origin != "" && !matchModelOrigin(normalizeModelOrigin(k8sModel.Spec.Origin), queryArgs.Origin) {
+			continue
+		}
+		if queryArgs.Phase != "" && !strings.EqualFold(string(k8sModel.Status.Phase), queryArgs.Phase) {
 			continue
 		}
 

--- a/SaFE/apiserver/pkg/handlers/model-handlers/types.go
+++ b/SaFE/apiserver/pkg/handlers/model-handlers/types.go
@@ -17,6 +17,7 @@ type ListModelQuery struct {
 	Workspace  string `form:"workspace" binding:"omitempty"`  // Filter by workspace (for local models)
 	Origin     string `form:"origin" binding:"omitempty"`     // Filter by origin: "external", "fine_tuned", "rl_trained", or "custom" (all non-external)
 	Search     string `form:"search" binding:"omitempty"`     // Fuzzy search by displayName (case-insensitive)
+	Phase      string `form:"phase" binding:"omitempty"`      // Filter by phase: "Pending", "Uploading", "Downloading", "Ready", "Failed" (case-insensitive)
 }
 
 // ChatRequest represents the unified request to chat with a model or workload.

--- a/SaFE/docs/apis/playground-models.md
+++ b/SaFE/docs/apis/playground-models.md
@@ -133,10 +133,13 @@ Playground Models API provides a model management interface for the AI Playgroun
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| limit | int | No | Records per page, default 10 |
+| limit | int | No | Records per page (limit=0 or omitted returns all matching records) |
 | offset | int | No | Pagination offset, default 0 |
-| inferenceStatus | string | No | Filter by inference status (e.g., "Running", "Pending", "Stopped") |
-| accessMode | string | No | Filter by access mode: "remote_api" or "local" |
+| accessMode | string | No | Filter by access mode: "local", "remote_api", "local_path", "s3_sync" |
+| workspace | string | No | Filter by workspace (public models with empty workspace are always included) |
+| origin | string | No | Filter by origin: "external", "fine_tuned", "rl_trained", or "custom" (all non-external) |
+| search | string | No | Fuzzy search by displayName (case-insensitive) |
+| phase | string | No | Filter by model phase: "Pending", "Uploading", "Downloading", "Ready", "Failed" (case-insensitive) |
 
 **Response Example**:
 ```json


### PR DESCRIPTION
## Summary
- Add a `phase` query parameter to `GET /api/v1/playground/models` so models can be filtered by lifecycle phase (`Pending` / `Uploading` / `Downloading` / `Ready` / `Failed`).
- Filtering is applied on both the DB-first listing path and the K8s fallback path, and is case-insensitive (via `strings.EqualFold`).
- Update `docs/apis/playground-models.md` to document the full, accurate query parameter set (limit/offset/accessMode/workspace/origin/search/phase) and drop the stale `inferenceStatus` row.

## Notes
- Unknown query params were silently ignored before, so `phase` had no effect previously.
- Valid values are the model phases above; e.g. use `phase=Downloading` (not `Download`).

## Test plan
- [ ] `go build ./pkg/handlers/model-handlers/` passes (verified locally)
- [ ] `GET /playground/models?phase=Ready` returns only Ready models
- [ ] `GET /playground/models?phase=downloading` (lowercase) matches Downloading models
- [ ] Omitting `phase` preserves previous behavior