### PR TITLE
Update optimize prompt: emphasize resume-only crash recovery

### DIFF
--- a/SaFE/apiserver/pkg/handlers/optimization/prompt_builder.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/prompt_builder.go
@@ -255,11 +255,10 @@ func BuildHyperloomPrompt(cfg PromptConfig) string {
 	}
 
 	push("")
-	push("4. One session only. After the first launch, NEVER start a new `optimize`")
-	push("   (no `--model`, no \"Launch a New Optimization\") — that spawns a new <UTC_ts>")
-	push("   session and is forbidden. A `stop_reason` in state.json (e.g.")
-	push("   `baseline_failed`) is final: stop and exit. To recover an unexpected crash,")
-	push("   ONLY `optimize --resume` (same session dir).")
+	push("4. To recover an unexpected crash, ONLY DO `optimize --resume` (same session")
+	push("   dir). Which means, after the first launch, NEVER start a new `optimize` —")
+	push("   that spawns a new <UTC_ts> session and is forbidden. If a `stop_reason` in")
+	push("   current session state.json is final: stop and exit.")
 
 	body := strings.Join(lines, "\n")
 

--- a/SaFE/apiserver/pkg/handlers/optimization/prompt_builder_test.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/prompt_builder_test.go
@@ -52,8 +52,8 @@ func TestBuildHyperloomPromptClawMode(t *testing.T) {
 	assert.Assert(t, strings.Contains(prompt, "model,gpu,tps"))
 	assert.Assert(t, strings.Contains(prompt, "Report the session ID, log path, PID"))
 	assert.Assert(t, strings.Contains(prompt, "Then monitor the process every 300s"))
-	assert.Assert(t, strings.Contains(prompt, "One session only. After the first launch"))
-	assert.Assert(t, strings.Contains(prompt, "ONLY `optimize --resume` (same session dir)."))
+	assert.Assert(t, strings.Contains(prompt, "ONLY DO `optimize --resume` (same session"))
+	assert.Assert(t, strings.Contains(prompt, "current session state.json is final: stop and exit."))
 	assert.Assert(t, !strings.Contains(prompt, "Kernel Optimization:"))
 }
 
@@ -68,7 +68,7 @@ func TestBuildHyperloomPromptLocalModeOmitsRaySection(t *testing.T) {
 
 	assert.Assert(t, strings.Contains(prompt, "mode: local"))
 	assert.Assert(t, strings.Contains(prompt, "Then monitor the process every 300s"))
-	assert.Assert(t, strings.Contains(prompt, "One session only. After the first launch"))
+	assert.Assert(t, strings.Contains(prompt, "ONLY DO `optimize --resume` (same session"))
 	assert.Assert(t, !strings.Contains(prompt, "SandboxImage:"))
 	assert.Assert(t, !strings.Contains(prompt, "Kernel Optimization:"))
 	assert.Assert(t, !strings.Contains(prompt, "Task submission:"))


### PR DESCRIPTION
## Summary
- Reworded requirement #4 in the Hyperloom optimization prompt to lead with the crash-recovery rule: on an unexpected crash, the agent must ONLY run `optimize --resume` in the same session dir.
- Clarifies that after the first launch a new `optimize` is forbidden (it spawns a new `<UTC_ts>` session), and that a final `stop_reason` in the current session's `state.json` means stop and exit.
- Updated `prompt_builder_test.go` assertions to match the new wording.

## Test plan
- [ ] `go test ./SaFE/apiserver/pkg/handlers/optimization/...`
