### PR TITLE
fix(cicd): align images/entryPoints with resources in unified-job-proxy

### DIFF
--- a/SaFE/docker/cicd/unified-job-proxy/proxy.py
+++ b/SaFE/docker/cicd/unified-job-proxy/proxy.py
@@ -138,6 +138,15 @@ def build_payload_from_input(inp: Dict[str, Any]) -> Dict[str, Any]:
     if val is not None:
         env_map["SCALE_RUNNER_ID"] = val
 
+    # The workload API expects images/entryPoints to align with resources.
+    # For multi-node jobs convert_resources_to_array() expands a single resource
+    # config into multiple entries (e.g. Master + Worker), so every resource
+    # entry must get a matching image and entrypoint. Otherwise the Worker
+    # replica is generated without a container image and the Kubeflow admission
+    # webhook rejects the PyTorchJob.
+    resource_count = max(len(resources), 1)
+    entry_point = ensure_base64(command)
+
     workspace_id = getenv_str(WORKSPACE_ID_ENV)
     gvk_kind = "UnifiedJob"
     gvk_version = "v1"
@@ -151,8 +160,8 @@ def build_payload_from_input(inp: Dict[str, Any]) -> Dict[str, Any]:
         "displayName": display_name,
         "workspaceId": workspace_id,
         "resources": resources,
-        "images": [image],
-        "entryPoints": [ensure_base64(command)],
+        "images": [image] * resource_count,
+        "entryPoints": [entry_point] * resource_count,
         "env": env_map,
         "groupVersionKind": {"kind": gvk_kind, "version": gvk_version},
         "description": description,

