### PR TITLE
fix(job-manager): treat data-plane object NotFound as deletion to rec…

### DIFF
--- a/SaFE/job-manager/pkg/failover/failover.go
+++ b/SaFE/job-manager/pkg/failover/failover.go
@@ -325,6 +325,13 @@ func (r *FailoverReconciler) handle(ctx context.Context, workload *v1.Workload) 
 		return ctrlruntime.Result{RequeueAfter: time.Second}, nil
 	}
 
+	// Log the failover decision before deleting data-plane objects so the trigger
+	// (preemption vs failed condition) and retry budget are observable. This is the
+	// point where a CICD scaling runner set's whole runner pool gets torn down.
+	klog.Infof("failover deleting data-plane objects of workload %s, kind: %s, preempted: %t, failedCondition: %t, dispatchCnt: %d, maxRetry: %d",
+		workload.Name, workload.SpecKind(), v1.IsWorkloadPreempted(workload), jobutils.FindFailedCondition(workload),
+		v1.GetWorkloadDispatchCnt(workload), workload.Spec.MaxRetry)
+
 	if _, err := jobutils.DeleteObjectsByWorkload(ctx, r.Client, clusterClientSets.ClientFactory(), workload); err != nil {
 		return ctrlruntime.Result{}, err
 	}

--- a/SaFE/job-manager/pkg/scheduler/ttl_controller.go
+++ b/SaFE/job-manager/pkg/scheduler/ttl_controller.go
@@ -109,11 +109,15 @@ func (r *WorkloadTTLController) handle(ctx context.Context, workload *v1.Workloa
 			elapsedSeconds = int(nowTime.Sub(workload.Status.EndTime.Time).Seconds())
 		}
 		if elapsedSeconds >= ttlSeconds {
+			klog.Infof("TTL controller deleting workload %s: ended (phase: %s) and TTL elapsed (%d >= %d seconds)",
+				workload.Name, workload.Status.Phase, elapsedSeconds, ttlSeconds)
 			err = r.deleteWorkload(ctx, workload)
 		} else {
 			result.RequeueAfter = time.Duration(ttlSeconds-elapsedSeconds) * time.Second
 		}
 	case workload.IsTimeout():
+		klog.Infof("TTL controller stopping and deleting workload %s: timed out (timeout: %d seconds, phase: %s)",
+			workload.Name, workload.GetTimeout(), workload.Status.Phase)
 		if err = jobutils.MarkWorkloadStopped(
 			ctx, r.Client, workload,
 			jobutils.StopReasonTimeout, "the workload has timed out",

--- a/SaFE/job-manager/pkg/syncer/job_handler.go
+++ b/SaFE/job-manager/pkg/syncer/job_handler.go
@@ -109,6 +109,15 @@ func (r *SyncerReconciler) getK8sObjectStatus(ctx context.Context, message *reso
 	}
 	k8sObject, err := jobutils.GetObject(ctx, clientSets.ClientFactory(), message.name, message.namespace, message.gvk)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			klog.Infof("k8s object not found, treated as deleted: %s %s/%s, workload: %s, original action: %s",
+				message.gvk.Kind, message.namespace, message.name, adminWorkload.Name, message.action)
+			message.action = ResourceDel
+			return &jobutils.K8sObjectStatus{
+				Phase:   string(v1.K8sDeleted),
+				Message: fmt.Sprintf("%s %s is not found", message.gvk.Kind, message.name),
+			}, nil
+		}
 		klog.ErrorS(err, "failed to get k8s object", "name", message.name, "namespace", message.namespace)
 		return nil, err
 	}
@@ -233,6 +242,8 @@ func (r *SyncerReconciler) shouldReSchedule(ctx context.Context,
 		return false, nil
 	}
 	if message.action == ResourceDel {
+		klog.Infof("workload %s should reschedule: k8s object %s/%s deleted (ResourceDel), phase: %s, dispatchCnt: %d",
+			adminWorkload.Name, message.gvk.Kind, message.name, adminWorkload.Status.Phase, message.dispatchCount)
 		return true, nil
 	}
 	// The additional IsWorkloadPreempted check prevents issues when the service restarts during
@@ -272,6 +283,14 @@ func (r *SyncerReconciler) updateAdminWorkloadByJob(ctx context.Context, clientS
 			}
 		}
 		return adminWorkload, nil
+	}
+	if commonworkload.IsCICDScalingRunnerSet(adminWorkload) {
+		// A CICD scaling runner set reaching the generic phase logic means its
+		// RunnerScaleSetId is empty (ARS not yet/again reconciled by ARC, or being
+		// deleted). The generic path may mark it Failed/Stopped and lead to deletion,
+		// so make this dangerous fall-through observable.
+		klog.Infof("CICD scaling runner set %s entered generic phase handling (empty RunnerScaleSetId), k8s.phase: %s, action: %s, dispatchCnt: %d",
+			adminWorkload.Name, status.Phase, message.action, message.dispatchCount)
 	}
 	if status.Phase != "" {
 		r.updateAdminWorkloadPhase(adminWorkload, status, message)
@@ -322,6 +341,8 @@ func (r *SyncerReconciler) updateAdminWorkloadPhase(adminWorkload *v1.Workload,
 			}
 		}
 		if shouldTerminateWorkload(adminWorkload, status, message.dispatchCount) {
+			klog.Infof("workload %s phase -> Failed (k8s failed, kind: %s, dispatchCnt: %d, message: %s)",
+				adminWorkload.Name, adminWorkload.SpecKind(), message.dispatchCount, status.Message)
 			adminWorkload.Status.Phase = v1.WorkloadFailed
 		}
 	case v1.K8sDeleted:
