### PR TITLE
Optimize Claw session dispatch and completion tracking

### DIFF
--- a/SaFE/apiserver/pkg/handlers/optimization/broadcast_test.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/broadcast_test.go
@@ -63,7 +63,7 @@ func TestMaybeUpdateTaskStatus(t *testing.T) {
 
 func TestResolveStatusFromClawEmptySession(t *testing.T) {
 	h := &Handler{clawClient: NewClawClient("", "")}
-	status, msg := h.resolveStatusFromClaw("", errors.New("stream dropped"))
+	status, msg := h.resolveStatusFromClaw("", errors.New("stream dropped"), "bearer", false)
 	assert.Equal(t, dbclient.OptimizationTaskStatusFailed, status)
 	assert.Contains(t, msg, "stream dropped")
 }

--- a/SaFE/apiserver/pkg/handlers/optimization/claw_client.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/claw_client.go
@@ -217,12 +217,21 @@ func (c *ClawClient) createSession(ctx context.Context, req *SessionRequest) (Cr
 		// Older Claw versions return fields at the top level.
 		SessionID   string `json:"session_id"`
 		AgentStatus string `json:"agent_status"`
+		Message     struct {
+			MessageID  string `json:"message_id"`
+			Dispatched bool   `json:"dispatched"`
+		} `json:"message"`
 	}
 	if err := json.Unmarshal(raw, &envelope); err != nil {
 		return CreateSessionResult{}, fmt.Errorf("claw create session: parse response: %w", err)
 	}
 	if envelope.SessionID != "" {
-		return CreateSessionResult{SessionID: envelope.SessionID, AgentStatus: envelope.AgentStatus}, nil
+		return CreateSessionResult{
+			SessionID:   envelope.SessionID,
+			AgentStatus: envelope.AgentStatus,
+			MessageID:   envelope.Message.MessageID,
+			Dispatched:  envelope.Message.Dispatched,
+		}, nil
 	}
 	var data SessionResponse
 	if len(envelope.Data) > 0 {

--- a/SaFE/apiserver/pkg/handlers/optimization/claw_client.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/claw_client.go
@@ -80,31 +80,44 @@ type SessionRequest struct {
 	Name         string                 `json:"name,omitempty"`
 	AgentID      string                 `json:"agent_id,omitempty"`
 	SystemPrompt string                 `json:"system_prompt,omitempty"`
+	Mode         string                 `json:"mode,omitempty"`
 	Config       map[string]interface{} `json:"config,omitempty"`
+	Message      *MessageRequest        `json:"message,omitempty"`
 }
 
 // SessionResponse wraps the common response envelope for session-creation.
 // Claw returns { code, data: { session_id, ... }, request_id }. We parse
 // defensively: fall back to top-level session_id if the server changes shape.
 type SessionResponse struct {
-	SessionID string `json:"session_id"`
+	SessionID   string `json:"session_id"`
+	AgentStatus string `json:"agent_status"`
+	Message     struct {
+		MessageID  string `json:"message_id"`
+		Dispatched bool   `json:"dispatched"`
+	} `json:"message"`
 }
 
+type CreateSessionResult struct {
+	SessionID   string
+	AgentStatus string
+	MessageID   string
+	Dispatched  bool
+}
 
 // MessageRequest maps to POST /sessions/{id}/messages.
 type MessageRequest struct {
-	Content      string                   `json:"content,omitempty"`
-	Contents     []MessageContent         `json:"contents,omitempty"`
-	MessageType  string                   `json:"messageType,omitempty"`
-	TaskMode     string                   `json:"taskMode,omitempty"`
-	Attachments  []map[string]interface{} `json:"attachments,omitempty"`
-	Tools        []int                    `json:"tools,omitempty"`
-	ExtData      map[string]interface{}   `json:"extData,omitempty"`
-	WorkspaceID  string                   `json:"workspaceId,omitempty"`
+	Content     string                   `json:"content,omitempty"`
+	Contents    []MessageContent         `json:"contents,omitempty"`
+	MessageType string                   `json:"messageType,omitempty"`
+	TaskMode    string                   `json:"taskMode,omitempty"`
+	Attachments []map[string]interface{} `json:"attachments,omitempty"`
+	Tools       []int                    `json:"tools,omitempty"`
+	ExtData     map[string]interface{}   `json:"extData,omitempty"`
+	WorkspaceID string                   `json:"workspaceId,omitempty"`
 	// Image is the container image forwarded to Claw as body.image. Sessions.ts
 	// reads this field (not sandbox_image) and uses it as finalSandboxImage,
 	// which Brain then treats as the GPU sandbox image.
-	Image       string           `json:"image,omitempty"`
+	Image string `json:"image,omitempty"`
 	// Resource overrides the plugin's default GPU/CPU/memory spec.
 	// Sessions.ts reads body.resource (not body.resource_gpu) at line 407.
 	Resource map[string]string `json:"resource,omitempty"`
@@ -149,22 +162,45 @@ type ClawArtifact struct {
 // CreateSession creates a new Claw session. AgentID defaults to the value
 // configured for the Model Optimization feature if empty.
 func (c *ClawClient) CreateSession(ctx context.Context, req *SessionRequest) (string, error) {
+	result, err := c.createSession(ctx, req)
+	if err != nil {
+		return "", err
+	}
+	return result.SessionID, nil
+}
+
+func (c *ClawClient) CreateSessionWithMessage(ctx context.Context, req *SessionRequest) (CreateSessionResult, error) {
+	if req == nil || req.Message == nil {
+		return CreateSessionResult{}, fmt.Errorf("claw create session with message: message is required")
+	}
+	normalizeMessageDefaults(req.Message)
+	result, err := c.createSession(ctx, req)
+	if err != nil {
+		return CreateSessionResult{}, err
+	}
+	if !result.Dispatched {
+		return CreateSessionResult{}, fmt.Errorf("claw create session: first message was not dispatched")
+	}
+	return result, nil
+}
+
+func (c *ClawClient) createSession(ctx context.Context, req *SessionRequest) (CreateSessionResult, error) {
 	body, err := json.Marshal(req)
 	if err != nil {
-		return "", fmt.Errorf("marshal session request: %w", err)
+		return CreateSessionResult{}, fmt.Errorf("marshal session request: %w", err)
 	}
 
 	httpReq, err := http.NewRequestWithContext(
 		ctx, http.MethodPost, c.baseURL+clawPathSessions, bytes.NewReader(body),
 	)
 	if err != nil {
-		return "", err
+		return CreateSessionResult{}, err
 	}
 	c.applyHeaders(httpReq)
 
 	resp, err := c.controlClient.Do(httpReq)
 	if err != nil {
-		return "", fmt.Errorf("claw POST /sessions: %w", err)
+		return CreateSessionResult{}, fmt.Errorf("claw POST /sessions: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -172,31 +208,37 @@ func (c *ClawClient) CreateSession(ctx context.Context, req *SessionRequest) (st
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		klog.ErrorS(nil, "claw: create session failed",
 			"status", resp.StatusCode, "body", truncate(string(raw), 512))
-		return "", fmt.Errorf("claw returned HTTP %d: %s", resp.StatusCode, truncate(string(raw), 512))
+		return CreateSessionResult{}, fmt.Errorf("claw returned HTTP %d: %s", resp.StatusCode, truncate(string(raw), 512))
 	}
 
 	var envelope struct {
 		Code int             `json:"code"`
 		Data json.RawMessage `json:"data"`
 		// Older Claw versions return fields at the top level.
-		SessionID string `json:"session_id"`
+		SessionID   string `json:"session_id"`
+		AgentStatus string `json:"agent_status"`
 	}
 	if err := json.Unmarshal(raw, &envelope); err != nil {
-		return "", fmt.Errorf("claw create session: parse response: %w", err)
+		return CreateSessionResult{}, fmt.Errorf("claw create session: parse response: %w", err)
 	}
 	if envelope.SessionID != "" {
-		return envelope.SessionID, nil
+		return CreateSessionResult{SessionID: envelope.SessionID, AgentStatus: envelope.AgentStatus}, nil
 	}
 	var data SessionResponse
 	if len(envelope.Data) > 0 {
 		if err := json.Unmarshal(envelope.Data, &data); err != nil {
-			return "", fmt.Errorf("claw create session: parse data: %w", err)
+			return CreateSessionResult{}, fmt.Errorf("claw create session: parse data: %w", err)
 		}
 	}
 	if data.SessionID == "" {
-		return "", fmt.Errorf("claw create session: empty session id in response: %s", truncate(string(raw), 256))
+		return CreateSessionResult{}, fmt.Errorf("claw create session: empty session id in response: %s", truncate(string(raw), 256))
 	}
-	return data.SessionID, nil
+	return CreateSessionResult{
+		SessionID:   data.SessionID,
+		AgentStatus: data.AgentStatus,
+		MessageID:   data.Message.MessageID,
+		Dispatched:  data.Message.Dispatched,
+	}, nil
 }
 
 // SendMessage fires a message into an existing Claw session. This is a
@@ -205,12 +247,7 @@ func (c *ClawClient) SendMessage(ctx context.Context, sessionID string, req *Mes
 	if sessionID == "" {
 		return fmt.Errorf("claw send message: empty session id")
 	}
-	if req.MessageType == "" {
-		req.MessageType = "text"
-	}
-	if req.TaskMode == "" {
-		req.TaskMode = "agent"
-	}
+	normalizeMessageDefaults(req)
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -291,23 +328,72 @@ type SessionStatus struct {
 	AgentStatus string `json:"agent_status"`
 }
 
-// IsTerminal reports whether the Claw session has finished (successfully or not).
-// Mirrors the completion logic in Hyperloom ci/claw_client.py:monitor_session.
-// agent_status "idle" means the agent finished its run and is waiting; treat as terminal.
+const (
+	clawAgentStatusRunning   = "running"
+	clawAgentStatusIdle      = "idle"
+	clawAgentStatusStopped   = "stopped"
+	clawAgentStatusFailed    = "failed"
+	clawAgentStatusCancelled = "cancelled"
+)
+
+// IsTerminal is kept for legacy callers that already know the session has left
+// its initial idle state. New optimize code should use IsTerminalAfterRunning.
 func (s *SessionStatus) IsTerminal() bool {
-	return s.AgentStatus == "stopped" ||
-		s.AgentStatus == "failed" ||
-		s.AgentStatus == "idle" ||
-		s.Status == "completed" ||
-		s.Status == "stopped" ||
-		s.Status == "failed"
+	return s.IsTerminalAfterRunning(true)
 }
 
 // IsSucceeded reports whether the session completed successfully.
 func (s *SessionStatus) IsSucceeded() bool {
-	return s.AgentStatus == "idle" ||
-		s.AgentStatus == "stopped" && s.Status != "failed" ||
-		s.Status == "completed"
+	return s.IsTerminalAfterRunning(true) && !s.IsFailedTerminal()
+}
+
+func (s *SessionStatus) IsAgentRunning() bool {
+	return strings.ToLower(strings.TrimSpace(s.AgentStatus)) == clawAgentStatusRunning
+}
+
+func (s *SessionStatus) IsAgentIdle() bool {
+	return strings.ToLower(strings.TrimSpace(s.AgentStatus)) == clawAgentStatusIdle
+}
+
+func (s *SessionStatus) IsHardTerminal() bool {
+	switch strings.ToLower(strings.TrimSpace(s.AgentStatus)) {
+	case clawAgentStatusStopped, clawAgentStatusFailed, clawAgentStatusCancelled:
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(s.Status)) {
+	case clawAgentStatusStopped, clawAgentStatusFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *SessionStatus) IsFailedTerminal() bool {
+	as := strings.ToLower(strings.TrimSpace(s.AgentStatus))
+	st := strings.ToLower(strings.TrimSpace(s.Status))
+	return as == clawAgentStatusFailed || as == clawAgentStatusCancelled || st == clawAgentStatusFailed
+}
+
+func (s *SessionStatus) IsTerminalAfterRunning(sawRunning bool) bool {
+	if s == nil {
+		return false
+	}
+	if s.IsHardTerminal() {
+		return true
+	}
+	return sawRunning && s.IsAgentIdle()
+}
+
+func normalizeMessageDefaults(req *MessageRequest) {
+	if req == nil {
+		return
+	}
+	if req.MessageType == "" {
+		req.MessageType = "text"
+	}
+	if req.TaskMode == "" {
+		req.TaskMode = "agent"
+	}
 }
 
 // GetSession fetches the current state of a Claw session. Used to reconcile

--- a/SaFE/apiserver/pkg/handlers/optimization/claw_client.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/claw_client.go
@@ -92,8 +92,10 @@ type SessionResponse struct {
 	SessionID   string `json:"session_id"`
 	AgentStatus string `json:"agent_status"`
 	Message     struct {
-		MessageID  string `json:"message_id"`
-		Dispatched bool   `json:"dispatched"`
+		MessageID string `json:"message_id"`
+		// Dispatched is a pointer so we can tell "field absent" (older Claw
+		// builds that omit it) apart from an explicit dispatched:false.
+		Dispatched *bool `json:"dispatched"`
 	} `json:"message"`
 }
 
@@ -101,7 +103,8 @@ type CreateSessionResult struct {
 	SessionID   string
 	AgentStatus string
 	MessageID   string
-	Dispatched  bool
+	// Dispatched is nil when Claw did not report the field at all.
+	Dispatched *bool
 }
 
 // MessageRequest maps to POST /sessions/{id}/messages.
@@ -178,7 +181,11 @@ func (c *ClawClient) CreateSessionWithMessage(ctx context.Context, req *SessionR
 	if err != nil {
 		return CreateSessionResult{}, err
 	}
-	if !result.Dispatched {
+	// Only reject when Claw explicitly reports the first message was NOT
+	// dispatched. Older Claw versions omit the `dispatched` field entirely; in
+	// that case (Dispatched == nil) we accept as long as a session was created,
+	// consistent with the defensive response parsing used elsewhere here.
+	if result.Dispatched != nil && !*result.Dispatched {
 		return CreateSessionResult{}, fmt.Errorf("claw create session: first message was not dispatched")
 	}
 	return result, nil
@@ -219,7 +226,7 @@ func (c *ClawClient) createSession(ctx context.Context, req *SessionRequest) (Cr
 		AgentStatus string `json:"agent_status"`
 		Message     struct {
 			MessageID  string `json:"message_id"`
-			Dispatched bool   `json:"dispatched"`
+			Dispatched *bool  `json:"dispatched"`
 		} `json:"message"`
 	}
 	if err := json.Unmarshal(raw, &envelope); err != nil {

--- a/SaFE/apiserver/pkg/handlers/optimization/claw_client_http_test.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/claw_client_http_test.go
@@ -73,6 +73,22 @@ func TestClawCreateSessionWithMessage(t *testing.T) {
 	assert.True(t, res.Dispatched)
 }
 
+func TestClawCreateSessionWithMessageTopLevelEnvelope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"session_id":"sess-1","agent_status":"running","message":{"message_id":"msg-1","dispatched":true}}`))
+	}))
+	defer srv.Close()
+	c := NewClawClient(srv.URL, "test-key")
+	res, err := c.CreateSessionWithMessage(context.Background(), &SessionRequest{
+		Name:    "opt",
+		Message: &MessageRequest{Content: "hi"},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "sess-1", res.SessionID)
+	assert.Equal(t, "msg-1", res.MessageID)
+	assert.True(t, res.Dispatched)
+}
+
 func TestClawSendMessage(t *testing.T) {
 	c, _ := newClawTestServer(t)
 	err := c.SendMessage(context.Background(), "sess-1", &MessageRequest{Content: "hi"})

--- a/SaFE/apiserver/pkg/handlers/optimization/claw_client_http_test.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/claw_client_http_test.go
@@ -24,7 +24,7 @@ func newClawTestServer(t *testing.T) (*ClawClient, *httptest.Server) {
 	// GET/DELETE /sessions/{id} -> status / delete.
 	// GET /sessions/{id}/files -> list artifacts.
 	mux.HandleFunc("/sessions", func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"code":0,"data":{"session_id":"sess-1"}}`))
+		_, _ = w.Write([]byte(`{"code":0,"data":{"session_id":"sess-1","agent_status":"running","message":{"message_id":"msg-1","dispatched":true}}}`))
 	})
 	mux.HandleFunc("/sessions/", func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -58,6 +58,19 @@ func TestClawCreateSession(t *testing.T) {
 	id, err := c.CreateSession(context.Background(), &SessionRequest{Name: "opt"})
 	assert.NoError(t, err)
 	assert.Equal(t, "sess-1", id)
+}
+
+func TestClawCreateSessionWithMessage(t *testing.T) {
+	c, _ := newClawTestServer(t)
+	res, err := c.CreateSessionWithMessage(context.Background(), &SessionRequest{
+		Name:    "opt",
+		Message: &MessageRequest{Content: "hi"},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "sess-1", res.SessionID)
+	assert.Equal(t, "running", res.AgentStatus)
+	assert.Equal(t, "msg-1", res.MessageID)
+	assert.True(t, res.Dispatched)
 }
 
 func TestClawSendMessage(t *testing.T) {

--- a/SaFE/apiserver/pkg/handlers/optimization/claw_client_http_test.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/claw_client_http_test.go
@@ -70,7 +70,7 @@ func TestClawCreateSessionWithMessage(t *testing.T) {
 	assert.Equal(t, "sess-1", res.SessionID)
 	assert.Equal(t, "running", res.AgentStatus)
 	assert.Equal(t, "msg-1", res.MessageID)
-	assert.True(t, res.Dispatched)
+	assert.True(t, res.Dispatched != nil && *res.Dispatched)
 }
 
 func TestClawCreateSessionWithMessageTopLevelEnvelope(t *testing.T) {
@@ -86,7 +86,40 @@ func TestClawCreateSessionWithMessageTopLevelEnvelope(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "sess-1", res.SessionID)
 	assert.Equal(t, "msg-1", res.MessageID)
-	assert.True(t, res.Dispatched)
+	assert.True(t, res.Dispatched != nil && *res.Dispatched)
+}
+
+// TestClawCreateSessionWithMessageNoDispatchedField verifies that an older
+// Claw build which omits the `dispatched` field is accepted (we cannot prove
+// non-dispatch, and a session was created), rather than failing every submit.
+func TestClawCreateSessionWithMessageNoDispatchedField(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"code":0,"data":{"session_id":"sess-1","agent_status":"running","message":{"message_id":"msg-1"}}}`))
+	}))
+	defer srv.Close()
+	c := NewClawClient(srv.URL, "test-key")
+	res, err := c.CreateSessionWithMessage(context.Background(), &SessionRequest{
+		Name:    "opt",
+		Message: &MessageRequest{Content: "hi"},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "sess-1", res.SessionID)
+	assert.Nil(t, res.Dispatched)
+}
+
+// TestClawCreateSessionWithMessageExplicitNotDispatched verifies that an
+// explicit dispatched:false is still treated as a hard failure.
+func TestClawCreateSessionWithMessageExplicitNotDispatched(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"code":0,"data":{"session_id":"sess-1","agent_status":"idle","message":{"message_id":"msg-1","dispatched":false}}}`))
+	}))
+	defer srv.Close()
+	c := NewClawClient(srv.URL, "test-key")
+	_, err := c.CreateSessionWithMessage(context.Background(), &SessionRequest{
+		Name:    "opt",
+		Message: &MessageRequest{Content: "hi"},
+	})
+	assert.Error(t, err)
 }
 
 func TestClawSendMessage(t *testing.T) {

--- a/SaFE/apiserver/pkg/handlers/optimization/handler.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/handler.go
@@ -488,6 +488,15 @@ func (t *sessionCompletionTracker) terminalStatus() *SessionStatus {
 	return &cp
 }
 
+func (t *sessionCompletionTracker) sawRunningStatus() bool {
+	if t == nil {
+		return false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.sawRunning
+}
+
 // consumeClawStream is the per-task goroutine that pulls the upstream Claw
 // SSE stream, parses it, persists events, and broadcasts them to live HTTP
 // subscribers. It runs until the stream ends or returns an error; either
@@ -500,7 +509,7 @@ func (h *Handler) consumeClawStream(taskID, sessionID string, hub *taskHub, claw
 			klog.ErrorS(fmt.Errorf("%v", r), "consume claw stream panicked", "task_id", taskID)
 			streamErr = fmt.Errorf("panic: %v", r)
 		}
-		h.finalizeTask(taskID, hub, streamErr, clawBearer, tracker.terminalStatus())
+		h.finalizeTask(taskID, hub, streamErr, clawBearer, tracker.terminalStatus(), tracker.sawRunningStatus())
 	}()
 
 	parser := NewSSEParser()
@@ -560,9 +569,25 @@ func (h *Handler) consumeClawStream(taskID, sessionID string, hub *taskHub, claw
 
 	for {
 		err := h.clawClient.Stream(ctx, sessionID, "", onEvent)
-		if err == nil || errors.Is(err, context.Canceled) {
-			// Normal exit: stream EOF or context cancelled (agent idle / hub closed).
+		if errors.Is(err, context.Canceled) {
+			// Normal exit: poll goroutine confirmed terminal, or hub closed.
 			break
+		}
+		if err == nil {
+			// Upstream EOF is only terminal if Claw status confirms it. Otherwise
+			// reconnect so a transient stream close doesn't strand the task.
+			ss, getErr := h.getSessionWithRetry(ctx, sessionID, clawBearer)
+			if getErr == nil && tracker.observe(ss) {
+				break
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(5 * time.Second):
+			}
+			klog.InfoS("claw stream EOF before terminal status, reconnecting",
+				"task_id", taskID, "session_id", sessionID)
+			continue
 		}
 		// Stream dropped unexpectedly (network blip, LB idle timeout, etc.).
 		// Check whether the session is still active before retrying.
@@ -647,6 +672,7 @@ func (h *Handler) finalizeTask(
 	streamErr error,
 	clawBearer string,
 	terminalStatus *SessionStatus,
+	sawRunning bool,
 ) {
 	task, err := h.dbClient.GetOptimizationTask(context.Background(), taskID)
 	status := dbclient.OptimizationTaskStatusSucceeded
@@ -671,21 +697,24 @@ func (h *Handler) finalizeTask(
 				// The SSE connection dropped (e.g. network blip, LB timeout).
 				// The Claw session may still be running — query it before
 				// deciding the final status so we don't mark a live task Failed.
-				status, msg = h.resolveStatusFromClaw(task.ClawSessionID, streamErr)
+				status, msg = h.resolveStatusFromClaw(task.ClawSessionID, streamErr, clawBearer, sawRunning)
 			} else {
-				// Agent went idle normally. Verify the skill ran to completion by
-				// checking for the optimization report — its absence means the skill
-				// exited early (e.g. sandbox_create_failed) even though Claw reports idle.
-				if task.ClawSessionID != "" && !h.hasOptimizationReport(task.ClawSessionID, clawBearer) {
-					status = dbclient.OptimizationTaskStatusFailed
-					msg = "optimization report not found; skill may have exited early"
-				} else {
-					msg = "completed"
+				// A clean stream EOF is not itself a completion signal. Poll Claw
+				// once before writing any terminal state; initial idle must still
+				// wait for a running -> idle edge.
+				status, msg = h.resolveStatusFromClaw(task.ClawSessionID, nil, clawBearer, sawRunning)
+				if status == dbclient.OptimizationTaskStatusSucceeded {
+					if task.ClawSessionID != "" && !h.hasOptimizationReport(task.ClawSessionID, clawBearer) {
+						status = dbclient.OptimizationTaskStatusFailed
+						msg = "optimization report not found; skill may have exited early"
+					}
 				}
 			}
-			_ = h.dbClient.UpdateOptimizationTaskStatus(
-				context.Background(), taskID, status, task.CurrentPhase, msg,
-			)
+			if status != dbclient.OptimizationTaskStatusRunning {
+				_ = h.dbClient.UpdateOptimizationTaskStatus(
+					context.Background(), taskID, status, task.CurrentPhase, msg,
+				)
+			}
 		}
 	}
 	// If the session is still running (stream dropped transiently), do not emit
@@ -765,9 +794,18 @@ func (h *Handler) getSessionWithRetry(ctx context.Context, sessionID, clawBearer
 // resolveStatusFromClaw queries the Claw session to determine the true task
 // status when the SSE stream dropped unexpectedly. This prevents marking a
 // still-running Hyperloom session as Failed due to a transient connection drop.
-func (h *Handler) resolveStatusFromClaw(sessionID string, streamErr error) (dbclient.OptimizationTaskStatus, string) {
-	fallbackStatus := dbclient.OptimizationTaskStatusFailed
-	fallbackMsg := "claw stream error: " + streamErr.Error()
+func (h *Handler) resolveStatusFromClaw(
+	sessionID string,
+	streamErr error,
+	clawBearer string,
+	sawRunning bool,
+) (dbclient.OptimizationTaskStatus, string) {
+	fallbackStatus := dbclient.OptimizationTaskStatusRunning
+	fallbackMsg := ""
+	if streamErr != nil {
+		fallbackStatus = dbclient.OptimizationTaskStatusFailed
+		fallbackMsg = "claw stream error: " + streamErr.Error()
+	}
 
 	if sessionID == "" {
 		return fallbackStatus, fallbackMsg
@@ -775,7 +813,7 @@ func (h *Handler) resolveStatusFromClaw(sessionID string, streamErr error) (dbcl
 
 	// Retry on transient failures: a brief Claw blip must not flip a task to
 	// Failed when the underlying session may still be alive.
-	ss, err := h.getSessionWithRetry(context.Background(), sessionID, h.clawClient.apiKey)
+	ss, err := h.getSessionWithRetry(context.Background(), sessionID, clawBearer)
 	if err != nil {
 		klog.V(4).InfoS("resolveStatusFromClaw: get session failed after retries, keeping stream error",
 			"session_id", sessionID, "error", err)
@@ -786,7 +824,8 @@ func (h *Handler) resolveStatusFromClaw(sessionID string, streamErr error) (dbcl
 		"session_id", sessionID,
 		"status", ss.Status, "agent_status", ss.AgentStatus, "stream_err", streamErr)
 
-	if !ss.IsTerminal() {
+	tracker := newSessionCompletionTracker(sawRunning)
+	if !tracker.observe(ss) {
 		// Session is still running — do not mark as Failed. Return Running so
 		// the caller skips writing a terminal status; the Detail page will show
 		// the task as still in progress.
@@ -794,10 +833,7 @@ func (h *Handler) resolveStatusFromClaw(sessionID string, streamErr error) (dbcl
 			"session_id", sessionID, "agent_status", ss.AgentStatus)
 		return dbclient.OptimizationTaskStatusRunning, ""
 	}
-	if ss.Status == "failed" || ss.AgentStatus == "failed" {
-		return dbclient.OptimizationTaskStatusFailed, "claw session failed"
-	}
-	return dbclient.OptimizationTaskStatusSucceeded, "completed"
+	return taskStatusFromClawSession(tracker.terminalStatus())
 }
 
 // hasOptimizationReport checks whether the Claw session contains an

--- a/SaFE/apiserver/pkg/handlers/optimization/handler.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/handler.go
@@ -12,8 +12,10 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
+	sqrl "github.com/Masterminds/squirrel"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/lib/pq"
@@ -28,6 +30,7 @@ import (
 	commonconfig "github.com/AMD-AIG-AIMA/SAFE/common/pkg/config"
 	dbclient "github.com/AMD-AIG-AIMA/SAFE/common/pkg/database/client"
 	commonerrors "github.com/AMD-AIG-AIMA/SAFE/common/pkg/errors"
+	jsonutils "github.com/AMD-AIG-AIMA/SAFE/utils/pkg/json"
 )
 
 // Handler is the HTTP entry point for Model Optimization. It orchestrates
@@ -95,6 +98,19 @@ func (h *Handler) CreateTask(c *gin.Context) {
 	c.JSON(http.StatusCreated, resp)
 }
 
+func optimizationActiveSandboxWorkloadSql() sqrl.Sqlizer {
+	dbTags := dbclient.GetWorkloadFieldTags()
+	sandboxGVK := v1.GroupVersionKind{Kind: "Sandbox", Version: common.DefaultVersion}
+	return sqrl.And{
+		sqrl.Eq{dbclient.GetFieldTag(dbTags, "IsDeleted"): false},
+		sqrl.Eq{dbclient.GetFieldTag(dbTags, "GVK"): string(jsonutils.MarshalSilently(sandboxGVK))},
+		sqrl.Or{
+			sqrl.Eq{dbclient.GetFieldTag(dbTags, "Phase"): string(v1.WorkloadRunning)},
+			sqrl.Eq{dbclient.GetFieldTag(dbTags, "Phase"): string(v1.WorkloadPending)},
+		},
+	}
+}
+
 func (h *Handler) submitTask(
 	ctx context.Context,
 	req *CreateTaskRequest,
@@ -117,15 +133,15 @@ func (h *Handler) submitTask(
 	}
 
 	if h.maxConcurrent > 0 {
-		running, err := h.dbClient.CountRunningOptimizationTasks(ctx, workspace)
+		running, err := h.dbClient.CountWorkloads(ctx, optimizationActiveSandboxWorkloadSql())
 		if err != nil {
-			klog.ErrorS(err, "count running optimization tasks", "workspace", workspace)
+			klog.ErrorS(err, "count active optimization sandboxes")
 			return nil, commonerrors.NewInternalError("failed to enforce concurrency limit")
 		}
-		if int(running) >= h.maxConcurrent {
+		if running >= h.maxConcurrent {
 			return nil, commonerrors.NewBadRequest(
-				fmt.Sprintf("workspace %q already has %d running optimization tasks (limit=%d)",
-					workspace, running, h.maxConcurrent),
+				fmt.Sprintf("already has %d active optimization sandboxes (limit=%d)",
+					running, h.maxConcurrent),
 			)
 		}
 	}
@@ -178,23 +194,6 @@ func (h *Handler) submitTask(
 		return nil, commonerrors.NewInternalError("failed to persist task")
 	}
 
-	createCtx, cancel := context.WithTimeout(WithClawBearer(context.Background(), clawBearer), 30*time.Second)
-	defer cancel()
-	sessionName := fmt.Sprintf("safe-opt-%s-%s", resolved.DisplayName, taskID[len(taskID)-8:])
-	sessionID, err := h.clawClient.CreateSession(createCtx, &SessionRequest{
-		Name:    sessionName,
-		AgentID: h.clawAgentID,
-	})
-	if err != nil {
-		klog.ErrorS(err, "create claw session", "task_id", taskID)
-		_ = h.dbClient.UpdateOptimizationTaskStatus(ctx, taskID,
-			dbclient.OptimizationTaskStatusFailed, 0, "failed to create Claw session: "+err.Error())
-		return nil, commonerrors.NewInternalError("failed to create Claw session")
-	}
-	_ = h.dbClient.UpdateOptimizationTaskClawSession(ctx, taskID, sessionID)
-
-	sendCtx, sendCancel := context.WithTimeout(WithClawBearer(context.Background(), clawBearer), 30*time.Second)
-	defer sendCancel()
 	gpuCount := promptCfg.TP * promptCfg.EP
 	if gpuCount <= 0 {
 		gpuCount = 1
@@ -237,18 +236,29 @@ func (h *Handler) submitTask(
 		"cpu":         fmt.Sprintf("%d", promptCfg.RayCpu),
 		"memory":      fmt.Sprintf("%dGi", promptCfg.RayMemoryGi),
 	}
-	if err := h.clawClient.SendMessage(sendCtx, sessionID, msgReq); err != nil {
-		klog.ErrorS(err, "send hyperloom prompt", "task_id", taskID, "session_id", sessionID)
-		_ = h.clawClient.DeleteSession(WithClawBearer(context.Background(), clawBearer), sessionID)
+
+	createCtx, cancel := context.WithTimeout(WithClawBearer(context.Background(), clawBearer), 30*time.Second)
+	defer cancel()
+	sessionName := fmt.Sprintf("safe-opt-%s-%s", resolved.DisplayName, taskID[len(taskID)-8:])
+	createResult, err := h.clawClient.CreateSessionWithMessage(createCtx, &SessionRequest{
+		Name:    sessionName,
+		AgentID: h.clawAgentID,
+		Message: msgReq,
+	})
+	if err != nil {
+		klog.ErrorS(err, "create and dispatch claw session", "task_id", taskID)
 		_ = h.dbClient.UpdateOptimizationTaskStatus(ctx, taskID,
-			dbclient.OptimizationTaskStatusFailed, 0, "failed to send prompt: "+err.Error())
+			dbclient.OptimizationTaskStatusFailed, 0, "failed to create and dispatch Claw session: "+err.Error())
 		return nil, commonerrors.NewInternalError("failed to submit task to Claw")
 	}
+	sessionID := createResult.SessionID
+	_ = h.dbClient.UpdateOptimizationTaskClawSession(ctx, taskID, sessionID)
 
 	_ = h.dbClient.UpdateOptimizationTaskStatus(ctx, taskID,
 		dbclient.OptimizationTaskStatusRunning, 0, "")
 	hub, _ := h.hubs.getOrCreate(taskID, 0)
-	go h.consumeClawStream(taskID, sessionID, hub, clawBearer)
+	go h.consumeClawStream(taskID, sessionID, hub, clawBearer,
+		strings.EqualFold(createResult.AgentStatus, clawAgentStatusRunning))
 
 	return &CreateTaskResponse{
 		ID:            taskID,
@@ -438,18 +448,59 @@ func (h *Handler) StreamEvents(c *gin.Context) {
 
 // ── Background consumer ─────────────────────────────────────────────────
 
+type sessionCompletionTracker struct {
+	mu          sync.Mutex
+	sawRunning  bool
+	terminalHit *SessionStatus
+}
+
+func newSessionCompletionTracker(assumeRunning bool) *sessionCompletionTracker {
+	return &sessionCompletionTracker{sawRunning: assumeRunning}
+}
+
+func (t *sessionCompletionTracker) observe(ss *SessionStatus) bool {
+	if t == nil || ss == nil {
+		return false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if ss.IsAgentRunning() {
+		t.sawRunning = true
+	}
+	if !ss.IsTerminalAfterRunning(t.sawRunning) {
+		return false
+	}
+	cp := *ss
+	t.terminalHit = &cp
+	return true
+}
+
+func (t *sessionCompletionTracker) terminalStatus() *SessionStatus {
+	if t == nil {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.terminalHit == nil {
+		return nil
+	}
+	cp := *t.terminalHit
+	return &cp
+}
+
 // consumeClawStream is the per-task goroutine that pulls the upstream Claw
 // SSE stream, parses it, persists events, and broadcasts them to live HTTP
 // subscribers. It runs until the stream ends or returns an error; either
 // way the task is transitioned to a terminal status.
-func (h *Handler) consumeClawStream(taskID, sessionID string, hub *taskHub, clawBearer string) {
+func (h *Handler) consumeClawStream(taskID, sessionID string, hub *taskHub, clawBearer string, assumeRunning bool) {
 	var streamErr error
+	tracker := newSessionCompletionTracker(assumeRunning)
 	defer func() {
 		if r := recover(); r != nil {
 			klog.ErrorS(fmt.Errorf("%v", r), "consume claw stream panicked", "task_id", taskID)
 			streamErr = fmt.Errorf("panic: %v", r)
 		}
-		h.finalizeTask(taskID, hub, streamErr, clawBearer)
+		h.finalizeTask(taskID, hub, streamErr, clawBearer, tracker.terminalStatus())
 	}()
 
 	parser := NewSSEParser()
@@ -486,7 +537,7 @@ func (h *Handler) consumeClawStream(taskID, sessionID string, hub *taskHub, claw
 						"task_id", taskID, "error", err)
 					continue
 				}
-				if ss.IsTerminal() {
+				if tracker.observe(ss) {
 					klog.InfoS("consumeClawStream: session terminal, cancelling stream",
 						"task_id", taskID, "session_id", sessionID,
 						"status", ss.Status, "agent_status", ss.AgentStatus)
@@ -526,7 +577,7 @@ func (h *Handler) consumeClawStream(taskID, sessionID string, hub *taskHub, claw
 		// cancels ctx once the session truly reaches terminal, which exits
 		// this loop via context.Canceled.
 		ss, getErr := h.getSessionWithRetry(ctx, sessionID, clawBearer)
-		if getErr == nil && ss.IsTerminal() {
+		if getErr == nil && tracker.observe(ss) {
 			streamErr = err
 			break
 		}
@@ -588,10 +639,15 @@ func (h *Handler) maybeUpdateTaskStatus(taskID string, p ParsedEvent) {
 	)
 }
 
-// finalizeTask runs when the Claw stream ends; it marks the task succeeded
-// by default (the skill will emit a failed-terminal phase event if needed),
-// flushes a done frame, and tears down the hub.
-func (h *Handler) finalizeTask(taskID string, hub *taskHub, streamErr error, clawBearer string) {
+// finalizeTask runs when the Claw stream ends; it uses agent_status terminal
+// edges when available, flushes a done frame, and tears down the hub.
+func (h *Handler) finalizeTask(
+	taskID string,
+	hub *taskHub,
+	streamErr error,
+	clawBearer string,
+	terminalStatus *SessionStatus,
+) {
 	task, err := h.dbClient.GetOptimizationTask(context.Background(), taskID)
 	status := dbclient.OptimizationTaskStatusSucceeded
 	msg := ""
@@ -604,7 +660,14 @@ func (h *Handler) finalizeTask(taskID string, hub *taskHub, streamErr error, cla
 			status = task.Status
 			msg = task.Message
 		default:
-			if streamErr != nil {
+			if terminalStatus != nil {
+				status, msg = taskStatusFromClawSession(terminalStatus)
+				if status == dbclient.OptimizationTaskStatusSucceeded &&
+					task.ClawSessionID != "" && !h.hasOptimizationReport(task.ClawSessionID, clawBearer) {
+					status = dbclient.OptimizationTaskStatusFailed
+					msg = "optimization report not found; skill may have exited early"
+				}
+			} else if streamErr != nil {
 				// The SSE connection dropped (e.g. network blip, LB timeout).
 				// The Claw session may still be running — query it before
 				// deciding the final status so we don't mark a live task Failed.
@@ -643,6 +706,25 @@ func (h *Handler) finalizeTask(taskID string, hub *taskHub, streamErr error, cla
 	if task != nil && status == dbclient.OptimizationTaskStatusSucceeded {
 		go h.fetchAndInjectMetrics(context.Background(), task)
 	}
+}
+
+func taskStatusFromClawSession(ss *SessionStatus) (dbclient.OptimizationTaskStatus, string) {
+	if ss != nil && ss.IsFailedTerminal() {
+		return dbclient.OptimizationTaskStatusFailed, "claw session failed"
+	}
+	return dbclient.OptimizationTaskStatusSucceeded, "completed"
+}
+
+const clawResumeAssumeRunningAfter = time.Hour
+
+func assumeSessionAlreadyRan(task *dbclient.OptimizationTask) bool {
+	if task == nil {
+		return false
+	}
+	if task.CurrentPhase > 0 {
+		return true
+	}
+	return task.StartedAt.Valid && time.Since(task.StartedAt.Time) > clawResumeAssumeRunningAfter
 }
 
 // getSessionWithRetry fetches the Claw session status, retrying on transient
@@ -839,15 +921,16 @@ func (h *Handler) recoverRunningTasks(ctx context.Context) {
 			continue
 		}
 
-		if ss.IsTerminal() {
+		assumeRunning := assumeSessionAlreadyRan(task)
+		if newSessionCompletionTracker(assumeRunning).observe(ss) {
 			// Determine status directly from the SessionStatus we already fetched —
 			// avoids a second GetSession call inside resolveStatusFromClaw which would
 			// use the service key and fail for user-owned sessions.
-			status := dbclient.OptimizationTaskStatusSucceeded
-			msg := "completed"
-			if ss.AgentStatus == "failed" || ss.Status == "failed" {
+			status, msg := taskStatusFromClawSession(ss)
+			if status == dbclient.OptimizationTaskStatusSucceeded &&
+				!h.hasOptimizationReport(task.ClawSessionID, clawBearer) {
 				status = dbclient.OptimizationTaskStatusFailed
-				msg = "claw session failed"
+				msg = "optimization report not found; skill may have exited early"
 			}
 			_ = h.dbClient.UpdateOptimizationTaskStatus(ctx, task.ID, status, task.CurrentPhase, msg)
 			klog.InfoS("recoverRunningTasks: finalized terminal task",
@@ -858,7 +941,7 @@ func (h *Handler) recoverRunningTasks(ctx context.Context) {
 		} else {
 			// Session still active — reconnect the stream.
 			hub, _ := h.hubs.getOrCreate(task.ID, 0)
-			go h.consumeClawStream(task.ID, task.ClawSessionID, hub, clawBearer)
+			go h.consumeClawStream(task.ID, task.ClawSessionID, hub, clawBearer, assumeRunning)
 			klog.InfoS("recoverRunningTasks: reconnected stream",
 				"task_id", task.ID, "session_id", task.ClawSessionID)
 		}

--- a/SaFE/apiserver/pkg/handlers/optimization/handler.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/handler.go
@@ -717,12 +717,25 @@ func (h *Handler) finalizeTask(
 			}
 		}
 	}
-	// If the session is still running (stream dropped transiently), do not emit
-	// a terminal done frame and do not tear down the hub. The Detail page will
-	// see Running status on next poll and keep showing a live task.
+	// If the session is still running (stream dropped transiently and Claw was
+	// unreachable) we normally leave the task Running for the next reconnect /
+	// recoverRunningTasks pass instead of tearing it down. But if the task has
+	// already outlived any plausible sandbox lifetime, the session is certainly
+	// dead — finalize it as Failed so it does not linger as a phantom Running
+	// forever, which a clean EOF plus a persistently failing GetSession could
+	// otherwise cause.
 	if status == dbclient.OptimizationTaskStatusRunning {
-		h.hubs.remove(taskID)
-		return
+		if task != nil && clawSessionLikelyExpired(task) {
+			status = dbclient.OptimizationTaskStatusFailed
+			msg = "claw session unreachable and task exceeded max lifetime; marking failed"
+			_ = h.dbClient.UpdateOptimizationTaskStatus(
+				context.Background(), taskID, status, task.CurrentPhase, msg,
+			)
+			// Fall through to emit a terminal done frame and tear down the hub.
+		} else {
+			h.hubs.remove(taskID)
+			return
+		}
 	}
 
 	done := makeDoneEvent(taskID, hub.nextSeq(), status, msg)
@@ -744,16 +757,18 @@ func taskStatusFromClawSession(ss *SessionStatus) (dbclient.OptimizationTaskStat
 	return dbclient.OptimizationTaskStatusSucceeded, "completed"
 }
 
-const clawResumeAssumeRunningAfter = time.Hour
+// clawSessionMaxLifetime is an upper bound on how long an optimization Claw
+// session can plausibly stay alive. The GPU sandbox enforces its own timeout
+// (typically <= 25h), so a task still Running well past this — with a Claw
+// session we can no longer reach — is treated as dead rather than left as a
+// phantom Running forever.
+const clawSessionMaxLifetime = 48 * time.Hour
 
-func assumeSessionAlreadyRan(task *dbclient.OptimizationTask) bool {
-	if task == nil {
+func clawSessionLikelyExpired(task *dbclient.OptimizationTask) bool {
+	if task == nil || !task.StartedAt.Valid {
 		return false
 	}
-	if task.CurrentPhase > 0 {
-		return true
-	}
-	return task.StartedAt.Valid && time.Since(task.StartedAt.Time) > clawResumeAssumeRunningAfter
+	return time.Since(task.StartedAt.Time) > clawSessionMaxLifetime
 }
 
 // getSessionWithRetry fetches the Claw session status, retrying on transient
@@ -957,7 +972,13 @@ func (h *Handler) recoverRunningTasks(ctx context.Context) {
 			continue
 		}
 
-		assumeRunning := assumeSessionAlreadyRan(task)
+		// A task only reaches recoverRunningTasks if it was persisted as
+		// Running, which means submitTask had already created the session and
+		// dispatched its first message — the agent has run at least once. Treat
+		// the session as having been running so a current idle state correctly
+		// reads as "completed" rather than "never started" (which would force a
+		// needless reconnect and could strand a genuinely-finished task).
+		assumeRunning := true
 		if newSessionCompletionTracker(assumeRunning).observe(ss) {
 			// Determine status directly from the SessionStatus we already fetched —
 			// avoids a second GetSession call inside resolveStatusFromClaw which would

--- a/SaFE/apiserver/pkg/handlers/optimization/handler_claw_test.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/handler_claw_test.go
@@ -35,14 +35,22 @@ func sessionServer(t *testing.T, status, agentStatus string) *httptest.Server {
 func TestResolveStatusFromClawSucceeded(t *testing.T) {
 	srv := sessionServer(t, "completed", "idle")
 	h := clawHandler(srv.URL)
-	status, _ := h.resolveStatusFromClaw("s1", errors.New("transient"))
+	status, _ := h.resolveStatusFromClaw("s1", errors.New("transient"), "bearer", true)
 	assert.Equal(t, dbclient.OptimizationTaskStatusSucceeded, status)
+}
+
+func TestResolveStatusFromClawInitialIdleStillRunning(t *testing.T) {
+	srv := sessionServer(t, "active", "idle")
+	h := clawHandler(srv.URL)
+	status, msg := h.resolveStatusFromClaw("s1", errors.New("transient"), "bearer", false)
+	assert.Equal(t, dbclient.OptimizationTaskStatusRunning, status)
+	assert.Empty(t, msg)
 }
 
 func TestResolveStatusFromClawFailed(t *testing.T) {
 	srv := sessionServer(t, "failed", "failed")
 	h := clawHandler(srv.URL)
-	status, msg := h.resolveStatusFromClaw("s1", errors.New("transient"))
+	status, msg := h.resolveStatusFromClaw("s1", errors.New("transient"), "bearer", false)
 	assert.Equal(t, dbclient.OptimizationTaskStatusFailed, status)
 	assert.Equal(t, "claw session failed", msg)
 }
@@ -50,7 +58,7 @@ func TestResolveStatusFromClawFailed(t *testing.T) {
 func TestResolveStatusFromClawStillRunning(t *testing.T) {
 	srv := sessionServer(t, "running", "busy")
 	h := clawHandler(srv.URL)
-	status, _ := h.resolveStatusFromClaw("s1", errors.New("transient"))
+	status, _ := h.resolveStatusFromClaw("s1", errors.New("transient"), "bearer", false)
 	assert.Equal(t, dbclient.OptimizationTaskStatusRunning, status)
 }
 
@@ -61,8 +69,19 @@ func TestResolveStatusFromClawGetSessionError(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 	h := clawHandler(srv.URL)
-	status, _ := h.resolveStatusFromClaw("s1", errors.New("stream broke"))
+	status, _ := h.resolveStatusFromClaw("s1", errors.New("stream broke"), "bearer", false)
 	assert.Equal(t, dbclient.OptimizationTaskStatusFailed, status)
+}
+
+func TestResolveStatusFromClawCleanEOFGetSessionErrorKeepsRunning(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	h := clawHandler(srv.URL)
+	status, msg := h.resolveStatusFromClaw("s1", nil, "bearer", false)
+	assert.Equal(t, dbclient.OptimizationTaskStatusRunning, status)
+	assert.Empty(t, msg)
 }
 
 func TestHasOptimizationReport(t *testing.T) {

--- a/SaFE/apiserver/pkg/handlers/optimization/helpers_test.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/helpers_test.go
@@ -13,9 +13,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
 
+	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
 	dbclient "github.com/AMD-AIG-AIMA/SAFE/common/pkg/database/client"
 )
 
@@ -151,13 +152,26 @@ func TestEscapeClawFilePath(t *testing.T) {
 	assert.Equal(t, "x/y", escapeClawFilePath("x\\y"))
 }
 
+func TestOptimizationActiveSandboxWorkloadSql(t *testing.T) {
+	sql, args, err := optimizationActiveSandboxWorkloadSql().ToSql()
+	assert.NoError(t, err)
+	assert.Contains(t, sql, "is_deleted")
+	assert.Contains(t, sql, "gvk")
+	assert.Contains(t, sql, "phase")
+	assert.Contains(t, args, false)
+	assert.Contains(t, args, string(v1.WorkloadRunning))
+	assert.Contains(t, args, string(v1.WorkloadPending))
+}
+
 func TestSessionStatusTerminalSucceeded(t *testing.T) {
 	assert.True(t, (&SessionStatus{AgentStatus: "failed"}).IsTerminal())
-	assert.True(t, (&SessionStatus{Status: "completed"}).IsTerminal())
+	assert.False(t, (&SessionStatus{Status: "completed"}).IsTerminal())
 	assert.False(t, (&SessionStatus{AgentStatus: "running"}).IsTerminal())
+	assert.False(t, (&SessionStatus{AgentStatus: "idle"}).IsTerminalAfterRunning(false))
+	assert.True(t, (&SessionStatus{AgentStatus: "idle"}).IsTerminalAfterRunning(true))
 
 	assert.True(t, (&SessionStatus{AgentStatus: "idle"}).IsSucceeded())
-	assert.True(t, (&SessionStatus{Status: "completed"}).IsSucceeded())
+	assert.False(t, (&SessionStatus{Status: "completed"}).IsSucceeded())
 	assert.False(t, (&SessionStatus{Status: "failed"}).IsSucceeded())
 }
 

--- a/SaFE/apiserver/pkg/handlers/optimization/submit_test.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/submit_test.go
@@ -78,7 +78,7 @@ func TestSubmitTaskBranches(t *testing.T) {
 
 	// concurrency limit exceeded -> bad request.
 	mockDB := mock_client.NewMockInterface(ctrl)
-	mockDB.EXPECT().CountRunningOptimizationTasks(gomock.Any(), gomock.Any()).Return(int64(5), nil)
+	mockDB.EXPECT().CountWorkloads(gomock.Any(), gomock.Any()).Return(5, nil)
 	h3 := &Handler{
 		clawClient:    NewClawClient("https://claw", ""),
 		dbClient:      mockDB,


### PR DESCRIPTION
## Summary
- Create optimization Claw sessions with the initial message in a single request so the session is dispatched atomically.
- Use Claw `agent_status` transitions to avoid treating the initial `idle` state as completion.
- Gate optimization concurrency with active Sandbox workloads in Running/Pending phases instead of stale optimization task rows.

## Test plan
- `go test -count=1 ./apiserver/pkg/handlers/optimization`