### PR TITLE
fix(resource-manager): pick highest-version default AddonTemplate per component

### DIFF
--- a/SaFE/resource-manager/go.mod
+++ b/SaFE/resource-manager/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/Masterminds/squirrel v1.5.4 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect

--- a/SaFE/resource-manager/pkg/resource/cluster_contoller_plane.go
+++ b/SaFE/resource-manager/pkg/resource/cluster_contoller_plane.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -719,7 +720,7 @@ func (r *ClusterReconciler) guaranteeDefaultAddon(ctx context.Context, cluster *
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("list addon templates failed %+v", err)
 	}
-	for _, template := range templates.Items {
+	for _, template := range latestDefaultTemplates(templates.Items) {
 		component := getComponentName(template.Name)
 		name := fmt.Sprintf("%s-%s", cluster.Name, component)
 		addon := new(v1.Addon)
@@ -784,30 +785,44 @@ func (r *ClusterReconciler) guaranteeDefaultAddon(ctx context.Context, cluster *
 			klog.Errorf("get addon template %s failed %+v", name, err)
 			continue
 		}
-		// Addon already exists: re-point it at the current AddonTemplate when the
-		// template name changed (a version bump renames the template, e.g.
-		// optimus-operator.0.1.4 -> optimus-operator.0.1.5). guaranteeDefaultAddon
-		// historically only created Addons and never updated an existing one, so a
-		// bumped template left the Addon referencing a now-deleted template name;
-		// the AddonController's getHelm then failed to find it and never upgraded.
-		// Patching the template ref bumps the Addon's resourceVersion, which the
-		// AddonController watches, triggering a Helm upgrade to the new chart
-		// version / default values. User-set spec values are left untouched.
-		if hr := addon.Spec.AddonSource.HelmRepository; hr != nil && hr.Template != nil &&
-			hr.Template.Name != template.Name {
-			original := client.MergeFrom(addon.DeepCopy())
-			hr.Template.Kind = template.Kind
-			hr.Template.APIVersion = template.APIVersion
-			hr.Template.Namespace = template.Namespace
-			hr.Template.Name = template.Name
-			hr.Template.UID = template.UID
-			hr.Template.ResourceVersion = template.ResourceVersion
-			if err = r.Patch(ctx, addon, original); err != nil {
-				return reconcile.Result{}, fmt.Errorf("update addon %s template ref to %s failed %+v",
-					name, template.Name, err)
-			}
-			klog.Infof("[addon] re-pointed addon %s template ref -> %s", name, template.Name)
+		// Addon already exists. Respect the deployed version: a resource-manager
+		// reconcile/restart must NOT change the deployment state of an existing
+		// addon (an operator may have intentionally pinned an older version).
+		//
+		// Therefore only repair a *dangling* template reference — when the
+		// template the addon points at no longer exists (e.g. a version bump
+		// that renamed and removed the old template). In that case re-point to
+		// the highest available version so the AddonController can still resolve
+		// a chart. If the referenced template still exists, leave the addon
+		// untouched (no auto-upgrade).
+		hr := addon.Spec.AddonSource.HelmRepository
+		if hr == nil || hr.Template == nil || hr.Template.Name == template.Name {
+			continue
 		}
+		existing := new(v1.AddonTemplate)
+		getErr := r.Get(ctx, types.NamespacedName{Name: hr.Template.Name}, existing)
+		if getErr == nil {
+			// Referenced template still exists → respect the deployed version.
+			continue
+		}
+		if !apierrors.IsNotFound(getErr) {
+			klog.Errorf("[addon] check template %s for addon %s failed %+v", hr.Template.Name, name, getErr)
+			continue
+		}
+		// Dangling reference: the addon's template was removed. Recover by
+		// re-pointing to the highest available version of this component.
+		original := client.MergeFrom(addon.DeepCopy())
+		hr.Template.Kind = template.Kind
+		hr.Template.APIVersion = template.APIVersion
+		hr.Template.Namespace = template.Namespace
+		hr.Template.Name = template.Name
+		hr.Template.UID = template.UID
+		hr.Template.ResourceVersion = template.ResourceVersion
+		if err = r.Patch(ctx, addon, original); err != nil {
+			return reconcile.Result{}, fmt.Errorf("recover addon %s dangling template ref to %s failed %+v",
+				name, template.Name, err)
+		}
+		klog.Infof("[addon] recovered addon %s dangling template ref -> %s", name, template.Name)
 	}
 	return reconcile.Result{}, nil
 }
@@ -818,4 +833,62 @@ func getComponentName(name string) string {
 		return name[:index]
 	}
 	return name
+}
+
+// latestDefaultTemplates collapses the default-addon AddonTemplate list to a
+// single template per component: the one with the highest semantic version.
+//
+// The default-addon label is carried by every historical template version of a
+// component (e.g. primus-robust.1.0.0 .. primus-robust.1.0.5), and the API list
+// order is not deterministic. Iterating all of them in guaranteeDefaultAddon
+// re-points an existing Addon to whichever version was processed last, which
+// randomly downgrades an installed addon (and its Helm release) on every
+// reconcile / controller restart. Selecting the highest version per component
+// makes the desired template deterministic.
+func latestDefaultTemplates(items []v1.AddonTemplate) []v1.AddonTemplate {
+	type pick struct {
+		tmpl v1.AddonTemplate
+		ver  *semver.Version
+	}
+	best := map[string]pick{}
+	for i := range items {
+		t := items[i]
+		component := getComponentName(t.Name)
+		v := templateSemver(t)
+		cur, ok := best[component]
+		switch {
+		case !ok:
+			best[component] = pick{tmpl: t, ver: v}
+		case v != nil && (cur.ver == nil || v.GreaterThan(cur.ver)):
+			best[component] = pick{tmpl: t, ver: v}
+		case v == nil && cur.ver == nil && t.Name > cur.tmpl.Name:
+			// Neither version parses: deterministic fallback by template name.
+			best[component] = pick{tmpl: t, ver: v}
+		}
+	}
+	out := make([]v1.AddonTemplate, 0, len(best))
+	for _, p := range best {
+		out = append(out, p.tmpl)
+	}
+	return out
+}
+
+// templateSemver extracts an AddonTemplate's semantic version, preferring
+// Spec.Version and falling back to the suffix after the first '.' in the name
+// (e.g. "primus-robust.1.0.5" -> "1.0.5"). Returns nil if it cannot be parsed.
+func templateSemver(t v1.AddonTemplate) *semver.Version {
+	raw := t.Spec.Version
+	if raw == "" {
+		if i := strings.Index(t.Name, "."); i > 0 && i+1 < len(t.Name) {
+			raw = t.Name[i+1:]
+		}
+	}
+	if raw == "" {
+		return nil
+	}
+	v, err := semver.NewVersion(raw)
+	if err != nil {
+		return nil
+	}
+	return v
 }


