### PR TITLE
fix(optimization): make event replay idempotent across reconnects

### DIFF
--- a/SaFE/apiserver/pkg/handlers/optimization/broadcast_test.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/broadcast_test.go
@@ -6,8 +6,10 @@
 package optimization
 
 import (
+	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -21,8 +23,23 @@ func TestBuildEvent(t *testing.T) {
 	hub := newTaskHub("t1", 0)
 	ev := h.buildEvent("t1", hub, EventTypePhase, PhaseEventPayload{Phase: 3, PhaseName: "Profile"})
 	assert.Equal(t, "t1-1", ev.ID)
+	assert.Equal(t, int64(1), ev.Seq)
 	assert.Equal(t, EventTypePhase, ev.Type)
 	assert.Contains(t, string(ev.Payload), "Profile")
+}
+
+func TestBuildEventFromClawUsesStableID(t *testing.T) {
+	h := &Handler{}
+	raw := ClawSSEEvent{ID: "claw-event-1", Event: "tool_used", Data: "{}"}
+
+	ev1 := h.buildEventFromClaw("t1", newTaskHub("t1", 0), raw, 0, EventTypeLog, LogEventPayload{Message: "a"})
+	ev2 := h.buildEventFromClaw("t1", newTaskHub("t1", 99), raw, 0, EventTypeLog, LogEventPayload{Message: "a"})
+	ev3 := h.buildEventFromClaw("t1", newTaskHub("t1", 0), raw, 1, EventTypeLog, LogEventPayload{Message: "a"})
+
+	assert.Equal(t, ev1.ID, ev2.ID)
+	assert.NotEqual(t, ev1.ID, ev3.ID)
+	assert.Equal(t, int64(1), ev1.Seq)
+	assert.Equal(t, int64(100), ev2.Seq)
 }
 
 func TestPersistAndBroadcast(t *testing.T) {
@@ -35,11 +52,50 @@ func TestPersistAndBroadcast(t *testing.T) {
 	hub := newTaskHub("t1", 0)
 	ch, _ := hub.subscribe("s", 0)
 
-	ev := Event{ID: "t1-1", TaskID: "t1", Type: EventTypeLog}
-	h.persistAndBroadcast("t1", hub, ev)
+	ev := Event{ID: "t1-1", TaskID: "t1", Type: EventTypeLog, Seq: 1}
+	assert.True(t, h.persistAndBroadcast("t1", hub, ev))
 
 	got := <-ch
 	assert.Equal(t, "t1-1", got.ID)
+}
+
+func TestPersistAndBroadcastSkipsDuplicate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockDB := mock_client.NewMockInterface(ctrl)
+	mockDB.EXPECT().AppendOptimizationEvent(gomock.Any(), gomock.Any()).Return(dbclient.ErrOptimizationEventDuplicate)
+
+	h := &Handler{dbClient: mockDB}
+	hub := newTaskHub("t1", 0)
+	ch, _ := hub.subscribe("s", 0)
+
+	ev := Event{ID: "t1-c-dup-0", TaskID: "t1", Type: EventTypeLog, Seq: 2}
+	assert.False(t, h.persistAndBroadcast("t1", hub, ev))
+	select {
+	case got := <-ch:
+		t.Fatalf("duplicate event should not broadcast, got %#v", got)
+	case <-time.After(10 * time.Millisecond):
+	}
+}
+
+func TestResolveAfterSeqUsesPersistedEventID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockDB := mock_client.NewMockInterface(ctrl)
+	mockDB.EXPECT().OptimizationEventSeq(gomock.Any(), "t1", "stable-id").Return(int64(42), true, nil)
+
+	h := &Handler{dbClient: mockDB}
+	assert.Equal(t, int64(42), h.resolveAfterSeq(context.Background(), "t1", "stable-id"))
+}
+
+func TestResolveAfterSeqFallsBackToLegacyID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockDB := mock_client.NewMockInterface(ctrl)
+	mockDB.EXPECT().OptimizationEventSeq(gomock.Any(), "t1", "t1-7").Return(int64(0), false, nil)
+
+	h := &Handler{dbClient: mockDB}
+	assert.Equal(t, int64(7), h.resolveAfterSeq(context.Background(), "t1", "t1-7"))
 }
 
 func TestMaybeUpdateTaskStatus(t *testing.T) {

--- a/SaFE/apiserver/pkg/handlers/optimization/broadcast_test.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/broadcast_test.go
@@ -8,9 +8,14 @@ package optimization
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
@@ -96,6 +101,62 @@ func TestResolveAfterSeqFallsBackToLegacyID(t *testing.T) {
 
 	h := &Handler{dbClient: mockDB}
 	assert.Equal(t, int64(7), h.resolveAfterSeq(context.Background(), "t1", "t1-7"))
+}
+
+func TestStreamEventsReplaysAllPagesForTerminalTask(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockDB := mock_client.NewMockInterface(ctrl)
+
+	page1 := make([]*dbclient.OptimizationEvent, 10000)
+	for i := range page1 {
+		seq := int64(i + 1)
+		evType := EventTypeLog
+		if i == 0 {
+			evType = EventTypeBenchmark
+		}
+		page1[i] = &dbclient.OptimizationEvent{
+			EventID:   "t1-c-" + strconv.FormatInt(seq, 10),
+			TaskID:    "t1",
+			Type:      string(evType),
+			Payload:   `{"message":"event"}`,
+			Seq:       seq,
+			Timestamp: seq,
+		}
+	}
+	page2 := []*dbclient.OptimizationEvent{{
+		EventID:   "t1-c-10001",
+		TaskID:    "t1",
+		Type:      string(EventTypeLog),
+		Payload:   `{"message":"last"}`,
+		Seq:       10001,
+		Timestamp: 10001,
+	}}
+
+	mockDB.EXPECT().GetOptimizationTask(gomock.Any(), "t1").Return(&dbclient.OptimizationTask{
+		ID:     "t1",
+		Status: dbclient.OptimizationTaskStatusSucceeded,
+	}, nil)
+	gomock.InOrder(
+		mockDB.EXPECT().ListOptimizationEvents(gomock.Any(), "t1", int64(0), 10000).Return(page1, nil),
+		mockDB.EXPECT().ListOptimizationEvents(gomock.Any(), "t1", int64(10000), 10000).Return(page2, nil),
+	)
+
+	h := &Handler{dbClient: mockDB, hubs: newHubRegistry()}
+	rsp := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rsp)
+	c.Request = httptest.NewRequest(http.MethodGet, "/events", nil)
+	c.Params = gin.Params{{Key: "id", Value: "t1"}}
+
+	h.StreamEvents(c)
+
+	body := rsp.Body.String()
+	assert.Equal(t, http.StatusOK, rsp.Code)
+	assert.Equal(t, "text/event-stream", rsp.Header().Get("Content-Type"))
+	assert.Contains(t, body, "id: t1-c-10001")
+	assert.Contains(t, body, "id: t1-10002")
+	assert.True(t, strings.Index(body, "id: t1-c-10001") < strings.Index(body, "id: t1-10002"))
 }
 
 func TestMaybeUpdateTaskStatus(t *testing.T) {

--- a/SaFE/apiserver/pkg/handlers/optimization/claw_client.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/claw_client.go
@@ -77,10 +77,10 @@ func NewClawClient(baseURL, apiKey string) *ClawClient {
 
 // SessionRequest mirrors Claw's POST /sessions body.
 type SessionRequest struct {
-	Name         string                 `json:"name,omitempty"`
-	AgentID      string                 `json:"agent_id,omitempty"`
-	SystemPrompt string                 `json:"system_prompt,omitempty"`
-	Mode         string                 `json:"mode,omitempty"`
+	Name         string `json:"name,omitempty"`
+	AgentID      string `json:"agent_id,omitempty"`
+	SystemPrompt string `json:"system_prompt,omitempty"`
+	Mode         string `json:"mode,omitempty"`
 	// Env is the session-scoped environment forwarded as the TOP-LEVEL body.env.
 	// Claw's POST /sessions parses session_env from body.env (parseSessionEnv),
 	// NOT from message.env — so per-task overrides like CLAUDE_MODEL must be set
@@ -313,12 +313,12 @@ func (c *ClawClient) Stream(
 		return fmt.Errorf("claw stream: empty session id")
 	}
 
-	url := c.baseURL + fmt.Sprintf(clawPathStream, sessionID)
+	streamURL := c.baseURL + fmt.Sprintf(clawPathStream, sessionID)
 	if afterEventID != "" {
-		url += "?after_event_id=" + afterEventID
+		streamURL += "?after_event_id=" + url.QueryEscape(afterEventID)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, streamURL, nil)
 	if err != nil {
 		return err
 	}

--- a/SaFE/apiserver/pkg/handlers/optimization/claw_client_http_test.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/claw_client_http_test.go
@@ -188,7 +188,9 @@ func TestClawDownloadProxyPath(t *testing.T) {
 func TestClawStream(t *testing.T) {
 	// Dedicated server returning an SSE stream.
 	mux := http.NewServeMux()
+	var gotAfterEventID string
 	mux.HandleFunc("/chat/sessions/sess-1/messages", func(w http.ResponseWriter, r *http.Request) {
+		gotAfterEventID = r.URL.Query().Get("after_event_id")
 		w.Header().Set("Content-Type", "text/event-stream")
 		_, _ = w.Write([]byte("id: 1\nevent: phase\ndata: {\"phase\":1}\n\n"))
 	})
@@ -204,6 +206,14 @@ func TestClawStream(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, events, 1)
 	assert.Equal(t, "phase", events[0].Event)
+
+	events = nil
+	err = c.Stream(context.Background(), "sess-1", "event+1/2", func(e ClawSSEEvent) error {
+		events = append(events, e)
+		return nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "event+1/2", gotAfterEventID)
 
 	// Empty session id -> error.
 	assert.Error(t, c.Stream(context.Background(), "", "", func(ClawSSEEvent) error { return nil }))

--- a/SaFE/apiserver/pkg/handlers/optimization/handler.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/handler.go
@@ -7,6 +7,8 @@ package optimization
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -370,7 +372,7 @@ func (h *Handler) StreamEvents(c *gin.Context) {
 		return
 	}
 
-	afterSeq := parseAfterSeq(c.Query("after_event_id"))
+	afterSeq := h.resolveAfterSeq(c.Request.Context(), id, c.Query("after_event_id"))
 
 	// Prepare SSE headers before any write.
 	c.Writer.Header().Set("Content-Type", "text/event-stream")
@@ -389,27 +391,40 @@ func (h *Handler) StreamEvents(c *gin.Context) {
 		return writeSSEEvent(c.Writer, flusher, ev)
 	}
 
-	// 1. Replay.
-	events, err := h.dbClient.ListOptimizationEvents(ctx, id, afterSeq, 10000)
-	if err != nil {
-		klog.ErrorS(err, "replay optimization events", "task_id", id)
-	}
 	lastSeq := afterSeq
 	isTerminal := task.Status == dbclient.OptimizationTaskStatusSucceeded ||
 		task.Status == dbclient.OptimizationTaskStatusFailed ||
 		task.Status == dbclient.OptimizationTaskStatusInterrupted
-	for _, dbev := range events {
-		if dbev.Seq > lastSeq {
-			lastSeq = dbev.Seq
+	hasBenchmark := false
+	const replayPageSize = 10000
+	for {
+		events, err := h.dbClient.ListOptimizationEvents(ctx, id, lastSeq, replayPageSize)
+		if err != nil {
+			klog.ErrorS(err, "replay optimization events", "task_id", id, "after_seq", lastSeq)
+			break
 		}
-		// For terminal tasks, skip persisted done events — we emit a fresh done
-		// at the very end so backfill benchmark/kernel events (which have higher
-		// synthetic seq numbers) are always delivered before the terminal marker.
-		if isTerminal && EventType(dbev.Type) == EventTypeDone {
-			continue
+		if len(events) == 0 {
+			break
 		}
-		if err := writeFrame(dbEventToAPI(dbev)); err != nil {
-			return
+		if hasBenchmarkEvents(events) {
+			hasBenchmark = true
+		}
+		for _, dbev := range events {
+			if dbev.Seq > lastSeq {
+				lastSeq = dbev.Seq
+			}
+			// For terminal tasks, skip persisted done events — we emit a fresh done
+			// at the very end so backfill benchmark/kernel events (which have higher
+			// synthetic seq numbers) are always delivered before the terminal marker.
+			if isTerminal && EventType(dbev.Type) == EventTypeDone {
+				continue
+			}
+			if err := writeFrame(dbEventToAPI(dbev)); err != nil {
+				return
+			}
+		}
+		if len(events) < replayPageSize {
+			break
 		}
 	}
 
@@ -420,7 +435,7 @@ func (h *Handler) StreamEvents(c *gin.Context) {
 		// pipeline ran in orchestrator mode (sub-jobs). Try to backfill from
 		// Claw session artifacts. This fires asynchronously; on the next page
 		// load the events are already in DB and will be replayed before done.
-		if task.Status == dbclient.OptimizationTaskStatusSucceeded && !hasBenchmarkEvents(events) {
+		if task.Status == dbclient.OptimizationTaskStatusSucceeded && !hasBenchmark {
 			go h.fetchAndInjectMetrics(context.Background(), task)
 		}
 		_ = writeFrame(makeDoneEvent(id, lastSeq+1, task.Status, task.Message))
@@ -569,18 +584,23 @@ func (h *Handler) consumeClawStream(taskID, sessionID string, hub *taskHub, claw
 		}
 	}()
 
+	var lastClawEventID string
 	onEvent := func(raw ClawSSEEvent) error {
 		parsed := parser.Parse(raw)
-		for _, p := range parsed {
-			ev := h.buildEvent(taskID, hub, p.Type, p.Payload)
-			h.persistAndBroadcast(taskID, hub, ev)
-			h.maybeUpdateTaskStatus(taskID, p)
+		for i, p := range parsed {
+			ev := h.buildEventFromClaw(taskID, hub, raw, i, p.Type, p.Payload)
+			if h.persistAndBroadcast(taskID, hub, ev) {
+				h.maybeUpdateTaskStatus(taskID, p)
+			}
+		}
+		if raw.ID != "" {
+			lastClawEventID = raw.ID
 		}
 		return nil
 	}
 
 	for {
-		err := h.clawClient.Stream(ctx, sessionID, "", onEvent)
+		err := h.clawClient.Stream(ctx, sessionID, lastClawEventID, onEvent)
 		if errors.Is(err, context.Canceled) {
 			// Normal exit: poll goroutine confirmed terminal, or hub closed.
 			break
@@ -637,25 +657,57 @@ func (h *Handler) buildEvent(taskID string, hub *taskHub, evType EventType, payl
 		Type:      evType,
 		Timestamp: nowMillis(),
 		Payload:   marshalPayload(payload),
+		Seq:       seq,
 	}
 }
 
-func (h *Handler) persistAndBroadcast(taskID string, hub *taskHub, ev Event) {
+func (h *Handler) buildEventFromClaw(
+	taskID string,
+	hub *taskHub,
+	raw ClawSSEEvent,
+	parsedIndex int,
+	evType EventType,
+	payload interface{},
+) Event {
+	seq := hub.nextSeq()
+	eventID := fmt.Sprintf("%s-%d", taskID, seq)
+	if raw.ID != "" {
+		eventID = stableClawEventID(taskID, raw.ID, parsedIndex)
+	}
+	return Event{
+		ID:        eventID,
+		TaskID:    taskID,
+		Type:      evType,
+		Timestamp: nowMillis(),
+		Payload:   marshalPayload(payload),
+		Seq:       seq,
+	}
+}
+
+func stableClawEventID(taskID, clawEventID string, parsedIndex int) string {
+	sum := sha256.Sum256([]byte(clawEventID))
+	return fmt.Sprintf("%s-c-%s-%d", taskID, hex.EncodeToString(sum[:8]), parsedIndex)
+}
+
+func (h *Handler) persistAndBroadcast(taskID string, hub *taskHub, ev Event) bool {
 	// Persist in a best-effort manner; the live channel still gets the event.
-	seq := parseSeqFromEventID(ev.ID)
 	dbev := &dbclient.OptimizationEvent{
 		EventID:   ev.ID,
 		TaskID:    taskID,
 		Type:      string(ev.Type),
 		Payload:   string(ev.Payload),
-		Seq:       seq,
+		Seq:       ev.Seq,
 		Timestamp: ev.Timestamp,
 	}
 	if err := h.dbClient.AppendOptimizationEvent(context.Background(), dbev); err != nil {
+		if errors.Is(err, dbclient.ErrOptimizationEventDuplicate) {
+			return false
+		}
 		klog.V(4).InfoS("persist optimization event failed",
-			"task_id", taskID, "seq", seq, "error", err)
+			"task_id", taskID, "seq", ev.Seq, "error", err)
 	}
 	hub.broadcast(ev)
+	return true
 }
 
 // maybeUpdateTaskStatus promotes the task's DB status when we see either a
@@ -1009,11 +1061,10 @@ func (h *Handler) recoverRunningTasks(ctx context.Context) {
 			}
 		} else {
 			// Session still active — reconnect the stream. Seed the hub from the
-			// highest persisted seq instead of restarting at 0: after an apiserver
-			// restart the in-memory counter is gone, and a 0-based counter would
-			// re-mint event_ids that already exist in the DB. Those collisions are
-			// now swallowed by the ON CONFLICT DO NOTHING insert, so newly produced
-			// events would be silently dropped until the counter caught up.
+			// highest persisted seq instead of restarting at 0 so API event order
+			// continues after an apiserver restart. Stable Claw-derived event_ids
+			// make replayed upstream history idempotent even when no in-memory
+			// Claw resume cursor survived the restart.
 			lastSeq, seqErr := h.dbClient.LatestOptimizationEventSeq(ctx, task.ID)
 			if seqErr != nil {
 				klog.ErrorS(seqErr, "recoverRunningTasks: get latest event seq failed, seeding 0",
@@ -1158,7 +1209,25 @@ func dbEventToAPI(dbev *dbclient.OptimizationEvent) Event {
 		Type:      EventType(dbev.Type),
 		Timestamp: dbev.Timestamp,
 		Payload:   json.RawMessage(dbev.Payload),
+		Seq:       dbev.Seq,
 	}
+}
+
+func (h *Handler) resolveAfterSeq(ctx context.Context, taskID, afterEventID string) int64 {
+	if afterEventID == "" {
+		return 0
+	}
+	seq, ok, err := h.dbClient.OptimizationEventSeq(ctx, taskID, afterEventID)
+	if err != nil {
+		klog.V(4).InfoS("resolve after event seq failed",
+			"task_id", taskID, "event_id", afterEventID, "error", err)
+	}
+	if ok {
+		return seq
+	}
+	// Backward compatibility for legacy taskID-seq ids and fresh terminal done
+	// frames emitted by StreamEvents without an already persisted DB row.
+	return parseAfterSeq(afterEventID)
 }
 
 func parseAfterSeq(afterEventID string) int64 {
@@ -1195,6 +1264,7 @@ func makeDoneEvent(taskID string, seq int64, status dbclient.OptimizationTaskSta
 		Type:      EventTypeDone,
 		Timestamp: nowMillis(),
 		Payload:   marshalPayload(payload),
+		Seq:       seq,
 	}
 }
 

--- a/SaFE/apiserver/pkg/handlers/optimization/handler.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/handler.go
@@ -1008,11 +1008,22 @@ func (h *Handler) recoverRunningTasks(ctx context.Context) {
 				go h.fetchAndInjectMetrics(ctx, task)
 			}
 		} else {
-			// Session still active — reconnect the stream.
-			hub, _ := h.hubs.getOrCreate(task.ID, 0)
+			// Session still active — reconnect the stream. Seed the hub from the
+			// highest persisted seq instead of restarting at 0: after an apiserver
+			// restart the in-memory counter is gone, and a 0-based counter would
+			// re-mint event_ids that already exist in the DB. Those collisions are
+			// now swallowed by the ON CONFLICT DO NOTHING insert, so newly produced
+			// events would be silently dropped until the counter caught up.
+			lastSeq, seqErr := h.dbClient.LatestOptimizationEventSeq(ctx, task.ID)
+			if seqErr != nil {
+				klog.ErrorS(seqErr, "recoverRunningTasks: get latest event seq failed, seeding 0",
+					"task_id", task.ID)
+				lastSeq = 0
+			}
+			hub, _ := h.hubs.getOrCreate(task.ID, lastSeq)
 			go h.consumeClawStream(task.ID, task.ClawSessionID, hub, clawBearer, assumeRunning)
 			klog.InfoS("recoverRunningTasks: reconnected stream",
-				"task_id", task.ID, "session_id", task.ClawSessionID)
+				"task_id", task.ID, "session_id", task.ClawSessionID, "last_seq", lastSeq)
 		}
 	}
 }

--- a/SaFE/apiserver/pkg/handlers/optimization/metrics_fetcher.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/metrics_fetcher.go
@@ -8,6 +8,7 @@ package optimization
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -109,7 +110,13 @@ func (h *Handler) appendSyntheticEvent(taskID string, evType EventType, payload 
 		Seq:       seq,
 		Timestamp: nowMillis(),
 	}
-	return h.dbClient.AppendOptimizationEvent(context.Background(), dbev)
+	if err := h.dbClient.AppendOptimizationEvent(context.Background(), dbev); err != nil {
+		if errors.Is(err, dbclient.ErrOptimizationEventDuplicate) {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 // ── Report parsing ────────────────────────────────────────────────────────────

--- a/SaFE/apiserver/pkg/handlers/optimization/types.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/types.go
@@ -250,6 +250,7 @@ type Event struct {
 	Type      EventType       `json:"type"`
 	Timestamp int64           `json:"timestamp"`
 	Payload   json.RawMessage `json:"payload"`
+	Seq       int64           `json:"-"`
 }
 
 // PhaseEventPayload maps to Hyperloom's Phase 0..10 progression.

--- a/SaFE/common/pkg/database/client/interface.go
+++ b/SaFE/common/pkg/database/client/interface.go
@@ -286,5 +286,6 @@ type OptimizationTaskInterface interface {
 
 	AppendOptimizationEvent(ctx context.Context, event *OptimizationEvent) error
 	ListOptimizationEvents(ctx context.Context, taskID string, afterSeq int64, limit int) ([]*OptimizationEvent, error)
+	OptimizationEventSeq(ctx context.Context, taskID string, eventID string) (int64, bool, error)
 	LatestOptimizationEventSeq(ctx context.Context, taskID string) (int64, error)
 }

--- a/SaFE/common/pkg/database/client/mock/mocker.go
+++ b/SaFE/common/pkg/database/client/mock/mocker.go
@@ -65,6 +65,22 @@ func (mr *MockInterfaceMockRecorder) AppendOptimizationEvent(ctx, event interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendOptimizationEvent", reflect.TypeOf((*MockInterface)(nil).AppendOptimizationEvent), ctx, event)
 }
 
+// OptimizationEventSeq mocks base method.
+func (m *MockInterface) OptimizationEventSeq(ctx context.Context, taskID, eventID string) (int64, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OptimizationEventSeq", ctx, taskID, eventID)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// OptimizationEventSeq indicates an expected call of OptimizationEventSeq.
+func (mr *MockInterfaceMockRecorder) OptimizationEventSeq(ctx, taskID, eventID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OptimizationEventSeq", reflect.TypeOf((*MockInterface)(nil).OptimizationEventSeq), ctx, taskID, eventID)
+}
+
 // BatchInsertAuditLogs mocks base method.
 func (m *MockInterface) BatchInsertAuditLogs(ctx context.Context, auditLogs []*client.AuditLog) error {
 	m.ctrl.T.Helper()
@@ -4984,6 +5000,22 @@ func (m *MockOptimizationTaskInterface) AppendOptimizationEvent(ctx context.Cont
 func (mr *MockOptimizationTaskInterfaceMockRecorder) AppendOptimizationEvent(ctx, event interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendOptimizationEvent", reflect.TypeOf((*MockOptimizationTaskInterface)(nil).AppendOptimizationEvent), ctx, event)
+}
+
+// OptimizationEventSeq mocks base method.
+func (m *MockOptimizationTaskInterface) OptimizationEventSeq(ctx context.Context, taskID, eventID string) (int64, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OptimizationEventSeq", ctx, taskID, eventID)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// OptimizationEventSeq indicates an expected call of OptimizationEventSeq.
+func (mr *MockOptimizationTaskInterfaceMockRecorder) OptimizationEventSeq(ctx, taskID, eventID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OptimizationEventSeq", reflect.TypeOf((*MockOptimizationTaskInterface)(nil).OptimizationEventSeq), ctx, taskID, eventID)
 }
 
 // CountRunningOptimizationTasks mocks base method.

--- a/SaFE/common/pkg/database/client/optimization_task.go
+++ b/SaFE/common/pkg/database/client/optimization_task.go
@@ -225,10 +225,13 @@ func (c *Client) AppendOptimizationEvent(
 		return err
 	}
 	// event_id is unique. Stream reconnects and apiserver restarts replay Claw
-	// history from the beginning (the hub seq resets to 0), so the same event_id
-	// can be produced more than once. Treat the insert as idempotent and skip on
-	// conflict instead of erroring out — otherwise every replayed event spams
-	// "duplicate key value violates unique constraint" (SQLSTATE 23505).
+	// history from the beginning, so already-persisted events are produced again
+	// with the same event_id. Treat the insert as idempotent and skip on conflict
+	// instead of erroring out — otherwise every replayed event spams "duplicate
+	// key value violates unique constraint" (SQLSTATE 23505). Note: this relies on
+	// the hub seq being re-seeded from the last persisted seq on reconnect (see
+	// recoverRunningTasks); otherwise a 0-based counter would re-mint live events
+	// onto existing ids and they would be silently dropped here.
 	return db.WithContext(ctx).Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "event_id"}},
 		DoNothing: true,

--- a/SaFE/common/pkg/database/client/optimization_task.go
+++ b/SaFE/common/pkg/database/client/optimization_task.go
@@ -224,7 +224,15 @@ func (c *Client) AppendOptimizationEvent(
 	if err != nil {
 		return err
 	}
-	return db.WithContext(ctx).Create(event).Error
+	// event_id is unique. Stream reconnects and apiserver restarts replay Claw
+	// history from the beginning (the hub seq resets to 0), so the same event_id
+	// can be produced more than once. Treat the insert as idempotent and skip on
+	// conflict instead of erroring out — otherwise every replayed event spams
+	// "duplicate key value violates unique constraint" (SQLSTATE 23505).
+	return db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "event_id"}},
+		DoNothing: true,
+	}).Create(event).Error
 }
 
 // ListOptimizationEvents returns events for a task starting after a given

--- a/SaFE/common/pkg/database/client/optimization_task.go
+++ b/SaFE/common/pkg/database/client/optimization_task.go
@@ -7,10 +7,14 @@ package client
 
 import (
 	"context"
+	"errors"
 	"time"
 
+	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
+
+var ErrOptimizationEventDuplicate = errors.New("optimization event already exists")
 
 // OptimizationTaskFilter encapsulates optional filter predicates for listing
 // optimization tasks. Zero-valued fields are ignored at query time.
@@ -224,18 +228,44 @@ func (c *Client) AppendOptimizationEvent(
 	if err != nil {
 		return err
 	}
-	// event_id is unique. Stream reconnects and apiserver restarts replay Claw
-	// history from the beginning, so already-persisted events are produced again
-	// with the same event_id. Treat the insert as idempotent and skip on conflict
-	// instead of erroring out — otherwise every replayed event spams "duplicate
-	// key value violates unique constraint" (SQLSTATE 23505). Note: this relies on
-	// the hub seq being re-seeded from the last persisted seq on reconnect (see
-	// recoverRunningTasks); otherwise a 0-based counter would re-mint live events
-	// onto existing ids and they would be silently dropped here.
-	return db.WithContext(ctx).Clauses(clause.OnConflict{
+	// event_id is unique. Stream reconnects and apiserver restarts may replay
+	// already-persisted Claw history; treat that as an idempotent duplicate
+	// instead of surfacing PostgreSQL 23505 noise.
+	result := db.WithContext(ctx).Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "event_id"}},
 		DoNothing: true,
-	}).Create(event).Error
+	}).Create(event)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return ErrOptimizationEventDuplicate
+	}
+	return nil
+}
+
+// OptimizationEventSeq returns the persisted sequence for an event id.
+func (c *Client) OptimizationEventSeq(
+	ctx context.Context,
+	taskID string,
+	eventID string,
+) (int64, bool, error) {
+	db, err := c.GetGormDB()
+	if err != nil {
+		return 0, false, err
+	}
+	var event OptimizationEvent
+	err = db.WithContext(ctx).
+		Select("seq").
+		Where("task_id = ? AND event_id = ?", taskID, eventID).
+		Take(&event).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, err
+	}
+	return event.Seq, true, nil
 }
 
 // ListOptimizationEvents returns events for a task starting after a given

--- a/SaFE/common/pkg/database/client/optimization_task_test.go
+++ b/SaFE/common/pkg/database/client/optimization_task_test.go
@@ -29,6 +29,7 @@ func TestOptimizationTaskCRUD(t *testing.T) {
 	_, _ = c.CountRunningOptimizationTasks(ctx, "ws")
 	_ = c.AppendOptimizationEvent(ctx, &OptimizationEvent{TaskID: "t1"})
 	_, _ = c.ListOptimizationEvents(ctx, "t1", 0, 10)
+	_, _, _ = c.OptimizationEventSeq(ctx, "t1", "t1-1")
 	_, _ = c.LatestOptimizationEventSeq(ctx, "t1")
 }
 


### PR DESCRIPTION
## Summary

Hardens optimization event persistence and replay across Claw SSE reconnects and apiserver restarts.

- Inserts into `optimization_event` are idempotent on `event_id`, avoiding PostgreSQL 23505 duplicate-key log floods when Claw history is replayed.
- Claw-originated events now use stable event ids derived from the upstream SSE `id:` plus parsed-event index, while DB `seq` remains the ordering cursor for frontend replay.
- Stream reconnects now pass the last upstream Claw event id back as `after_event_id`, so transient EOF/network drops resume instead of replaying from the beginning.
- Duplicate replayed events are skipped without live broadcast, preventing duplicate UI events even if Claw replays history anyway or after apiserver restart.
- `/optimization/tasks/:id/events` resolves arbitrary persisted event ids back to DB seq and replays in pages, removing the old 10000-event truncation gap.
- Recovered running tasks still seed hub seq from the last persisted seq so new API events continue after the prior high-water mark.

## Test plan

- [x] `go build ./apiserver/pkg/handlers/optimization/... ./common/pkg/database/client/...`
- [x] `go test ./apiserver/pkg/handlers/optimization/...`
- [x] `go test ./common/pkg/database/client/...`
- [x] `git diff --check`
- [ ] Deploy and verify with active optimization tasks: restart apiserver, confirm no 23505 spam, no duplicate live SSE events, and newly generated events continue to persist.