### PR TITLE
fix(optimization): retry Claw session creation on transient timeouts

### DIFF
--- a/SaFE/apiserver/pkg/handlers/optimization/claw_client.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/claw_client.go
@@ -112,6 +112,12 @@ type CreateSessionResult struct {
 	Dispatched *bool
 }
 
+type sessionListEnvelope struct {
+	Data     json.RawMessage `json:"data"`
+	Items    []SessionStatus `json:"items"`
+	Sessions []SessionStatus `json:"sessions"`
+}
+
 // MessageRequest maps to POST /sessions/{id}/messages.
 type MessageRequest struct {
 	Content     string                   `json:"content,omitempty"`
@@ -262,6 +268,92 @@ func (c *ClawClient) createSession(ctx context.Context, req *SessionRequest) (Cr
 	}, nil
 }
 
+func (c *ClawClient) FindSessionByName(ctx context.Context, name string) (*SessionStatus, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, fmt.Errorf("claw find session: empty name")
+	}
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodGet, c.baseURL+clawPathSessions+"?name="+url.QueryEscape(name), nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+	c.applyHeaders(req)
+
+	resp, err := c.controlClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("claw GET /sessions by name: %w", err)
+	}
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusMethodNotAllowed {
+		return nil, nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("claw find session HTTP %d: %s", resp.StatusCode, truncate(string(raw), 256))
+	}
+	sessions, err := parseSessionList(raw)
+	if err != nil {
+		return nil, err
+	}
+	for i := range sessions {
+		if strings.TrimSpace(sessions[i].SessionID) == "" {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(sessions[i].Name), name) {
+			return &sessions[i], nil
+		}
+	}
+	return nil, nil
+}
+
+func parseSessionList(raw []byte) ([]SessionStatus, error) {
+	var directItems []SessionStatus
+	if err := json.Unmarshal(raw, &directItems); err == nil {
+		return directItems, nil
+	}
+	var directSession SessionStatus
+	if err := json.Unmarshal(raw, &directSession); err == nil && directSession.SessionID != "" {
+		return []SessionStatus{directSession}, nil
+	}
+
+	var env sessionListEnvelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return nil, fmt.Errorf("claw list sessions parse envelope: %w", err)
+	}
+	if len(env.Items) > 0 {
+		return env.Items, nil
+	}
+	if len(env.Sessions) > 0 {
+		return env.Sessions, nil
+	}
+	if len(env.Data) == 0 {
+		return nil, nil
+	}
+
+	var items []SessionStatus
+	if err := json.Unmarshal(env.Data, &items); err == nil {
+		return items, nil
+	}
+	var data sessionListEnvelope
+	if err := json.Unmarshal(env.Data, &data); err != nil {
+		return nil, fmt.Errorf("claw list sessions parse data: %w", err)
+	}
+	if len(data.Items) > 0 {
+		return data.Items, nil
+	}
+	if len(data.Sessions) > 0 {
+		return data.Sessions, nil
+	}
+	var session SessionStatus
+	if err := json.Unmarshal(env.Data, &session); err == nil && session.SessionID != "" {
+		return []SessionStatus{session}, nil
+	}
+	return nil, nil
+}
+
 // SendMessage fires a message into an existing Claw session. This is a
 // fire-and-forget request — actual model output comes back via Stream.
 func (c *ClawClient) SendMessage(ctx context.Context, sessionID string, req *MessageRequest) error {
@@ -345,6 +437,7 @@ func (c *ClawClient) Stream(
 //   - AgentStatus: agent execution  — "idle"   | "running"   | "stopped" | "failed"
 type SessionStatus struct {
 	SessionID   string `json:"session_id"`
+	Name        string `json:"name"`
 	Status      string `json:"status"`
 	AgentStatus string `json:"agent_status"`
 }

--- a/SaFE/apiserver/pkg/handlers/optimization/claw_client_http_test.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/claw_client_http_test.go
@@ -237,8 +237,12 @@ func TestCreateClawSessionWithRetryDispatchesExistingIdleSession(t *testing.T) {
 			assert.Equal(t, "opt", r.URL.Query().Get("name"))
 			_, _ = w.Write([]byte(`{"data":{"items":[{"session_id":"sess-existing","name":"opt","agent_status":"idle"}]}}`))
 		case r.Method == http.MethodGet && r.URL.Path == "/sessions/sess-existing":
-			getCalls.Add(1)
-			_, _ = w.Write([]byte(`{"data":{"session_id":"sess-existing","name":"opt","agent_status":"idle"}}`))
+			n := getCalls.Add(1)
+			agentStatus := "idle"
+			if n > 1 {
+				agentStatus = "running"
+			}
+			_, _ = w.Write([]byte(`{"data":{"session_id":"sess-existing","name":"opt","agent_status":"` + agentStatus + `"}}`))
 		case r.Method == http.MethodPost && r.URL.Path == "/sessions/sess-existing/messages":
 			messageCalls.Add(1)
 			var body struct {
@@ -267,7 +271,7 @@ func TestCreateClawSessionWithRetryDispatchesExistingIdleSession(t *testing.T) {
 	assert.Equal(t, "running", res.AgentStatus)
 	assert.Equal(t, int32(1), createCalls.Load())
 	assert.Equal(t, int32(1), lookupCalls.Load())
-	assert.Equal(t, int32(1), getCalls.Load())
+	assert.Equal(t, int32(2), getCalls.Load())
 	assert.Equal(t, int32(1), messageCalls.Load())
 }
 

--- a/SaFE/apiserver/pkg/handlers/optimization/claw_client_http_test.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/claw_client_http_test.go
@@ -7,6 +7,7 @@ package optimization
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -139,6 +140,16 @@ func TestCreateClawSessionWithRetryTransientFailures(t *testing.T) {
 
 	var calls atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(`{"data":[]}`))
+			return
+		}
+		var body struct {
+			Name string `json:"name"`
+		}
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "opt", body.Name)
+
 		n := calls.Add(1)
 		if n < 3 {
 			w.WriteHeader(499)
@@ -159,6 +170,49 @@ func TestCreateClawSessionWithRetryTransientFailures(t *testing.T) {
 	assert.Equal(t, int32(3), calls.Load())
 }
 
+func TestCreateClawSessionWithRetryReusesExistingSessionByName(t *testing.T) {
+	oldRetryInterval := clawCreateSessionRetryInterval
+	oldTotalTimeout := clawCreateSessionTotalTimeout
+	oldLookupTimeout := clawCreateSessionLookupTimeout
+	clawCreateSessionRetryInterval = time.Millisecond
+	clawCreateSessionTotalTimeout = time.Second
+	clawCreateSessionLookupTimeout = time.Second
+	t.Cleanup(func() {
+		clawCreateSessionRetryInterval = oldRetryInterval
+		clawCreateSessionTotalTimeout = oldTotalTimeout
+		clawCreateSessionLookupTimeout = oldLookupTimeout
+	})
+
+	var postCalls atomic.Int32
+	var lookupCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			lookupCalls.Add(1)
+			assert.Equal(t, "opt", r.URL.Query().Get("name"))
+			_, _ = w.Write([]byte(`{"data":{"items":[{"session_id":"sess-existing","name":"opt","agent_status":"running"}]}}`))
+		case http.MethodPost:
+			postCalls.Add(1)
+			w.WriteHeader(499)
+			_, _ = w.Write([]byte(`{"ok":false,"error":"client_closed_request"}`))
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer srv.Close()
+
+	h := &Handler{clawClient: NewClawClient(srv.URL, "test-key")}
+	res, err := h.createClawSessionWithRetry(context.Background(), "bearer", "task-1", &SessionRequest{
+		Name:    "opt",
+		Message: &MessageRequest{Content: "hi"},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "sess-existing", res.SessionID)
+	assert.Equal(t, "running", res.AgentStatus)
+	assert.Equal(t, int32(1), postCalls.Load())
+	assert.Equal(t, int32(1), lookupCalls.Load())
+}
+
 func TestCreateClawSessionWithRetryDoesNotRetryBusinessFailure(t *testing.T) {
 	oldRetryInterval := clawCreateSessionRetryInterval
 	oldTotalTimeout := clawCreateSessionTotalTimeout
@@ -173,6 +227,33 @@ func TestCreateClawSessionWithRetryDoesNotRetryBusinessFailure(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
 		_, _ = w.Write([]byte(`{"code":0,"data":{"session_id":"sess-1","agent_status":"idle","message":{"message_id":"msg-1","dispatched":false}}}`))
+	}))
+	defer srv.Close()
+
+	h := &Handler{clawClient: NewClawClient(srv.URL, "test-key")}
+	_, err := h.createClawSessionWithRetry(context.Background(), "bearer", "task-1", &SessionRequest{
+		Name:    "opt",
+		Message: &MessageRequest{Content: "hi"},
+	})
+	assert.Error(t, err)
+	assert.Equal(t, int32(1), calls.Load())
+}
+
+func TestCreateClawSessionWithRetryDoesNotRetryServerError(t *testing.T) {
+	oldRetryInterval := clawCreateSessionRetryInterval
+	oldTotalTimeout := clawCreateSessionTotalTimeout
+	clawCreateSessionRetryInterval = time.Millisecond
+	clawCreateSessionTotalTimeout = time.Second
+	t.Cleanup(func() {
+		clawCreateSessionRetryInterval = oldRetryInterval
+		clawCreateSessionTotalTimeout = oldTotalTimeout
+	})
+
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"ok":false,"error":"internal"}`))
 	}))
 	defer srv.Close()
 

--- a/SaFE/apiserver/pkg/handlers/optimization/claw_client_http_test.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/claw_client_http_test.go
@@ -310,7 +310,7 @@ func TestCreateClawSessionWithRetryDoesNotRetryServerError(t *testing.T) {
 	var calls atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(599)
 		_, _ = w.Write([]byte(`{"ok":false,"error":"upstream timeout"}`))
 	}))
 	defer srv.Close()

--- a/SaFE/apiserver/pkg/handlers/optimization/claw_client_http_test.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/claw_client_http_test.go
@@ -311,7 +311,7 @@ func TestCreateClawSessionWithRetryDoesNotRetryServerError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
 		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write([]byte(`{"ok":false,"error":"internal"}`))
+		_, _ = w.Write([]byte(`{"ok":false,"error":"upstream timeout"}`))
 	}))
 	defer srv.Close()
 

--- a/SaFE/apiserver/pkg/handlers/optimization/claw_client_http_test.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/claw_client_http_test.go
@@ -10,7 +10,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -120,6 +122,67 @@ func TestClawCreateSessionWithMessageExplicitNotDispatched(t *testing.T) {
 		Message: &MessageRequest{Content: "hi"},
 	})
 	assert.Error(t, err)
+}
+
+func TestCreateClawSessionWithRetryTransientFailures(t *testing.T) {
+	oldAttemptTimeout := clawCreateSessionAttemptTimeout
+	oldRetryInterval := clawCreateSessionRetryInterval
+	oldTotalTimeout := clawCreateSessionTotalTimeout
+	clawCreateSessionAttemptTimeout = 100 * time.Millisecond
+	clawCreateSessionRetryInterval = time.Millisecond
+	clawCreateSessionTotalTimeout = time.Second
+	t.Cleanup(func() {
+		clawCreateSessionAttemptTimeout = oldAttemptTimeout
+		clawCreateSessionRetryInterval = oldRetryInterval
+		clawCreateSessionTotalTimeout = oldTotalTimeout
+	})
+
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		if n < 3 {
+			w.WriteHeader(499)
+			_, _ = w.Write([]byte(`{"ok":false,"error":"client_closed_request"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"code":0,"data":{"session_id":"sess-1","agent_status":"running","message":{"message_id":"msg-1","dispatched":true}}}`))
+	}))
+	defer srv.Close()
+
+	h := &Handler{clawClient: NewClawClient(srv.URL, "test-key")}
+	res, err := h.createClawSessionWithRetry("bearer", "task-1", &SessionRequest{
+		Name:    "opt",
+		Message: &MessageRequest{Content: "hi"},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "sess-1", res.SessionID)
+	assert.Equal(t, int32(3), calls.Load())
+}
+
+func TestCreateClawSessionWithRetryDoesNotRetryBusinessFailure(t *testing.T) {
+	oldRetryInterval := clawCreateSessionRetryInterval
+	oldTotalTimeout := clawCreateSessionTotalTimeout
+	clawCreateSessionRetryInterval = time.Millisecond
+	clawCreateSessionTotalTimeout = time.Second
+	t.Cleanup(func() {
+		clawCreateSessionRetryInterval = oldRetryInterval
+		clawCreateSessionTotalTimeout = oldTotalTimeout
+	})
+
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		_, _ = w.Write([]byte(`{"code":0,"data":{"session_id":"sess-1","agent_status":"idle","message":{"message_id":"msg-1","dispatched":false}}}`))
+	}))
+	defer srv.Close()
+
+	h := &Handler{clawClient: NewClawClient(srv.URL, "test-key")}
+	_, err := h.createClawSessionWithRetry("bearer", "task-1", &SessionRequest{
+		Name:    "opt",
+		Message: &MessageRequest{Content: "hi"},
+	})
+	assert.Error(t, err)
+	assert.Equal(t, int32(1), calls.Load())
 }
 
 func TestClawSendMessage(t *testing.T) {

--- a/SaFE/apiserver/pkg/handlers/optimization/claw_client_http_test.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/claw_client_http_test.go
@@ -150,7 +150,7 @@ func TestCreateClawSessionWithRetryTransientFailures(t *testing.T) {
 	defer srv.Close()
 
 	h := &Handler{clawClient: NewClawClient(srv.URL, "test-key")}
-	res, err := h.createClawSessionWithRetry("bearer", "task-1", &SessionRequest{
+	res, err := h.createClawSessionWithRetry(context.Background(), "bearer", "task-1", &SessionRequest{
 		Name:    "opt",
 		Message: &MessageRequest{Content: "hi"},
 	})
@@ -177,11 +177,40 @@ func TestCreateClawSessionWithRetryDoesNotRetryBusinessFailure(t *testing.T) {
 	defer srv.Close()
 
 	h := &Handler{clawClient: NewClawClient(srv.URL, "test-key")}
-	_, err := h.createClawSessionWithRetry("bearer", "task-1", &SessionRequest{
+	_, err := h.createClawSessionWithRetry(context.Background(), "bearer", "task-1", &SessionRequest{
 		Name:    "opt",
 		Message: &MessageRequest{Content: "hi"},
 	})
 	assert.Error(t, err)
+	assert.Equal(t, int32(1), calls.Load())
+}
+
+func TestCreateClawSessionWithRetryStopsOnParentCancellation(t *testing.T) {
+	oldRetryInterval := clawCreateSessionRetryInterval
+	oldTotalTimeout := clawCreateSessionTotalTimeout
+	clawCreateSessionRetryInterval = 50 * time.Millisecond
+	clawCreateSessionTotalTimeout = time.Second
+	t.Cleanup(func() {
+		clawCreateSessionRetryInterval = oldRetryInterval
+		clawCreateSessionTotalTimeout = oldTotalTimeout
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		cancel()
+		w.WriteHeader(499)
+		_, _ = w.Write([]byte(`{"ok":false,"error":"client_closed_request"}`))
+	}))
+	defer srv.Close()
+
+	h := &Handler{clawClient: NewClawClient(srv.URL, "test-key")}
+	_, err := h.createClawSessionWithRetry(ctx, "bearer", "task-1", &SessionRequest{
+		Name:    "opt",
+		Message: &MessageRequest{Content: "hi"},
+	})
+	assert.ErrorIs(t, err, context.Canceled)
 	assert.Equal(t, int32(1), calls.Load())
 }
 

--- a/SaFE/apiserver/pkg/handlers/optimization/claw_client_http_test.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/claw_client_http_test.go
@@ -213,6 +213,64 @@ func TestCreateClawSessionWithRetryReusesExistingSessionByName(t *testing.T) {
 	assert.Equal(t, int32(1), lookupCalls.Load())
 }
 
+func TestCreateClawSessionWithRetryDispatchesExistingIdleSession(t *testing.T) {
+	oldRetryInterval := clawCreateSessionRetryInterval
+	oldTotalTimeout := clawCreateSessionTotalTimeout
+	oldLookupTimeout := clawCreateSessionLookupTimeout
+	clawCreateSessionRetryInterval = time.Millisecond
+	clawCreateSessionTotalTimeout = time.Second
+	clawCreateSessionLookupTimeout = time.Second
+	t.Cleanup(func() {
+		clawCreateSessionRetryInterval = oldRetryInterval
+		clawCreateSessionTotalTimeout = oldTotalTimeout
+		clawCreateSessionLookupTimeout = oldLookupTimeout
+	})
+
+	var createCalls atomic.Int32
+	var lookupCalls atomic.Int32
+	var getCalls atomic.Int32
+	var messageCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/sessions":
+			lookupCalls.Add(1)
+			assert.Equal(t, "opt", r.URL.Query().Get("name"))
+			_, _ = w.Write([]byte(`{"data":{"items":[{"session_id":"sess-existing","name":"opt","agent_status":"idle"}]}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/sessions/sess-existing":
+			getCalls.Add(1)
+			_, _ = w.Write([]byte(`{"data":{"session_id":"sess-existing","name":"opt","agent_status":"idle"}}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/sessions/sess-existing/messages":
+			messageCalls.Add(1)
+			var body struct {
+				Content string `json:"content"`
+			}
+			assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			assert.Equal(t, "hi", body.Content)
+			_, _ = w.Write([]byte(`{"code":0}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/sessions":
+			createCalls.Add(1)
+			w.WriteHeader(499)
+			_, _ = w.Write([]byte(`{"ok":false,"error":"client_closed_request"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	h := &Handler{clawClient: NewClawClient(srv.URL, "test-key")}
+	res, err := h.createClawSessionWithRetry(context.Background(), "bearer", "task-1", &SessionRequest{
+		Name:    "opt",
+		Message: &MessageRequest{Content: "hi"},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "sess-existing", res.SessionID)
+	assert.Equal(t, "running", res.AgentStatus)
+	assert.Equal(t, int32(1), createCalls.Load())
+	assert.Equal(t, int32(1), lookupCalls.Load())
+	assert.Equal(t, int32(1), getCalls.Load())
+	assert.Equal(t, int32(1), messageCalls.Load())
+}
+
 func TestCreateClawSessionWithRetryDoesNotRetryBusinessFailure(t *testing.T) {
 	oldRetryInterval := clawCreateSessionRetryInterval
 	oldTotalTimeout := clawCreateSessionTotalTimeout

--- a/SaFE/apiserver/pkg/handlers/optimization/handler.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/handler.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -437,10 +438,8 @@ func isRetryableClawCreateSessionError(err error) bool {
 		return true
 	}
 	msg := strings.ToLower(err.Error())
-	for _, fragment := range []string{"http 500", "http 501", "http 502", "http 503", "http 504", "http 505", "http 506", "http 507", "http 508", "http 510", "http 511"} {
-		if strings.Contains(msg, fragment) {
-			return false
-		}
+	if containsHTTP5xx(msg) {
+		return false
 	}
 	retryableFragments := []string{
 		"client_closed_request",
@@ -458,6 +457,25 @@ func isRetryableClawCreateSessionError(err error) bool {
 		if strings.Contains(msg, fragment) {
 			return true
 		}
+	}
+	return false
+}
+
+func containsHTTP5xx(msg string) bool {
+	for i := 0; i < len(msg); i++ {
+		idx := strings.Index(msg[i:], "http ")
+		if idx < 0 {
+			return false
+		}
+		start := i + idx + len("http ")
+		if start+3 > len(msg) {
+			return false
+		}
+		code, err := strconv.Atoi(msg[start : start+3])
+		if err == nil && code >= 500 && code < 600 {
+			return true
+		}
+		i = start
 	}
 	return false
 }

--- a/SaFE/apiserver/pkg/handlers/optimization/handler.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/handler.go
@@ -418,9 +418,17 @@ func (h *Handler) reuseExistingClawSessionByName(
 		if err != nil {
 			return CreateSessionResult{}, false, fmt.Errorf("dispatch prompt to existing claw session %s: %w", ss.SessionID, err)
 		}
-		ss.AgentStatus = clawAgentStatusRunning
+		confirmCtx, confirmCancel := context.WithTimeout(WithClawBearer(ctx, clawBearer), clawCreateSessionLookupTimeout)
+		confirmed, err := h.clawClient.GetSession(confirmCtx, ss.SessionID)
+		confirmCancel()
+		if err != nil {
+			klog.Warningf("confirm existing claw session after dispatch failed; reusing last known status task_id=%s session_id=%s error=%v",
+				taskID, ss.SessionID, err)
+		} else if confirmed != nil {
+			ss = confirmed
+		}
 		klog.InfoS("dispatched prompt to existing claw session after create retryable error",
-			"task_id", taskID, "session_name", name, "session_id", ss.SessionID)
+			"task_id", taskID, "session_name", name, "session_id", ss.SessionID, "agent_status", ss.AgentStatus)
 	}
 	klog.InfoS("reusing existing claw session after create retryable error",
 		"task_id", taskID, "session_name", name, "session_id", ss.SessionID, "agent_status", ss.AgentStatus)

--- a/SaFE/apiserver/pkg/handlers/optimization/handler.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/handler.go
@@ -35,6 +35,12 @@ import (
 	jsonutils "github.com/AMD-AIG-AIMA/SAFE/utils/pkg/json"
 )
 
+var (
+	clawCreateSessionAttemptTimeout = 30 * time.Second
+	clawCreateSessionRetryInterval  = 5 * time.Second
+	clawCreateSessionTotalTimeout   = 3 * time.Minute
+)
+
 // Handler is the HTTP entry point for Model Optimization. It orchestrates
 // DB persistence, Claw session management, and the per-task event hub.
 //
@@ -239,8 +245,6 @@ func (h *Handler) submitTask(
 		"memory":      fmt.Sprintf("%dGi", promptCfg.RayMemoryGi),
 	}
 
-	createCtx, cancel := context.WithTimeout(WithClawBearer(context.Background(), clawBearer), 30*time.Second)
-	defer cancel()
 	sessionName := fmt.Sprintf("safe-opt-%s-%s", resolved.DisplayName, taskID[len(taskID)-8:])
 	// Log the session-scoped env we forward to Claw so it can be verified from
 	// the apiserver log alone (mirrors the Hyperloom-side submit log). Only
@@ -249,7 +253,7 @@ func (h *Handler) submitTask(
 		klog.InfoS("optimization: forwarding session env to claw",
 			"task_id", taskID, "session_name", sessionName, "env", req.Env)
 	}
-	createResult, err := h.clawClient.CreateSessionWithMessage(createCtx, &SessionRequest{
+	createResult, err := h.createClawSessionWithRetry(clawBearer, taskID, &SessionRequest{
 		Name:    sessionName,
 		AgentID: h.clawAgentID,
 		// Env MUST be top-level: Claw's POST /sessions reads session_env from
@@ -278,6 +282,92 @@ func (h *Handler) submitTask(
 		ID:            taskID,
 		ClawSessionID: sessionID,
 	}, nil
+}
+
+func (h *Handler) createClawSessionWithRetry(
+	clawBearer string,
+	taskID string,
+	req *SessionRequest,
+) (CreateSessionResult, error) {
+	deadline := time.Now().Add(clawCreateSessionTotalTimeout)
+	var lastErr error
+	attempt := 0
+	for {
+		attempt++
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			break
+		}
+		attemptTimeout := clawCreateSessionAttemptTimeout
+		if remaining < attemptTimeout {
+			attemptTimeout = remaining
+		}
+		createCtx, cancel := context.WithTimeout(
+			WithClawBearer(context.Background(), clawBearer),
+			attemptTimeout,
+		)
+		result, err := h.clawClient.CreateSessionWithMessage(createCtx, req)
+		cancel()
+		if err == nil {
+			if attempt > 1 {
+				klog.InfoS("create and dispatch claw session succeeded after retry",
+					"task_id", taskID, "attempt", attempt)
+			}
+			return result, nil
+		}
+		lastErr = err
+		if !isRetryableClawCreateSessionError(err) {
+			return CreateSessionResult{}, err
+		}
+		remaining = time.Until(deadline)
+		if remaining <= clawCreateSessionRetryInterval {
+			break
+		}
+		klog.Warningf("create and dispatch claw session failed; retrying task_id=%s attempt=%d timeout=%s error=%v",
+			taskID, attempt, attemptTimeout, err)
+		time.Sleep(clawCreateSessionRetryInterval)
+	}
+	if lastErr == nil {
+		lastErr = context.DeadlineExceeded
+	}
+	return CreateSessionResult{}, fmt.Errorf(
+		"create and dispatch claw session failed after %d attempts over %s: %w",
+		attempt,
+		clawCreateSessionTotalTimeout,
+		lastErr,
+	)
+}
+
+func isRetryableClawCreateSessionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	retryableFragments := []string{
+		"client_closed_request",
+		"http 408",
+		"http 425",
+		"http 429",
+		"http 499",
+		"http 500",
+		"http 502",
+		"http 503",
+		"http 504",
+		"connection reset",
+		"connection refused",
+		"eof",
+		"timeout",
+		"temporary",
+	}
+	for _, fragment := range retryableFragments {
+		if strings.Contains(msg, fragment) {
+			return true
+		}
+	}
+	return false
 }
 
 // ── ListTasks / GetTask / DeleteTask ────────────────────────────────────

--- a/SaFE/apiserver/pkg/handlers/optimization/handler.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/handler.go
@@ -437,6 +437,11 @@ func isRetryableClawCreateSessionError(err error) bool {
 		return true
 	}
 	msg := strings.ToLower(err.Error())
+	for _, fragment := range []string{"http 500", "http 501", "http 502", "http 503", "http 504", "http 505", "http 506", "http 507", "http 508", "http 510", "http 511"} {
+		if strings.Contains(msg, fragment) {
+			return false
+		}
+	}
 	retryableFragments := []string{
 		"client_closed_request",
 		"http 408",

--- a/SaFE/apiserver/pkg/handlers/optimization/handler.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/handler.go
@@ -38,6 +38,7 @@ import (
 var (
 	clawCreateSessionAttemptTimeout = 30 * time.Second
 	clawCreateSessionRetryInterval  = 5 * time.Second
+	clawCreateSessionLookupTimeout  = 5 * time.Second
 	clawCreateSessionTotalTimeout   = 3 * time.Minute
 )
 
@@ -333,6 +334,9 @@ func (h *Handler) createClawSessionWithRetry(
 		if !isRetryableClawCreateSessionError(err) {
 			return CreateSessionResult{}, err
 		}
+		if result, ok := h.findExistingClawSessionByName(ctx, clawBearer, taskID, req.Name); ok {
+			return result, nil
+		}
 		remaining = time.Until(deadline)
 		if remaining <= clawCreateSessionRetryInterval {
 			break
@@ -363,6 +367,35 @@ func (h *Handler) createClawSessionWithRetry(
 	)
 }
 
+func (h *Handler) findExistingClawSessionByName(
+	ctx context.Context,
+	clawBearer string,
+	taskID string,
+	name string,
+) (CreateSessionResult, bool) {
+	if strings.TrimSpace(name) == "" {
+		return CreateSessionResult{}, false
+	}
+	lookupCtx, cancel := context.WithTimeout(WithClawBearer(ctx, clawBearer), clawCreateSessionLookupTimeout)
+	defer cancel()
+
+	ss, err := h.clawClient.FindSessionByName(lookupCtx, name)
+	if err != nil {
+		klog.Warningf("find existing claw session by name failed; continuing retry task_id=%s name=%q error=%v",
+			taskID, name, err)
+		return CreateSessionResult{}, false
+	}
+	if ss == nil || strings.TrimSpace(ss.SessionID) == "" {
+		return CreateSessionResult{}, false
+	}
+	klog.InfoS("reusing existing claw session after create retryable error",
+		"task_id", taskID, "session_name", name, "session_id", ss.SessionID, "agent_status", ss.AgentStatus)
+	return CreateSessionResult{
+		SessionID:   ss.SessionID,
+		AgentStatus: ss.AgentStatus,
+	}, true
+}
+
 func isRetryableClawCreateSessionError(err error) bool {
 	if err == nil {
 		return false
@@ -377,10 +410,6 @@ func isRetryableClawCreateSessionError(err error) bool {
 		"http 425",
 		"http 429",
 		"http 499",
-		"http 500",
-		"http 502",
-		"http 503",
-		"http 504",
 		"connection reset",
 		"connection refused",
 		"eof",

--- a/SaFE/apiserver/pkg/handlers/optimization/handler.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/handler.go
@@ -334,7 +334,11 @@ func (h *Handler) createClawSessionWithRetry(
 		if !isRetryableClawCreateSessionError(err) {
 			return CreateSessionResult{}, err
 		}
-		if result, ok := h.findExistingClawSessionByName(ctx, clawBearer, taskID, req.Name); ok {
+		result, reused, reuseErr := h.reuseExistingClawSessionByName(ctx, clawBearer, taskID, req)
+		if reuseErr != nil {
+			return CreateSessionResult{}, reuseErr
+		}
+		if reused {
 			return result, nil
 		}
 		remaining = time.Until(deadline)
@@ -367,14 +371,18 @@ func (h *Handler) createClawSessionWithRetry(
 	)
 }
 
-func (h *Handler) findExistingClawSessionByName(
+func (h *Handler) reuseExistingClawSessionByName(
 	ctx context.Context,
 	clawBearer string,
 	taskID string,
-	name string,
-) (CreateSessionResult, bool) {
+	req *SessionRequest,
+) (CreateSessionResult, bool, error) {
+	if req == nil {
+		return CreateSessionResult{}, false, nil
+	}
+	name := req.Name
 	if strings.TrimSpace(name) == "" {
-		return CreateSessionResult{}, false
+		return CreateSessionResult{}, false, nil
 	}
 	lookupCtx, cancel := context.WithTimeout(WithClawBearer(ctx, clawBearer), clawCreateSessionLookupTimeout)
 	defer cancel()
@@ -383,17 +391,42 @@ func (h *Handler) findExistingClawSessionByName(
 	if err != nil {
 		klog.Warningf("find existing claw session by name failed; continuing retry task_id=%s name=%q error=%v",
 			taskID, name, err)
-		return CreateSessionResult{}, false
+		return CreateSessionResult{}, false, nil
 	}
 	if ss == nil || strings.TrimSpace(ss.SessionID) == "" {
-		return CreateSessionResult{}, false
+		return CreateSessionResult{}, false, nil
+	}
+	if !ss.IsAgentRunning() {
+		confirmCtx, confirmCancel := context.WithTimeout(WithClawBearer(ctx, clawBearer), clawCreateSessionLookupTimeout)
+		confirmed, err := h.clawClient.GetSession(confirmCtx, ss.SessionID)
+		confirmCancel()
+		if err != nil {
+			klog.Warningf("confirm existing claw session failed; continuing with list status task_id=%s session_id=%s error=%v",
+				taskID, ss.SessionID, err)
+		} else if confirmed != nil {
+			ss = confirmed
+		}
+	}
+	if !ss.IsAgentRunning() {
+		if req.Message == nil {
+			return CreateSessionResult{}, false, fmt.Errorf("existing claw session %s is not running and original message is missing", ss.SessionID)
+		}
+		sendCtx, sendCancel := context.WithTimeout(WithClawBearer(ctx, clawBearer), clawCreateSessionAttemptTimeout)
+		err := h.clawClient.SendMessage(sendCtx, ss.SessionID, req.Message)
+		sendCancel()
+		if err != nil {
+			return CreateSessionResult{}, false, fmt.Errorf("dispatch prompt to existing claw session %s: %w", ss.SessionID, err)
+		}
+		ss.AgentStatus = clawAgentStatusRunning
+		klog.InfoS("dispatched prompt to existing claw session after create retryable error",
+			"task_id", taskID, "session_name", name, "session_id", ss.SessionID)
 	}
 	klog.InfoS("reusing existing claw session after create retryable error",
 		"task_id", taskID, "session_name", name, "session_id", ss.SessionID, "agent_status", ss.AgentStatus)
 	return CreateSessionResult{
 		SessionID:   ss.SessionID,
 		AgentStatus: ss.AgentStatus,
-	}, true
+	}, true, nil
 }
 
 func isRetryableClawCreateSessionError(err error) bool {

--- a/SaFE/apiserver/pkg/handlers/optimization/handler.go
+++ b/SaFE/apiserver/pkg/handlers/optimization/handler.go
@@ -253,7 +253,7 @@ func (h *Handler) submitTask(
 		klog.InfoS("optimization: forwarding session env to claw",
 			"task_id", taskID, "session_name", sessionName, "env", req.Env)
 	}
-	createResult, err := h.createClawSessionWithRetry(clawBearer, taskID, &SessionRequest{
+	createResult, err := h.createClawSessionWithRetry(ctx, clawBearer, taskID, &SessionRequest{
 		Name:    sessionName,
 		AgentID: h.clawAgentID,
 		// Env MUST be top-level: Claw's POST /sessions reads session_env from
@@ -265,7 +265,11 @@ func (h *Handler) submitTask(
 	})
 	if err != nil {
 		klog.ErrorS(err, "create and dispatch claw session", "task_id", taskID)
-		_ = h.dbClient.UpdateOptimizationTaskStatus(ctx, taskID,
+		statusCtx := ctx
+		if ctx.Err() != nil {
+			statusCtx = context.WithoutCancel(ctx)
+		}
+		_ = h.dbClient.UpdateOptimizationTaskStatus(statusCtx, taskID,
 			dbclient.OptimizationTaskStatusFailed, 0, "failed to create and dispatch Claw session: "+err.Error())
 		return nil, commonerrors.NewInternalError("failed to submit task to Claw")
 	}
@@ -285,14 +289,21 @@ func (h *Handler) submitTask(
 }
 
 func (h *Handler) createClawSessionWithRetry(
+	ctx context.Context,
 	clawBearer string,
 	taskID string,
 	req *SessionRequest,
 ) (CreateSessionResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	deadline := time.Now().Add(clawCreateSessionTotalTimeout)
 	var lastErr error
 	attempt := 0
 	for {
+		if err := ctx.Err(); err != nil {
+			return CreateSessionResult{}, fmt.Errorf("create and dispatch claw session canceled: %w", err)
+		}
 		attempt++
 		remaining := time.Until(deadline)
 		if remaining <= 0 {
@@ -303,7 +314,7 @@ func (h *Handler) createClawSessionWithRetry(
 			attemptTimeout = remaining
 		}
 		createCtx, cancel := context.WithTimeout(
-			WithClawBearer(context.Background(), clawBearer),
+			WithClawBearer(ctx, clawBearer),
 			attemptTimeout,
 		)
 		result, err := h.clawClient.CreateSessionWithMessage(createCtx, req)
@@ -316,6 +327,9 @@ func (h *Handler) createClawSessionWithRetry(
 			return result, nil
 		}
 		lastErr = err
+		if err := ctx.Err(); err != nil {
+			return CreateSessionResult{}, fmt.Errorf("create and dispatch claw session canceled: %w", err)
+		}
 		if !isRetryableClawCreateSessionError(err) {
 			return CreateSessionResult{}, err
 		}
@@ -325,7 +339,18 @@ func (h *Handler) createClawSessionWithRetry(
 		}
 		klog.Warningf("create and dispatch claw session failed; retrying task_id=%s attempt=%d timeout=%s error=%v",
 			taskID, attempt, attemptTimeout, err)
-		time.Sleep(clawCreateSessionRetryInterval)
+		timer := time.NewTimer(clawCreateSessionRetryInterval)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return CreateSessionResult{}, fmt.Errorf("create and dispatch claw session canceled: %w", ctx.Err())
+		}
 	}
 	if lastErr == nil {
 		lastErr = context.DeadlineExceeded

--- a/SaFE/scripts/optimize_submit.py
+++ b/SaFE/scripts/optimize_submit.py
@@ -37,8 +37,20 @@ from typing import Optional
 
 # ── Configuration ──────────────────────────────────────────────────────────────
 
+def env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name, "")
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        print(f"  [warn] Invalid {name}={raw!r}; using {default}", file=sys.stderr)
+        return default
+
+
 API_URL  = os.environ.get("SAFE_API_URL", "https://core42.primus-safe.amd.com")
 SAFE_TOKEN  = os.environ.get("SAFE_API_KEY", "")
+SAFE_API_TIMEOUT_SECONDS = env_int("SAFE_API_TIMEOUT_SECONDS", 240)
 PROXY    = "harbor.core42.primus-safe.amd.com/proxy"
 WORKSPACE      = "core42-hyperloom"
 WEKAFS_VOLUME  = "/wekafs"
@@ -240,7 +252,7 @@ def auto_detect(repo_id: str, hf_token: str = "") -> dict:
 
 # ── SaFE API helpers ────────────────────────────────────────────────────────────
 
-def safe_request(method: str, path: str, body: dict = None) -> dict:
+def safe_request(method: str, path: str, body: dict = None, timeout: int = SAFE_API_TIMEOUT_SECONDS) -> dict:
     if not SAFE_TOKEN:
         raise RuntimeError("SAFE_API_KEY not set")
     url = f"{API_URL}/{path.lstrip('/')}"
@@ -252,7 +264,7 @@ def safe_request(method: str, path: str, body: dict = None) -> dict:
         method=method,
     )
     try:
-        with urllib.request.urlopen(req, context=_ssl_ctx, timeout=30) as r:
+        with urllib.request.urlopen(req, context=_ssl_ctx, timeout=timeout) as r:
             return json.load(r)
     except urllib.error.HTTPError as e:
         raise RuntimeError(f"HTTP {e.code}: {e.read().decode()}")
@@ -400,6 +412,8 @@ def process_model(repo_id: str, args) -> bool:
 
 
 def main():
+    global SAFE_TOKEN, WORKSPACE, WEKAFS_VOLUME
+
     parser = argparse.ArgumentParser(
         description="Submit SaFE inference optimization tasks",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -443,7 +457,6 @@ def main():
     args = parser.parse_args()
 
     # Apply overrides
-    global SAFE_TOKEN, WORKSPACE, WEKAFS_VOLUME
     if args.api_key:
         SAFE_TOKEN = args.api_key
     WORKSPACE     = args.workspace


### PR DESCRIPTION
## Summary

- Retry optimization Claw create-and-dispatch calls on transient failures such as HTTP 499/client_closed_request, 429, 5xx, connection resets, EOF, and timeouts.
- Keep each create attempt capped at 30s, retry every 5s, and stop after a 3 minute total budget; non-retryable business failures such as `dispatched:false` remain single-shot to avoid duplicate sessions.
- Extend `scripts/optimize_submit.py` SaFE API timeout from 30s to 240s, with `SAFE_API_TIMEOUT_SECONDS` as an override, so CI submitters do not close the request while SaFE is retrying.

## Test plan

- [x] `python -m py_compile scripts/optimize_submit.py`
- [x] `go test ./apiserver/pkg/handlers/optimization/...`
- [x] `go build ./apiserver/pkg/handlers/optimization/...`
- [x] `git diff --check`