### PR TITLE
fix(optimization): send session env at top-level body.env for CreateS…

### DIFF
--- a/SaFE/apiserver/pkg/handlers/optimization/claw_client.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/claw_client.go
@@ -81,8 +81,13 @@ type SessionRequest struct {
 	AgentID      string                 `json:"agent_id,omitempty"`
 	SystemPrompt string                 `json:"system_prompt,omitempty"`
 	Mode         string                 `json:"mode,omitempty"`
-	Config       map[string]interface{} `json:"config,omitempty"`
-	Message      *MessageRequest        `json:"message,omitempty"`
+	// Env is the session-scoped environment forwarded as the TOP-LEVEL body.env.
+	// Claw's POST /sessions parses session_env from body.env (parseSessionEnv),
+	// NOT from message.env — so per-task overrides like CLAUDE_MODEL must be set
+	// here to actually reach the sandbox as session_env (highest precedence).
+	Env     map[string]string      `json:"env,omitempty"`
+	Config  map[string]interface{} `json:"config,omitempty"`
+	Message *MessageRequest        `json:"message,omitempty"`
 }
 
 // SessionResponse wraps the common response envelope for session-creation.

--- a/SaFE/apiserver/pkg/handlers/optimization/claw_client_env_test.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/claw_client_env_test.go
@@ -62,6 +62,32 @@ func TestSendMessageForwardsEnv(t *testing.T) {
 	assert.Equal(t, "1", envMap["INFERENCE_OPTIMIZER_ALLOW_CUSTOM_ORCH_MODEL"])
 }
 
+// TestCreateSessionForwardsTopLevelEnv asserts CreateSessionWithMessage puts
+// the session Env on the TOP-LEVEL POST /sessions body as `env`. Claw's
+// POST /sessions parses session_env from body.env (not message.env), so the
+// override only reaches the sandbox when set at the top level.
+func TestCreateSessionForwardsTopLevelEnv(t *testing.T) {
+	var captured map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &captured)
+		_, _ = w.Write([]byte(`{"session_id":"sess-1","agent_status":"running","message":{"message_id":"m1","dispatched":true}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := NewClawClient(srv.URL, "test-key")
+	_, err := client.CreateSessionWithMessage(context.Background(), &SessionRequest{
+		Name:    "opt",
+		Env:     map[string]string{"CLAUDE_MODEL": "claude-opus-4-8"},
+		Message: &MessageRequest{Content: "prompt"},
+	})
+	assert.NoError(t, err)
+
+	envMap, ok := captured["env"].(map[string]any)
+	assert.True(t, ok, "POST /sessions body must carry a top-level env object")
+	assert.Equal(t, "claude-opus-4-8", envMap["CLAUDE_MODEL"])
+}
+
 // TestSendMessageOmitsEnvWhenUnset asserts a message without Env sends no `env`
 // field, so Claw treats it as an empty session_env.
 func TestSendMessageOmitsEnvWhenUnset(t *testing.T) {

--- a/SaFE/apiserver/pkg/handlers/optimization/handler.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/handler.go
@@ -240,9 +240,21 @@ func (h *Handler) submitTask(
 	createCtx, cancel := context.WithTimeout(WithClawBearer(context.Background(), clawBearer), 30*time.Second)
 	defer cancel()
 	sessionName := fmt.Sprintf("safe-opt-%s-%s", resolved.DisplayName, taskID[len(taskID)-8:])
+	// Log the session-scoped env we forward to Claw so it can be verified from
+	// the apiserver log alone (mirrors the Hyperloom-side submit log). Only
+	// emitted when env is set; values are non-secret overrides like CLAUDE_MODEL.
+	if len(req.Env) > 0 {
+		klog.InfoS("optimization: forwarding session env to claw",
+			"task_id", taskID, "session_name", sessionName, "env", req.Env)
+	}
 	createResult, err := h.clawClient.CreateSessionWithMessage(createCtx, &SessionRequest{
 		Name:    sessionName,
 		AgentID: h.clawAgentID,
+		// Env MUST be top-level: Claw's POST /sessions reads session_env from
+		// body.env, not from message.env (the inlined first message does not
+		// carry env). Without this the CLAUDE_MODEL override never reaches the
+		// sandbox. Keep msgReq.Env too (harmless) for forward-compat.
+		Env:     req.Env,
 		Message: msgReq,
 	})
 	if err != nil {


### PR DESCRIPTION
…essionWithMessage

After the atomic create-with-message change (PR #631), session env was only set on message.env. Claw's POST /sessions parses session_env from the TOP-LEVEL body.env (parseSessionEnv), not from the inlined message, so per-task overrides like CLAUDE_MODEL never reached the sandbox.

- Add a top-level Env field to SessionRequest (json:"env").
- Set SessionRequest.Env = req.Env in submitTask's CreateSessionWithMessage call.
- Log the forwarded session env on the apiserver side so it is verifiable from logs alone.
- Add TestCreateSessionForwardsTopLevelEnv asserting POST /sessions carries top-level env.