@@ -337,6 +358,8 @@ func (r *SyncerReconciler) updateAdminWorkloadPhase(adminWorkload *v1.Workload,
 				// refer: actions-runner-controller/ephemeralrunner_controller.go: 374-381
 				adminWorkload.Status.Phase = v1.WorkloadSucceeded
 			} else {
+				klog.Infof("workload %s phase -> Stopped (k8s object %s deleted, kind: %s, dispatchCnt: %d)",
+					adminWorkload.Name, message.name, adminWorkload.SpecKind(), message.dispatchCount)
 				adminWorkload.Status.Phase = v1.WorkloadStopped
 			}
 		} else if commonworkload.IsApplication(adminWorkload) {

--- a/SaFE/job-manager/pkg/syncer/job_handler_notfound_test.go
+++ b/SaFE/job-manager/pkg/syncer/job_handler_notfound_test.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+package syncer
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"gotest.tools/assert"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
+	commonclient "github.com/AMD-AIG-AIMA/SAFE/common/pkg/k8sclient"
+	jobutils "github.com/AMD-AIG-AIMA/SAFE/job-manager/pkg/utils"
+)
+
+// TestGetK8sObjectStatusNotFoundTreatedAsDeleted verifies that when the managed
+// data-plane object is gone (e.g. failover deleted it for a restart), a NotFound is
+// reported as K8sDeleted and the action is rewritten to ResourceDel, so the workload
+// reschedules instead of being marked Failed and reaped by the TTL controller.
+func TestGetK8sObjectStatusNotFoundTreatedAsDeleted(t *testing.T) {
+	patches := gomonkey.ApplyFunc(jobutils.GetObject,
+		func(context.Context, *commonclient.ClientFactory, string, string, schema.GroupVersionKind) (*unstructured.Unstructured, error) {
+			return nil, apierrors.NewNotFound(schema.GroupResource{Resource: "autoscalingrunnersets"}, "w")
+		})
+	defer patches.Reset()
+
+	r := &SyncerReconciler{}
+	msg := &resourceMessage{
+		name:      "w",
+		namespace: "ns",
+		action:    ResourceUpdate,
+		gvk:       schema.GroupVersionKind{Kind: "AutoscalingRunnerSet"},
+	}
+	status, err := r.getK8sObjectStatus(context.Background(), msg, monkeyClientSets(), &v1.Workload{})
+	assert.NilError(t, err)
+	assert.Assert(t, status != nil)
+	assert.Equal(t, status.Phase, string(v1.K8sDeleted))
+	assert.Equal(t, msg.action, ResourceDel)
+}
+
+// TestGetK8sObjectStatusOtherErrorPropagated verifies non-NotFound errors are still
+// surfaced as errors and the action is left untouched.
+func TestGetK8sObjectStatusOtherErrorPropagated(t *testing.T) {
+	patches := gomonkey.ApplyFunc(jobutils.GetObject,
+		func(context.Context, *commonclient.ClientFactory, string, string, schema.GroupVersionKind) (*unstructured.Unstructured, error) {
+			return nil, errors.New("boom")
+		})
+	defer patches.Reset()
+
+	r := &SyncerReconciler{}
+	msg := &resourceMessage{
+		name:      "w",
+		namespace: "ns",
+		action:    ResourceUpdate,
+		gvk:       schema.GroupVersionKind{Kind: "AutoscalingRunnerSet"},
+	}
+	status, err := r.getK8sObjectStatus(context.Background(), msg, monkeyClientSets(), &v1.Workload{})
+	assert.Assert(t, err != nil)
+	assert.Assert(t, status == nil)
+	assert.Equal(t, msg.action, ResourceUpdate)
+}

--- a/SaFE/job-manager/pkg/syncer/pod_handler.go
+++ b/SaFE/job-manager/pkg/syncer/pod_handler.go
@@ -297,6 +297,12 @@ func updateCICDScalingRunnerSetPhase(adminWorkload *v1.Workload, pod *corev1.Pod
 	case corev1.PodPending:
 		adminWorkload.Status.Phase = v1.WorkloadPending
 	default:
+		// The listener pod left Running/Pending; the runner set becomes NotReady.
+		// This is the usual precursor to failover/deletion, so log the transition.
+		if adminWorkload.Status.Phase != v1.WorkloadNotReady {
+			klog.Infof("CICD scaling runner set %s phase -> NotReady (listener pod %s phase: %s)",
+				adminWorkload.Name, pod.Name, pod.Status.Phase)
+		}
 		adminWorkload.Status.Phase = v1.WorkloadNotReady
 	}
 }


### PR DESCRIPTION
…over CICD runner set

When failover deletes a CICD AutoscalingRunnerSet's data-plane object to restart it, a follow-up syncer event could GET the now-missing object and surface a k8s NotFound. IsUnrecoverableError classified that NotFound as fatal, so SetWorkloadFailed marked the workload Failed, and the short TTL deleted the admin workload (and its github secret) before reSchedule could run, leaving the runner set unrecoverable.

getK8sObjectStatus now treats NotFound as a deletion (K8sDeleted) and forces the action to ResourceDel, so the workload reschedules instead of being marked Failed and reaped.

Also add observability logs at the previously silent deletion-decision points (failover trigger, CICD generic phase fall-through, reschedule, terminal phase transitions, and TTL-driven deletion).