### PR TITLE
feat(optimization): raise per-workspace concurrency cap to 1024 and make it .env-controllable

### DIFF
--- a/SaFE/bootstrap/cd-deploy.sh
+++ b/SaFE/bootstrap/cd-deploy.sh
@@ -123,8 +123,10 @@ export CALLED_BY_CD=true
 # Using --type=merge avoids adding last-applied-configuration which would
 # conflict with subsequent helm upgrades.
 # Note: .env uses cd_require_approval; ConfigMap stores it as require_approval under cd:.
+#       .env uses cd_max_concurrent; ConfigMap stores it as max_concurrent under
+#       model_optimization: (per-workspace optimization-task concurrency cap).
 APISERVER_CM="primus-safe-apiserver"
-if [ -n "${cd_require_approval:-}" ]; then
+if [ -n "${cd_require_approval:-}" ] || [ -n "${cd_max_concurrent:-}" ]; then
     echo "Syncing .env values to apiserver ConfigMap $APISERVER_CM..."
 
     CURRENT_CONFIG=$(kubectl get configmap "$APISERVER_CM" -n "$NAMESPACE" \
@@ -134,6 +136,9 @@ if [ -n "${cd_require_approval:-}" ]; then
         printf '%s' "$CURRENT_CONFIG" > "$CM_TMP"
         if [ -n "${cd_require_approval:-}" ]; then
             sed -i "s/\(require_approval:\).*/\1 ${cd_require_approval}/" "$CM_TMP"
+        fi
+        if [ -n "${cd_max_concurrent:-}" ]; then
+            sed -i "s/\(max_concurrent:\).*/\1 ${cd_max_concurrent}/" "$CM_TMP"
         fi
         NEW_CONFIG_JSON=$(jq -Rs . < "$CM_TMP")
         rm -f "$CM_TMP"

--- a/SaFE/bootstrap/cd-deploy.sh
+++ b/SaFE/bootstrap/cd-deploy.sh
@@ -123,10 +123,10 @@ export CALLED_BY_CD=true
 # Using --type=merge avoids adding last-applied-configuration which would
 # conflict with subsequent helm upgrades.
 # Note: .env uses cd_require_approval; ConfigMap stores it as require_approval under cd:.
-#       .env uses cd_max_concurrent; ConfigMap stores it as max_concurrent under
-#       model_optimization: (per-workspace optimization-task concurrency cap).
+#       .env uses optimize_max_concurrent; ConfigMap stores it as max_concurrent
+#       under model_optimization: (per-workspace optimization-task concurrency cap).
 APISERVER_CM="primus-safe-apiserver"
-if [ -n "${cd_require_approval:-}" ] || [ -n "${cd_max_concurrent:-}" ]; then
+if [ -n "${cd_require_approval:-}" ] || [ -n "${optimize_max_concurrent:-}" ]; then
     echo "Syncing .env values to apiserver ConfigMap $APISERVER_CM..."
 
     CURRENT_CONFIG=$(kubectl get configmap "$APISERVER_CM" -n "$NAMESPACE" \
@@ -137,8 +137,8 @@ if [ -n "${cd_require_approval:-}" ] || [ -n "${cd_max_concurrent:-}" ]; then
         if [ -n "${cd_require_approval:-}" ]; then
             sed -i "s/\(require_approval:\).*/\1 ${cd_require_approval}/" "$CM_TMP"
         fi
-        if [ -n "${cd_max_concurrent:-}" ]; then
-            sed -i "s/\(max_concurrent:\).*/\1 ${cd_max_concurrent}/" "$CM_TMP"
+        if [ -n "${optimize_max_concurrent:-}" ]; then
+            sed -i "s/\(max_concurrent:\).*/\1 ${optimize_max_concurrent}/" "$CM_TMP"
         fi
         NEW_CONFIG_JSON=$(jq -Rs . < "$CM_TMP")
         rm -f "$CM_TMP"

--- a/SaFE/bootstrap/upgrade.sh
+++ b/SaFE/bootstrap/upgrade.sh
@@ -135,10 +135,10 @@ fi
 sed -i '/^cd:/,/^[a-z]/ s/require_approval: .*/require_approval: '"$cd_require_approval"'/' "$values_yaml"
 
 # Per-workspace optimization-task concurrency cap. Only override the chart
-# default (1024) when cd_max_concurrent is explicitly set in .env so a missing
-# key leaves the default untouched.
-if [[ -n "${cd_max_concurrent:-}" ]]; then
-  sed -i '/^model_optimization:/,/^[a-z]/ s/max_concurrent: .*/max_concurrent: '"$cd_max_concurrent"'/' "$values_yaml"
+# default (1024) when optimize_max_concurrent is explicitly set in .env so a
+# missing key leaves the default untouched.
+if [[ -n "${optimize_max_concurrent:-}" ]]; then
+  sed -i '/^model_optimization:/,/^[a-z]/ s/max_concurrent: .*/max_concurrent: '"$optimize_max_concurrent"'/' "$values_yaml"
 fi
 
 # Configure metrics port if defined in .env

--- a/SaFE/bootstrap/upgrade.sh
+++ b/SaFE/bootstrap/upgrade.sh
@@ -134,6 +134,13 @@ if [[ "$sso_enable" == "true" ]]; then
 fi
 sed -i '/^cd:/,/^[a-z]/ s/require_approval: .*/require_approval: '"$cd_require_approval"'/' "$values_yaml"
 
+# Per-workspace optimization-task concurrency cap. Only override the chart
+# default (1024) when cd_max_concurrent is explicitly set in .env so a missing
+# key leaves the default untouched.
+if [[ -n "${cd_max_concurrent:-}" ]]; then
+  sed -i '/^model_optimization:/,/^[a-z]/ s/max_concurrent: .*/max_concurrent: '"$cd_max_concurrent"'/' "$values_yaml"
+fi
+
 # Configure metrics port if defined in .env
 if [[ -n "${metrics_port:-}" ]]; then
   sed -i '/^job_manager:/,/^[a-z]/ s/metrics_port: .*/metrics_port: '"$metrics_port"'/' "$values_yaml"

--- a/SaFE/charts/primus-safe/templates/apiserver/config.yaml
+++ b/SaFE/charts/primus-safe/templates/apiserver/config.yaml
@@ -157,7 +157,7 @@ data:
       claw_agent_id: "{{ default "agent_default" (default dict .Values.model_optimization).claw_agent_id }}"
       secret_path: {{ default "" (default dict .Values.model_optimization).secret_path | quote }}
       default_workspace: "{{ default "control-plane-sandbox" (default dict .Values.model_optimization).default_workspace }}"
-      max_concurrent: {{ default 256 (default dict .Values.model_optimization).max_concurrent }}
+      max_concurrent: {{ default 1024 (default dict .Values.model_optimization).max_concurrent }}
     mcp:
       # Whether to enable MCP (Model Context Protocol) server for AI assistant integration
       enabled: {{ default true (default dict .Values.mcp).enabled }}

--- a/SaFE/charts/primus-safe/values.yaml
+++ b/SaFE/charts/primus-safe/values.yaml
@@ -263,7 +263,7 @@ model_optimization:
   secret_path: ""
   default_workspace: "control-plane-sandbox"
   # Per-workspace cap on concurrently running optimization tasks. Overridable
-  # per-deploy via .env `cd_max_concurrent` (synced into values.yaml by
+  # per-deploy via .env `optimize_max_concurrent` (synced into values.yaml by
   # upgrade.sh and into the live apiserver ConfigMap by cd-deploy.sh).
   max_concurrent: 1024
 sandbox:

--- a/SaFE/charts/primus-safe/values.yaml
+++ b/SaFE/charts/primus-safe/values.yaml
@@ -262,7 +262,10 @@ model_optimization:
   # Empty: skip file-based claw_api_key / claw_base_url; use Bearer ak-... or set a mount path.
   secret_path: ""
   default_workspace: "control-plane-sandbox"
-  max_concurrent: 256
+  # Per-workspace cap on concurrently running optimization tasks. Overridable
+  # per-deploy via .env `cd_max_concurrent` (synced into values.yaml by
+  # upgrade.sh and into the live apiserver ConfigMap by cd-deploy.sh).
+  max_concurrent: 1024
 sandbox:
   enable: true
   namespace: "agent-sandbox-system"

--- a/SaFE/common/pkg/config/config.go
+++ b/SaFE/common/pkg/config/config.go
@@ -655,7 +655,7 @@ func GetModelOptimizationDefaultWorkspace() string {
 // optimization tasks a single workspace can have running simultaneously.
 // Non-positive values disable the limit.
 func GetModelOptimizationMaxConcurrent() int {
-	return getInt(modelOptimizationConcurrency, 5)
+	return getInt(modelOptimizationConcurrency, 1024)
 }
 
 // GetModelOptimizationClawPluginID returns the Claw plugin ID for the

--- a/SaFE/docs/installation/upgrade.md
+++ b/SaFE/docs/installation/upgrade.md
@@ -38,7 +38,7 @@ For additional upgrade-specific behavior, you may add these optional keys to `.e
 | `proxy_image_registry` | Image registry for management components (overrides chart default) |
 | `helm_registry` | Helm chart registry for addons (e.g. `registry-1.docker.io`) |
 | `cd_require_approval` | CD deployment approval: `true` or `false` |
-| `cd_max_concurrent` | Per-workspace cap on concurrently running optimization tasks (integer, e.g. `1024`). Defaults to chart value `1024` when unset. Synced into both `values.yaml` and the live apiserver ConfigMap. |
+| `optimize_max_concurrent` | Per-workspace cap on concurrently running optimization tasks (integer, e.g. `1024`). Defaults to chart value `1024` when unset. Synced into both `values.yaml` and the live apiserver ConfigMap. |
 | `tracing_enable` | Enable OpenTelemetry tracing: `true` or `false` |
 | `tracing_mode` | Tracing mode: `all` or `error_only` |
 | `tracing_sampling_ratio` | Sampling ratio (e.g. `1.0`) |
@@ -67,7 +67,7 @@ The script performs the following steps:
      - `s3.enable` and `s3.secret` when S3 is enabled
      - `sso.enable` and `sso.secret` when SSO is enabled
      - `cd.require_approval` from `cd_require_approval`
-     - `model_optimization.max_concurrent` from `cd_max_concurrent` (when set)
+     - `model_optimization.max_concurrent` from `optimize_max_concurrent` (when set)
      - Tracing config when `tracing_enable=true`
      - `proxy.services` when `proxy_services` is set
    - If `primus-safe` is already installed: replaces CRDs, RBAC role, and webhooks manifests

--- a/SaFE/docs/installation/upgrade.md
+++ b/SaFE/docs/installation/upgrade.md
@@ -38,6 +38,7 @@ For additional upgrade-specific behavior, you may add these optional keys to `.e
 | `proxy_image_registry` | Image registry for management components (overrides chart default) |
 | `helm_registry` | Helm chart registry for addons (e.g. `registry-1.docker.io`) |
 | `cd_require_approval` | CD deployment approval: `true` or `false` |
+| `cd_max_concurrent` | Per-workspace cap on concurrently running optimization tasks (integer, e.g. `1024`). Defaults to chart value `1024` when unset. Synced into both `values.yaml` and the live apiserver ConfigMap. |
 | `tracing_enable` | Enable OpenTelemetry tracing: `true` or `false` |
 | `tracing_mode` | Tracing mode: `all` or `error_only` |
 | `tracing_sampling_ratio` | Sampling ratio (e.g. `1.0`) |
@@ -66,6 +67,7 @@ The script performs the following steps:
      - `s3.enable` and `s3.secret` when S3 is enabled
      - `sso.enable` and `sso.secret` when SSO is enabled
      - `cd.require_approval` from `cd_require_approval`
+     - `model_optimization.max_concurrent` from `cd_max_concurrent` (when set)
      - Tracing config when `tracing_enable=true`
      - `proxy.services` when `proxy_services` is set
    - If `primus-safe` is already installed: replaces CRDs, RBAC role, and webhooks manifests


### PR DESCRIPTION
## Summary
- Raise the default per-workspace optimization-task concurrency cap `model_optimization.max_concurrent` from **256 to 1024** (chart `values.yaml`, apiserver config template, and the Go fallback default are all consistent).
- Add a new `.env` key `cd_max_concurrent` to make the cap controllable at deploy time:
  - `bootstrap/upgrade.sh`: when set, sed it into `model_optimization.max_concurrent` in `values.yaml` (helm upgrade path).
  - `bootstrap/cd-deploy.sh`: after the helm upgrade, patch the live `primus-safe-apiserver` ConfigMap and `rollout restart` the apiserver so it takes effect immediately; when unset, the default is left untouched.
- Document `cd_max_concurrent` in `docs/installation/upgrade.md`.

## Background
The `core42-hyperloom` workspace hit the 256 concurrency cap, so submitting optimization tasks returned `HTTP 400 / Primus.00002: workspace "core42-hyperloom" already has 256 running optimization tasks (limit=256)`. This accounted for ~15% of pipeline failures and throttled batch model throughput. The limit is counted **per workspace** and originates from the apiserver's `GetModelOptimizationMaxConcurrent()` -> config key `model_optimization.max_concurrent`.

## Test plan
- [ ] `helm template` the `primus-safe-apiserver` ConfigMap and confirm `max_concurrent: 1024` when `.env` is not set.
- [ ] Set `.env` `cd_max_concurrent=2048`, run `upgrade.sh`, and confirm `values.yaml` is rewritten to 2048.
- [ ] After a CD deploy, confirm the live ConfigMap `max_concurrent` is synced and the apiserver has restarted/reloaded.
- [ ] Regression: submitting optimization tasks works while concurrency < cap, and only returns 400 once the cap is reached.
