### PR TITLE
fix: tolerant missing owner during validateOwnerWorkload

### DIFF
--- a/SaFE/webhooks/pkg/workload_webhook.go
+++ b/SaFE/webhooks/pkg/workload_webhook.go
@@ -16,6 +16,7 @@ import (
 
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -842,11 +843,19 @@ func (v *WorkloadValidator) validateCommon(ctx context.Context, newWorkload, old
 	return nil
 }
 
-// validateOwnerWorkload checks Spec.OwnerWorkloadId references an existing
-// Workload in the same workspace and is not self-referential. The owner link
-// is a runtime cleanup binding (see workload_types.go) and the dispatcher
-// cascades stop on owner-end events; enforcing existence at admission time
-// avoids dangling references that would leak the dependent Workload.
+// validateOwnerWorkload checks Spec.OwnerWorkloadId is not self-referential and,
+// when the owner exists, that it lives in the same workspace and does not form a
+// cycle. The owner link is a best-effort runtime cleanup binding (see
+// workload_types.go); it is not a correctness requirement.
+//
+// A NotFound owner must not block admission: the apiserver may create an
+// owner-labeled child (e.g. a preheat workload) before its owner workload is
+// persisted, so the owner can legitimately not exist yet at admission time and
+// becomes valid moments later (see issue #588). That case is tolerated.
+//
+// Any other lookup error (RBAC, connection, timeout) means we cannot verify the
+// owner; we fail closed with an InternalError rather than silently bypassing the
+// workspace/cycle checks.
 func (v *WorkloadValidator) validateOwnerWorkload(ctx context.Context, workload *v1.Workload) error {
 	ownerId := workload.GetOwnerWorkloadId()
 	if ownerId == "" {
@@ -857,8 +866,13 @@ func (v *WorkloadValidator) validateOwnerWorkload(ctx context.Context, workload 
 	}
 	owner := &v1.Workload{}
 	if err := v.Client.Get(ctx, client.ObjectKey{Name: ownerId}, owner); err != nil {
-		return commonerrors.NewBadRequest(
-			fmt.Sprintf("ownerWorkloadId %q not found: %v", ownerId, err))
+		if apierrors.IsNotFound(err) {
+			klog.Warningf("skipping owner validation for workload %q: ownerWorkloadId %q not found yet",
+				workload.Name, ownerId)
+			return nil
+		}
+		return commonerrors.NewInternalError(
+			fmt.Sprintf("failed to verify ownerWorkloadId %q: %v", ownerId, err))
 	}
 	if owner.Spec.Workspace != workload.Spec.Workspace {
 		return commonerrors.NewBadRequest(

--- a/SaFE/webhooks/pkg/workload_webhook_test.go
+++ b/SaFE/webhooks/pkg/workload_webhook_test.go
@@ -12,10 +12,13 @@ import (
 
 	"gotest.tools/assert"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
 	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/common"
@@ -177,6 +180,102 @@ func newTestScheme(t *testing.T) *runtime.Scheme {
 	err := v1.AddToScheme(s)
 	assert.NilError(t, err)
 	return s
+}
+
+func newWorkloadWithOwner(name, workspace, ownerId string) *v1.Workload {
+	w := &v1.Workload{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       v1.WorkloadSpec{Workspace: workspace},
+	}
+	if ownerId != "" {
+		v1.SetLabel(w, v1.OwnerLabel, ownerId)
+	}
+	return w
+}
+
+func TestValidateOwnerWorkload(t *testing.T) {
+	ctx := context.TODO()
+	scheme := newTestScheme(t)
+
+	tests := []struct {
+		name      string
+		workload  *v1.Workload
+		objects   []client.Object
+		expectErr bool
+	}{
+		{
+			name:      "no owner label is allowed",
+			workload:  newWorkloadWithOwner("child", "ws1", ""),
+			expectErr: false,
+		},
+		{
+			name:      "self reference is rejected",
+			workload:  newWorkloadWithOwner("child", "ws1", "child"),
+			expectErr: true,
+		},
+		{
+			// Regression test for issue #588: the apiserver creates an
+			// owner-labeled preheat child before its owner workload is
+			// persisted, so a missing owner must not block admission.
+			name:      "missing owner is tolerated",
+			workload:  newWorkloadWithOwner("child", "ws1", "owner-not-yet-created"),
+			expectErr: false,
+		},
+		{
+			name:     "existing owner in same workspace is allowed",
+			workload: newWorkloadWithOwner("child", "ws1", "owner"),
+			objects: []client.Object{
+				newWorkloadWithOwner("owner", "ws1", ""),
+			},
+			expectErr: false,
+		},
+		{
+			name:     "owner in different workspace is rejected",
+			workload: newWorkloadWithOwner("child", "ws1", "owner"),
+			objects: []client.Object{
+				newWorkloadWithOwner("owner", "ws2", ""),
+			},
+			expectErr: true,
+		},
+		{
+			name:     "cycle is rejected",
+			workload: newWorkloadWithOwner("child", "ws1", "owner"),
+			objects: []client.Object{
+				newWorkloadWithOwner("owner", "ws1", "child"),
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.objects...).Build()
+			v := &WorkloadValidator{Client: k8sClient}
+			err := v.validateOwnerWorkload(ctx, tt.workload)
+			assert.Equal(t, tt.expectErr, err != nil)
+		})
+	}
+}
+
+// TestValidateOwnerWorkload_LookupError ensures that a non-NotFound owner
+// lookup error (e.g. RBAC/connection) fails closed instead of silently
+// skipping the workspace/cycle checks.
+func TestValidateOwnerWorkload_LookupError(t *testing.T) {
+	ctx := context.TODO()
+	scheme := newTestScheme(t)
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+				return apierrors.NewServiceUnavailable("apiserver unreachable")
+			},
+		}).
+		Build()
+	v := &WorkloadValidator{Client: k8sClient}
+
+	err := v.validateOwnerWorkload(ctx, newWorkloadWithOwner("child", "ws1", "owner"))
+	assert.Assert(t, err != nil)
 }
 
 func TestMutateStickyNodes_EnablePreempt(t *testing.T) {


### PR DESCRIPTION
## Summary

Multi-node CICD UnifiedJobs were rejected at admission and never created. This fixes the root cause in the `validateOwnerWorkload` admission check.

When a multi-node CICD UnifiedJob is submitted, the apiserver creates owner-labeled **preheat child** workloads *before* it persists the **main** workload that owns them (`createWorkload` in `apiserver/pkg/handlers/resources/workload.go` creates preheat children first, then the main workload). The validating webhook's `validateOwnerWorkload` check (added in #559) requires the owner to already exist, so it rejected each preheat child with HTTP 400 (`ownerWorkloadId %q not found`). Because the failed create is rolled back, the main UnifiedJob was never created — the launcher wrote `Failed` to `SAFE_OUTPUT` and the GitHub job failed within ~5s without any training running.

Single-node / build jobs are unaffected because they don't create owner-linked preheat children.

Fixes #588.

## Root cause

The `primus-safe.owner` link is a **best-effort runtime cleanup binding**, not a correctness requirement (the dispatcher cascades stop on owner-end events). Enforcing the owner's existence at admission time turned a benign, expected creation-ordering window into a hard failure.

## Change

`SaFE/webhooks/pkg/workload_webhook.go` — `validateOwnerWorkload`:

- When the owner workload cannot be retrieved, **log a warning and skip** the owner-dependent checks instead of returning `BadRequest`. A missing owner is expected when an owner-labeled child is created moments before its owner is persisted; the link becomes valid shortly after.
- Preserved guards:
  - **Self-reference** (`ownerWorkloadId == workload.Name`) is still rejected (no lookup required).
  - **Workspace mismatch** and **ownership cycle** are still rejected **when the owner exists**.

This removes the need for the temporary in-cluster mitigation that patched the `primus-safe-webhook-validate` `objectSelector` to skip all owner-labeled workloads (which disabled *all* `vworkload` validation for those workloads).

## Tests

Adds `TestValidateOwnerWorkload` (`SaFE/webhooks/pkg/workload_webhook_test.go`) covering:

- no owner label → allowed
- self-reference → rejected
- **missing owner → allowed** (regression test for this issue)
- existing owner, same workspace → allowed
- owner in a different workspace → rejected
- ownership cycle → rejected

```bash
cd SaFE/webhooks && gofmt -l pkg/ && go test ./pkg/ -run TestValidateOwnerWorkload -v