### PR TITLE
test(webhooks): align owner-workload tests with NotFound tolerance

### DIFF
--- a/SaFE/webhooks/pkg/errors_test.go
+++ b/SaFE/webhooks/pkg/errors_test.go
@@ -164,10 +164,16 @@ func TestWorkloadOwnerWorkloadBranches(t *testing.T) {
 	v1.SetLabel(w, v1.OwnerLabel, "owner")
 	assert.Assert(t, v.validateOwnerWorkload(context.Background(), w) != nil)
 
-	// owner not found
+	// owner not found is tolerated: admission must not block when the owner
+	// workload is not yet persisted (issue #588).
 	w2 := validWorkload()
 	v1.SetLabel(w2, v1.OwnerLabel, "missing")
-	assert.Assert(t, v.validateOwnerWorkload(context.Background(), w2) != nil)
+	assert.NilError(t, v.validateOwnerWorkload(context.Background(), w2))
+
+	// self-referential owner is rejected
+	w3 := validWorkload()
+	v1.SetLabel(w3, v1.OwnerLabel, w3.Name)
+	assert.Assert(t, v.validateOwnerWorkload(context.Background(), w3) != nil)
 }
 
 // TestWorkloadAuthoringBranch covers authoring multi-node rejection.

--- a/SaFE/webhooks/pkg/workload5_test.go
+++ b/SaFE/webhooks/pkg/workload5_test.go
@@ -44,9 +44,9 @@ func TestWorkloadValidateCommonStepErrors(t *testing.T) {
 	lbl.Spec.CustomerLabels = map[string]string{"Bad Key": "v"}
 	assert.Assert(t, v.validateCommon(ctx, lbl, nil) != nil)
 
-	// owner workload missing
+	// self-referential owner workload (a missing owner is tolerated; see #588)
 	owner := fullValidWorkload()
-	v1.SetLabel(owner, v1.OwnerLabel, "missing")
+	v1.SetLabel(owner, v1.OwnerLabel, owner.Name)
 	assert.Assert(t, v.validateCommon(ctx, owner, nil) != nil)
 }
 


### PR DESCRIPTION
validateOwnerWorkload now tolerates a NotFound owner workload (issue #588): an owner-labeled child can be admitted before its owner is persisted, so a missing owner must not block admission. Update the stale assertions that still expected an error for a missing owner to expect nil, and keep error-branch coverage via a self-referential owner (which is still rejected).