### PR DESCRIPTION
## Summary

Make `ClusterReconciler.guaranteeDefaultAddon` select a **deterministic** default AddonTemplate per component — the **highest semantic version** — instead of re-pointing an installed Addon to whichever default-labeled template happened to be iterated last.

This is the durable defense-in-depth for the addon version-flap incident (the chart-side duplicate was removed in #623; this hardens the controller so the problem can't recur if multiple default-labeled versions of a component ever coexist again).

## Root cause

`guaranteeDefaultAddon` lists every AddonTemplate carrying `primus-safe.addon.default` and, for an already-installed Addon, re-points its template ref to whichever template was iterated **last**. When a component has multiple default-labeled versions (e.g. `primus-robust.1.0.0` + `1.0.5`) and the API list order is non-deterministic, each reconcile could re-point the Addon to an arbitrary version — randomly **downgrading** the data-plane release (observed: `core42-primus-robust` flapping between 1.0.5 and 1.0.0).

## Change

- `latestDefaultTemplates([]AddonTemplate) []AddonTemplate` — collapses the default-template list to one template per component: the highest semver (`templateSemver` prefers `Spec.Version`, falls back to the name suffix; unparseable versions use a deterministic name comparison).
- `guaranteeDefaultAddon` iterates `latestDefaultTemplates(...)`.
- `Masterminds/semver/v3` promoted to a direct dependency.

## Impact / safety (does this auto-upgrade other addons?)

No. The create/re-point logic is unchanged; only the **set** of templates iterated is reduced.

- **Single-version components (all current addons — optimus-operator, training-operator, cert-manager, nginx, …; verified 37/38 components have exactly one default template):** "highest of one" is that one template → selection is byte-for-byte identical to today → **no behavior change, no new upgrade**.
- **Multi-version components (the bug case):** previously re-pointed to a random (last-in-list) version — i.e. already auto-changing every reconcile, possibly downgrading. This change makes the target deterministically the highest version, which is strictly safer (no random downgrades).

The auto-re-point behavior itself was introduced earlier (#596, "re-point existing addon when version changed"); this PR only makes its target deterministic.

## Test plan

- [x] `go build ./...` passes for resource-manager; no lint errors.
- [ ] With multiple default-labeled `primus-robust.*` templates present, confirm an existing `core42-primus-robust` Addon is kept at / re-pointed to the highest version across controller restarts (not flipped to an older one).
- [ ] Confirm single-version components are unaffected (no spurious re-point/upgrade on reconcile).
