### PR TITLE
fix(sso): route pulse callbacks through bridge state

### DIFF
--- a/Web/apps/safe/src/router/guards/auth.ts
+++ b/Web/apps/safe/src/router/guards/auth.ts
@@ -33,9 +33,9 @@ export default function setupAuthGuard(router: Router) {
     if (code) {
       const state = to.query.state as string | undefined
 
-      // Check if this is an SSO request from another app (Lens / Hyperloom)
+      // Check if this is an SSO request from another app (Lens / Hyperloom / Pulse)
       // State format: {app}:{csrfToken}:{encodeURIComponent(bridgeUrl)}
-      const APP_PREFIXES = ['lens:', 'hyperloom:'] as const
+      const APP_PREFIXES = ['lens:', 'hyperloom:', 'pulse:'] as const
       const matchedPrefix = APP_PREFIXES.find((p) => state?.startsWith(p))
       if (matchedPrefix && state) {
         const parts = state.split(':')


### PR DESCRIPTION
Recognize Pulse wrapped SSO state so Safe can forward Okta callback codes back to the Pulse bridge endpoint.