--- a/SaFE/docker/cicd/unified-job-proxy/test_proxy.py
+++ b/SaFE/docker/cicd/unified-job-proxy/test_proxy.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+
+#  Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+#  See LICENSE for license information.
+
+"""Unit tests for unified-job-proxy payload construction.
+
+These tests focus on the invariant documented by the workload API
+(WorkloadSpec): images and entryPoints must align by index with resources.
+Regression coverage for issue #572, where multi-node UnifiedJob workloads were
+created with a single image/entryPoint while resources were expanded into
+Master + Worker entries, leaving the Worker container without an image.
+"""
+
+import base64
+import unittest
+
+import proxy
+
+
+class ConvertResourcesToArrayTest(unittest.TestCase):
+    def test_single_replica_returns_one_entry(self):
+        result = proxy.convert_resources_to_array({"replica": 1, "gpu": "8"})
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["replica"], 1)
+
+    def test_two_replicas_split_into_master_and_worker(self):
+        result = proxy.convert_resources_to_array({"replica": 2, "gpu": "8"})
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["replica"], 1)  # master
+        self.assertEqual(result[1]["replica"], 1)  # worker
+
+    def test_four_replicas_split_master_one_worker_rest(self):
+        result = proxy.convert_resources_to_array({"replica": 4, "gpu": "8"})
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["replica"], 1)  # master
+        self.assertEqual(result[1]["replica"], 3)  # worker
+
+    def test_string_replica_is_parsed(self):
+        result = proxy.convert_resources_to_array({"replica": "2", "gpu": "8"})
+        self.assertEqual(len(result), 2)
+
+    def test_missing_replica_defaults_to_one(self):
+        result = proxy.convert_resources_to_array({"gpu": "8"})
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["replica"], 1)
+
+
+class BuildPayloadAlignmentTest(unittest.TestCase):
+    """images/entryPoints must always match the length of resources."""
+
+    BASE_INPUT = {
+        "model": "llama",
+        "command": "python train.py",
+        "image": "myregistry/trainer:v1",
+    }
+
+    def _input(self, **overrides):
+        data = dict(self.BASE_INPUT)
+        data.update(overrides)
+        return data
+
+    def _assert_aligned(self, payload):
+        n = len(payload["resources"])
+        self.assertEqual(len(payload["images"]), n)
+        self.assertEqual(len(payload["entryPoints"]), n)
+
+    def test_single_node_lengths_are_one(self):
+        payload = proxy.build_payload_from_input(
+            self._input(resources={"replica": 1, "gpu": "8"})
+        )
+        self.assertEqual(len(payload["resources"]), 1)
+        self._assert_aligned(payload)
+
+    def test_multi_node_arrays_expanded_to_match_resources(self):
+        payload = proxy.build_payload_from_input(
+            self._input(resources={"replica": 2, "gpu": "8"})
+        )
+        self.assertEqual(len(payload["resources"]), 2)
+        self._assert_aligned(payload)
+        # Master and Worker share the same image and entrypoint.
+        self.assertEqual(payload["images"][0], payload["images"][1])
+        self.assertEqual(payload["entryPoints"][0], payload["entryPoints"][1])
+
+    def test_large_replica_still_aligned(self):
+        payload = proxy.build_payload_from_input(
+            self._input(resources={"replica": 4, "gpu": "8"})
+        )
+        self.assertEqual(len(payload["resources"]), 2)
+        self._assert_aligned(payload)
+
+    def test_missing_resources_keeps_arrays_non_empty(self):
+        payload = proxy.build_payload_from_input(self._input())
+        self.assertGreaterEqual(len(payload["resources"]), 1)
+        self._assert_aligned(payload)
+        self.assertTrue(payload["images"][0])
+        self.assertTrue(payload["entryPoints"][0])
+
+    def test_command_is_base64_encoded(self):
+        payload = proxy.build_payload_from_input(
+            self._input(resources={"replica": 2, "gpu": "8"})
+        )
+        decoded = base64.b64decode(payload["entryPoints"][0]).decode("utf-8")
+        self.assertEqual(decoded, "python train.py")
+
+    def test_already_base64_command_not_double_encoded(self):
+        encoded = base64.b64encode(b"python train.py").decode("ascii")
+        payload = proxy.build_payload_from_input(
+            self._input(command=encoded, resources={"replica": 2, "gpu": "8"})
+        )
+        self.assertEqual(payload["entryPoints"][0], encoded)
+
+    def test_image_value_propagated_to_all_entries(self):
+        payload = proxy.build_payload_from_input(
+            self._input(resources={"replica": 2, "gpu": "8"})
+        )
+        for img in payload["images"]:
+            self.assertEqual(img, "myregistry/trainer:v1")
+
+    def test_missing_required_fields_raise(self):
+        for missing in ("model", "command", "image"):
+            data = self._input(resources={"replica": 2})
+            data.pop(missing)
+            with self.assertRaises(ValueError):
+                proxy.build_payload_from_input(data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Fixes #572. Multi-node CI/CD `UnifiedJob` workloads failed before training started because the generated workload had multiple resource entries but only one image and one entrypoint.
In `unified-job-proxy`, `convert_resources_to_array()` expands a single multi-node resource config into separate Master/Worker entries, but the payload still only carried `images[0]` and `entryPoints[0]`. The job-manager then generated a Kubeflow `PyTorchJob` whose Worker replica had no container image, so the Kubeflow admission webhook rejected the job:
admission webhook "validator.pytorchjob.training-operator.kubeflow.org" denied the request: spec.pytorchReplicaSpecs[Worker].template.spec.containers[0].image: Required value

The workload API (`WorkloadSpec`) documents that `images` and `entryPoints` must match the length of `resources`, but the proxy only satisfied this for single-node jobs.
## Changes
- `SaFE/docker/cicd/unified-job-proxy/proxy.py`: expand `images` and `entryPoints` to match the resource count so every generated resource entry (Master and Worker) receives a matching image and entrypoint.
- `SaFE/docker/cicd/unified-job-proxy/test_proxy.py`: new unit tests covering the index-alignment invariant.
```python
resource_count = max(len(resources), 1)
entry_point = ensure_base64(command)
...
"images": [image] * resource_count,
"entryPoints": [entry_point] * resource_count,
```
## Test Plan

- [x] Unit tests pass:
  ```bash
  cd SaFE/docker/cicd/unified-job-proxy
  python3 test_proxy.py -v   # 13 passed
  ```

- [ ] End-to-end: submit a 2-node UnifiedJob via CI/CD and confirm the generated PyTorchJob has a non-empty image on both Master and Worker, the admission webhook accepts it, and training starts — without the hotfix patcher pod running.

- [ ] Remove the temporary unifiedjob-hotfix-patcher pod.