### PR TITLE
fix(docs): sync docs-site lockfile with package.json for npm ci

### DIFF
--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -8,9 +8,9 @@
       "name": "primus-safe-docs",
       "version": "0.0.0",
       "dependencies": {
-        "@docusaurus/core": "^3.10.1",
-        "@docusaurus/preset-classic": "^3.10.1",
-        "@docusaurus/theme-mermaid": "^3.10.1",
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/preset-classic": "3.10.1",
+        "@docusaurus/theme-mermaid": "3.10.1",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "prism-react-renderer": "^2.3.0",
@@ -18,9 +18,9 @@
         "react-dom": "^18.0.0"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "3.6.3",
-        "@docusaurus/tsconfig": "3.6.3",
-        "@docusaurus/types": "3.6.3",
+        "@docusaurus/module-type-aliases": "3.10.1",
+        "@docusaurus/tsconfig": "3.10.1",
+        "@docusaurus/types": "3.10.1",
         "typescript": "~5.5.2"
       },
       "engines": {
@@ -28,14 +28,14 @@
       }
     },
     "node_modules/@algolia/abtesting": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.20.1.tgz",
-      "integrity": "sha512-ZXOLrNfmAAhBrIPp+9LH9CDRHUqIx2Uf17YRN6GJ2D0wVPHhCwvMgegCUKQz3W78xVdmzEzjawqf93pPBZVMOg==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.21.0.tgz",
+      "integrity": "sha512-kGvHfBa9oQCvZh0YXeguSToBD9GNJ+gzUZQ9KPTg+KSsM36obYcsKPoX0NnlJtPflHXu7RkMaIi44xs9meR6Zw==",
       "dependencies": {
-        "@algolia/client-common": "5.54.1",
-        "@algolia/requester-browser-xhr": "5.54.1",
-        "@algolia/requester-fetch": "5.54.1",
-        "@algolia/requester-node-http": "5.54.1"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -71,92 +71,92 @@
       }
     },
     "node_modules/@algolia/client-abtesting": {
-      "version": "5.54.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.54.1.tgz",
-      "integrity": "sha512-xE6nz1DnpBlkp8Uq+PZdnuU29yhlfrgOIdb2M4+AxDOyDKpK88THFj80x9ZlPLLrFD1iQAt2HAwB5ZeTd4Ea+w==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.55.0.tgz",
+      "integrity": "sha512-Zt2GjIm7vsaf7K23tk5JmtcVNc38G9p0C2L2Lrm06miyLE/NL2etHtHInvuLc1DjxTp7Y2nId4X/tzwo372K8Q==",
       "dependencies": {
-        "@algolia/client-common": "5.54.1",
-        "@algolia/requester-browser-xhr": "5.54.1",
-        "@algolia/requester-fetch": "5.54.1",
-        "@algolia/requester-node-http": "5.54.1"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "5.54.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.54.1.tgz",
-      "integrity": "sha512-fcbniRV8wWJPX3IxGsbVs8JLO+Z5fXqbJOcWBd3duXYm8w0G/LiuFh9PX6ke0weNZNqLZMdQf+we/cR0ANHoOA==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.55.0.tgz",
+      "integrity": "sha512-7BueMuWYg/KBA2EX9zsQ+3OAleEyrJcB+SV5Al/9pLjMQq5mXB/8M5HaUPqZwN812g5kLzj9j43VThlZgWq0hg==",
       "dependencies": {
-        "@algolia/client-common": "5.54.1",
-        "@algolia/requester-browser-xhr": "5.54.1",
-        "@algolia/requester-fetch": "5.54.1",
-        "@algolia/requester-node-http": "5.54.1"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "5.54.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.54.1.tgz",
-      "integrity": "sha512-lc7N5SAyNaP30ZzAHJxSSsrLU1G/xztGdOArtGfJBEJ3zgNVpw/epLb1f5oA460VCA8BWDzRjcvd0ljekctItQ==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.55.0.tgz",
+      "integrity": "sha512-pJZIyhvUrs+B7c5Lw0iP5yP/NsqJMda7pKRYbfG4KtfGIVSMcAalZhdqL5UX8Z9DOC4KxO9tKV5RDeVjZU0VfQ==",
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-insights": {
-      "version": "5.54.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.54.1.tgz",
-      "integrity": "sha512-GfA5h/GOoEnigQSGmxs8+OWG+NH2VCaxcYIMoswcgjA77W5gQVG1KOvsoEB6k5Z85J9+lgvuYkmEgieFJIjuhg==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.55.0.tgz",
+      "integrity": "sha512-RydkKDhx0GWTYuw0ndTXHGM8hD8hgwftKE65FfnJZb5bPc9CevOqv3qNPUQiviAwkqT9hQNH31uDGeV3yZkgfA==",
       "dependencies": {
-        "@algolia/client-common": "5.54.1",
-        "@algolia/requester-browser-xhr": "5.54.1",
-        "@algolia/requester-fetch": "5.54.1",
-        "@algolia/requester-node-http": "5.54.1"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "5.54.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.54.1.tgz",
-      "integrity": "sha512-OYqOdhDivnWDAygdgobm+jvHvPQNYzdgQcfN3c11du/lRVVrzrpYQha85auVrvtQ6Q9Wgp3Q2o+Htti7eh0Tig==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.55.0.tgz",
+      "integrity": "sha512-XiS7gdFq/COWiwdWXZ8+RHuewfEo03TkGESk44zU8zTc/Z6R8fm4DNmV52swJKkeB2N9iC7NKpgpM22OOkcgTw==",
       "dependencies": {
-        "@algolia/client-common": "5.54.1",
-        "@algolia/requester-browser-xhr": "5.54.1",
-        "@algolia/requester-fetch": "5.54.1",
-        "@algolia/requester-node-http": "5.54.1"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.54.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.54.1.tgz",
-      "integrity": "sha512-d8wpaEfKE1c8/b71v+o5QoPcBZ+MzRLB19CC+j3d8uzCKMAi+8iGv9S89I+qelfHP5sfmkeXSyoAWUlEFzaObA==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.55.0.tgz",
+      "integrity": "sha512-LBEJ/q+hn1nJ0aYg5IcWgLNCPjWHTahWmpHNx1qUZMho+9CyWM6LaEnhac45UHjQm/j0m374HP685VrpL133lA==",
       "dependencies": {
-        "@algolia/client-common": "5.54.1",
-        "@algolia/requester-browser-xhr": "5.54.1",
-        "@algolia/requester-fetch": "5.54.1",
-        "@algolia/requester-node-http": "5.54.1"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "5.54.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.54.1.tgz",
-      "integrity": "sha512-oJdxuIawQpCuZUdQVkJRcv/IRRrz1a6WQBaiXx2F/xkUlrHhpsTkiuVje5hKl5de7asR9I4YuJ/Rm0MmXJt5Fw==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.55.0.tgz",
+      "integrity": "sha512-2/9jUXKH4IcdU5qxH6cbDH46ZBe46G7xr+MrcHwgEXZcUfdAvUgLSH53MAWuMgxvw0G5yoqiWMifHc62Os0fiQ==",
       "dependencies": {
-        "@algolia/client-common": "5.54.1",
-        "@algolia/requester-browser-xhr": "5.54.1",
-        "@algolia/requester-fetch": "5.54.1",
-        "@algolia/requester-node-http": "5.54.1"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -168,75 +168,75 @@
       "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
     },
     "node_modules/@algolia/ingestion": {
-      "version": "1.54.1",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.54.1.tgz",
-      "integrity": "sha512-yPyzbcTJ+yEr0LayhqZzmJnx6mVEu9HHIbC4t2RIfaC9FL5Zs9QoKmfcvdQumTXnW/MxPoiKASsCbgiRQGdHdQ==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.55.0.tgz",
+      "integrity": "sha512-80tKsQgxXWo+jK0v4YGCHqyTEXawhAKYyr3kOdN51ElfRqUFjZNPVhZk6vRiqSqXfvrH85ytacT3cbJR6+qolA==",
       "dependencies": {
-        "@algolia/client-common": "5.54.1",
-        "@algolia/requester-browser-xhr": "5.54.1",
-        "@algolia/requester-fetch": "5.54.1",
-        "@algolia/requester-node-http": "5.54.1"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/monitoring": {
-      "version": "1.54.1",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.54.1.tgz",
-      "integrity": "sha512-lxTECUGxJMb5gYJyKghsKTPu+VkrGCrvRMq4jWVp/fCI/Egj3ppB9RJH69O2+CH0k3oHDYed6o39d7FGYhL5OQ==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.55.0.tgz",
+      "integrity": "sha512-4UjmAL8ywGW4rCfK6Qmgw3wIjbrO2wl2s4Eq56JTiN40L2t0XTv0HZkYAmr6nfeiXO0he/2crvZRX6SATSepag==",
       "dependencies": {
-        "@algolia/client-common": "5.54.1",
-        "@algolia/requester-browser-xhr": "5.54.1",
-        "@algolia/requester-fetch": "5.54.1",
-        "@algolia/requester-node-http": "5.54.1"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "5.54.1",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.54.1.tgz",
-      "integrity": "sha512-jmuKjXR+Ktb/hDnGrOwhmGn/1/PRuRdhBqwOV15q+wakSmmdQqavK/KLuLgMih4BtEuT7QsPg2Lbo8EMtOMoOg==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.55.0.tgz",
+      "integrity": "sha512-LMpJPtIkfDsHIx5Ga+baNr22ntYbY+e2wT7MSIc/FjAnu9wnBFhx1H/GfhmP/c5/IvbThDX+3ilxPRjSfCI8aA==",
       "dependencies": {
-        "@algolia/client-common": "5.54.1",
-        "@algolia/requester-browser-xhr": "5.54.1",
-        "@algolia/requester-fetch": "5.54.1",
-        "@algolia/requester-node-http": "5.54.1"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.54.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.54.1.tgz",
-      "integrity": "sha512-PlbI8tNAG1XN5/dM7ciCe9pRuNhA/qnDg6U6r04kdEg8z6poY+jV2pdgCZrtCEJ8cOEcSLsRdCG8iK158iE7zw==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.55.0.tgz",
+      "integrity": "sha512-tDymJ7nFOAoUuecma3usK6o94dp8m4HYFDGh4ByYQXWkv14cpmDn+nWdylmcZO0Qvco107vqDo4+Anksnl8w1Q==",
       "dependencies": {
-        "@algolia/client-common": "5.54.1"
+        "@algolia/client-common": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-fetch": {
-      "version": "5.54.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.54.1.tgz",
-      "integrity": "sha512-TtYAKGxevDhM9gyXoNp+G0ysDsDV7qvkkQzWloG2GwqSJQy7r7+kE5xP7wV224XuJpsqoEM/gxk4yi2wHvTShQ==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.55.0.tgz",
+      "integrity": "sha512-6IDSB5o5dkDPQ4LdOW0Yuw/qy5MdWlO2xDHgPVZgW4YDjbxvnX5PAiV7/WWZdWyVObScZZnnHpPbiqfYs/zBLg==",
       "dependencies": {
-        "@algolia/client-common": "5.54.1"
+        "@algolia/client-common": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "5.54.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.54.1.tgz",
-      "integrity": "sha512-FwSyDcOZgzs62qBhO2BBmXarp163iKA6IjKcpmuTOZmEMtukj6sVNC9BF2A05hG8b1fTKv5c1VvIfjtUsUqSeA==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.55.0.tgz",
+      "integrity": "sha512-Yyyne4l//vDSdg4MhYJkaVne+KEPi833eCj3/T/87ernTwrvP6j9biXXZELsN8sLI/f2ndV/vugDIy2jdJQB6g==",
       "dependencies": {
-        "@algolia/client-common": "5.54.1"
+        "@algolia/client-common": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -3303,40 +3303,6 @@
         }
       }
     },
-    "node_modules/@docusaurus/bundler/node_modules/@docusaurus/types": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-      "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/bundler/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@docusaurus/core": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.10.1.tgz",
@@ -3468,17 +3434,16 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.6.3.tgz",
-      "integrity": "sha512-MjaXX9PN/k5ugNvfRZdWyKWq4FsrhN4LEXaj0pEmMebJuBNlFeGyKQUa9DRhJHpadNaiMLrbo9m3U7Ig5YlsZg==",
-      "dev": true,
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.1.tgz",
+      "integrity": "sha512-YoOZKUdGlp8xSYhuAkGdSo5Ydkbq4V4eK3sD8v0a2hloxCWdQbNBhkc+Ko9QyjpESc0BYcIGM5iHVAy5hdFV6w==",
       "dependencies": {
-        "@docusaurus/types": "3.6.3",
+        "@docusaurus/types": "3.10.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
         "@types/react-router-dom": "*",
-        "react-helmet-async": "*",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
         "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
       },
       "peerDependencies": {
@@ -3520,40 +3485,6 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/types": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-      "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@docusaurus/plugin-content-docs": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.10.1.tgz",
@@ -3586,58 +3517,6 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.1.tgz",
-      "integrity": "sha512-YoOZKUdGlp8xSYhuAkGdSo5Ydkbq4V4eK3sD8v0a2hloxCWdQbNBhkc+Ko9QyjpESc0BYcIGM5iHVAy5hdFV6w==",
-      "dependencies": {
-        "@docusaurus/types": "3.10.1",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/types": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-      "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@docusaurus/plugin-content-pages": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.10.1.tgz",
@@ -3660,40 +3539,6 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/types": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-      "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@docusaurus/plugin-css-cascade-layers": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.10.1.tgz",
@@ -3707,40 +3552,6 @@
       },
       "engines": {
         "node": ">=20.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-css-cascade-layers/node_modules/@docusaurus/types": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-      "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-css-cascade-layers/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
@@ -3763,40 +3574,6 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-debug/node_modules/@docusaurus/types": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-      "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-debug/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@docusaurus/plugin-google-analytics": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.10.1.tgz",
@@ -3813,40 +3590,6 @@
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/types": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-      "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
@@ -3868,40 +3611,6 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/types": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-      "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.10.1.tgz",
@@ -3918,40 +3627,6 @@
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/@docusaurus/types": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-      "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
@@ -3977,40 +3652,6 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/types": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-      "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@docusaurus/plugin-svgr": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.10.1.tgz",
@@ -4031,40 +3672,6 @@
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-svgr/node_modules/@docusaurus/types": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-      "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-svgr/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@docusaurus/preset-classic": {
@@ -4094,40 +3701,6 @@
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/types": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-      "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@docusaurus/theme-classic": {
@@ -4170,58 +3743,6 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.1.tgz",
-      "integrity": "sha512-YoOZKUdGlp8xSYhuAkGdSo5Ydkbq4V4eK3sD8v0a2hloxCWdQbNBhkc+Ko9QyjpESc0BYcIGM5iHVAy5hdFV6w==",
-      "dependencies": {
-        "@docusaurus/types": "3.10.1",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/types": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-      "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@docusaurus/theme-common": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.10.1.tgz",
@@ -4249,58 +3770,6 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.1.tgz",
-      "integrity": "sha512-YoOZKUdGlp8xSYhuAkGdSo5Ydkbq4V4eK3sD8v0a2hloxCWdQbNBhkc+Ko9QyjpESc0BYcIGM5iHVAy5hdFV6w==",
-      "dependencies": {
-        "@docusaurus/types": "3.10.1",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/types": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-      "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-common/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@docusaurus/theme-mermaid": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.10.1.tgz",
@@ -4326,58 +3795,6 @@
         "@mermaid-js/layout-elk": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@docusaurus/theme-mermaid/node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.1.tgz",
-      "integrity": "sha512-YoOZKUdGlp8xSYhuAkGdSo5Ydkbq4V4eK3sD8v0a2hloxCWdQbNBhkc+Ko9QyjpESc0BYcIGM5iHVAy5hdFV6w==",
-      "dependencies": {
-        "@docusaurus/types": "3.10.1",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@docusaurus/theme-mermaid/node_modules/@docusaurus/types": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-      "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-mermaid/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
@@ -4424,37 +3841,36 @@
       }
     },
     "node_modules/@docusaurus/tsconfig": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@docusaurus/tsconfig/-/tsconfig-3.6.3.tgz",
-      "integrity": "sha512-1pT/rTrRpMV15E4tJH95W5PrjboMn5JkKF+Ys8cTjMegetiXjs0gPFOSDA5hdTlberKQLDO50xPjMJHondLuzA==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/tsconfig/-/tsconfig-3.10.1.tgz",
+      "integrity": "sha512-rYvB7yqkdqWIpAbDzQljGfM4cDBkLTbhmagZBEcsyj6oPUsz47lmW2pYdN1j+7sGFgltbAmQH62xfbrij4Eh6Q==",
       "dev": true
     },
     "node_modules/@docusaurus/types": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.6.3.tgz",
-      "integrity": "sha512-xD9oTGDrouWzefkhe9ogB2fDV96/82cRpNGx2HIvI5L87JHNhQVIWimQ/3JIiiX/TEd5S9s+VO6FFguwKNRVow==",
-      "dev": true,
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
+      "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
         "@types/history": "^4.7.11",
+        "@types/mdast": "^4.0.2",
         "@types/react": "*",
         "commander": "^5.1.0",
         "joi": "^17.9.2",
-        "react-helmet-async": "^1.3.0",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
         "utility-types": "^3.10.0",
         "webpack": "^5.95.0",
         "webpack-merge": "^5.9.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/types/node_modules/webpack-merge": {
       "version": "5.10.0",
       "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
       "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "dev": true,
       "dependencies": {
         "clone-deep": "^4.0.1",
         "flat": "^5.0.2",
@@ -4507,40 +3923,6 @@
         "node": ">=20.0"
       }
     },
-    "node_modules/@docusaurus/utils-common/node_modules/@docusaurus/types": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-      "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/utils-common/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@docusaurus/utils-validation": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.10.1.tgz",
@@ -4557,40 +3939,6 @@
       },
       "engines": {
         "node": ">=20.0"
-      }
-    },
-    "node_modules/@docusaurus/utils/node_modules/@docusaurus/types": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-      "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/utils/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@hapi/hoek": {
@@ -6518,24 +5866,24 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "5.54.1",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.54.1.tgz",
-      "integrity": "sha512-v1AwSE7VrqyTn5C6v84fpwp05LqQol8gCJ6ki4bzfpnRqpEAPp/jPqcey1Dzr1fg7Ggsu0O81+3yMgQR9zdH5g==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.55.0.tgz",
+      "integrity": "sha512-af+rI+tUVeS9KWHPAZQHIHPOIC3StPRR6IwQu2nz1aQoTL6Gs5Ty3KsHCgbXMHOpoh9QqSjq8F3KJ8xmaCZSBA==",
       "dependencies": {
-        "@algolia/abtesting": "1.20.1",
-        "@algolia/client-abtesting": "5.54.1",
-        "@algolia/client-analytics": "5.54.1",
-        "@algolia/client-common": "5.54.1",
-        "@algolia/client-insights": "5.54.1",
-        "@algolia/client-personalization": "5.54.1",
-        "@algolia/client-query-suggestions": "5.54.1",
-        "@algolia/client-search": "5.54.1",
-        "@algolia/ingestion": "1.54.1",
-        "@algolia/monitoring": "1.54.1",
-        "@algolia/recommend": "5.54.1",
-        "@algolia/requester-browser-xhr": "5.54.1",
-        "@algolia/requester-fetch": "5.54.1",
-        "@algolia/requester-node-http": "5.54.1"
+        "@algolia/abtesting": "1.21.0",
+        "@algolia/client-abtesting": "5.55.0",
+        "@algolia/client-analytics": "5.55.0",
+        "@algolia/client-common": "5.55.0",
+        "@algolia/client-insights": "5.55.0",
+        "@algolia/client-personalization": "5.55.0",
+        "@algolia/client-query-suggestions": "5.55.0",
+        "@algolia/client-search": "5.55.0",
+        "@algolia/ingestion": "1.55.0",
+        "@algolia/monitoring": "1.55.0",
+        "@algolia/recommend": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -13680,9 +13028,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.13",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.13.tgz",
+      "integrity": "sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==",
       "funding": [
         {
           "type": "github",

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -16,9 +16,9 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@docusaurus/core": "3.6.3",
-    "@docusaurus/preset-classic": "3.6.3",
-    "@docusaurus/theme-mermaid": "3.6.3",
+    "@docusaurus/core": "3.10.1",
+    "@docusaurus/preset-classic": "3.10.1",
+    "@docusaurus/theme-mermaid": "3.10.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
@@ -26,9 +26,9 @@
     "react-dom": "^18.0.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.6.3",
-    "@docusaurus/tsconfig": "3.6.3",
-    "@docusaurus/types": "3.6.3",
+    "@docusaurus/module-type-aliases": "3.10.1",
+    "@docusaurus/tsconfig": "3.10.1",
+    "@docusaurus/types": "3.10.1",
     "typescript": "~5.5.2"
   },
   "browserslist": {


### PR DESCRIPTION
The Pages deploy workflow runs `npm ci`, which requires package.json and package-lock.json to be in sync. They had drifted (package.json pinned @docusaurus/* 3.6.3 while the lockfile resolved 3.10.1), so `npm ci` aborted with EUSAGE. This pins @docusaurus/* to 3.10.1 and regenerates the lockfile. Verified `npm ci` + `npm run build` locally.

Supersedes #612 (closed when its branch was renamed to the `fix/zicanli/XXX` convention).