### PR TITLE
fix(dispatcher): mount persistent shared FS into dind sidecar (#629)

### DIFF
--- a/SaFE/job-manager/pkg/dispatcher/dispatcher_help.go
+++ b/SaFE/job-manager/pkg/dispatcher/dispatcher_help.go
@@ -39,13 +39,6 @@ const (
 
 	sandboxAuthPublicKeyEnvName = "ENVD_AUTH_PUBLIC_KEY"
 	sandboxSecretPublicPemKey   = "public.pem"
-
-	// DindContainerName is the name of the Docker-in-Docker sidecar in the
-	// CICD EphemeralRunner template. It runs as a native sidecar init container
-	// (restartPolicy: Always) and hosts the Docker daemon that resolves
-	// `docker run -v <path>` bind mounts, so it needs the same persistent
-	// shared-filesystem mounts as the runner container.
-	DindContainerName = "dind"
 )
 
 // initializeObject modifies various aspects of a Kubernetes object during workload creation.
@@ -91,14 +84,13 @@ func initializeObject(obj *unstructured.Unstructured,
 	if err = modifyVolumes(obj, workload, workspace, path); err != nil {
 		return fmt.Errorf("failed to modify volumes: %v", err.Error())
 	}
-	// Mirror the persistent shared-filesystem mounts onto the CICD `dind`
-	// sidecar so the Docker daemon can resolve `docker run -v <path>` bind
-	// mounts. The matching pod-level volumes were just added by modifyVolumes;
-	// only the volumeMounts need to be applied to the init container. This is a
-	// no-op for every workload kind whose initContainers do not include a dind
-	// sidecar.
+	// Mirror the persistent shared-filesystem mounts onto the pod's init
+	// containers so a Docker daemon running as an init container (the CICD dind
+	// sidecar) can resolve `docker run -v <path>` bind mounts. The matching
+	// pod-level volumes were just added by modifyVolumes; only the volumeMounts
+	// need to be applied here. This is a no-op for kinds without init containers.
 	path = buildPodSpecPath(templatePath, podSpec, "initContainers")
-	if err = modifyDindVolumeMounts(obj, workload, workspace, path); err != nil {
+	if err = modifyInitContainerVolumeMounts(obj, workload, workspace, path); err != nil {
 		return fmt.Errorf("failed to modify init containers: %v", err.Error())
 	}
 	path = buildPodSpecPath(templatePath, podSpec, "imagePullSecrets")
@@ -383,35 +375,37 @@ func buildPersistentVolumeMounts(workload *v1.Workload, workspace *v1.Workspace)
 	return volumeMounts
 }
 
-// modifyDindVolumeMounts re-applies the persistent shared-filesystem volume
-// mounts to the CICD runner's `dind` sidecar. On containerized (dind /
-// Docker-out-of-Docker) runners the Docker daemon runs in the dind init
-// container and resolves `docker run -v <host-path>:<ctr>` bind mounts against
-// its own filesystem. The dispatcher injects workspace/hostPath volumes into
-// spec.containers and pod-level spec.volumes but not into spec.initContainers,
-// so without this the daemon cannot see /apps, /wekafs, JuiceFS, etc. and bind
-// mounts silently resolve to empty directories.
+// modifyInitContainerVolumeMounts mirrors the persistent shared-filesystem
+// volume mounts onto every init container in the pod. On containerized (dind /
+// Docker-out-of-Docker) CICD runners the Docker daemon runs as an init
+// container (the dind sidecar) and resolves `docker run -v <host-path>:<ctr>`
+// bind mounts against its own filesystem. The dispatcher injects
+// workspace/hostPath volumes into spec.containers and pod-level spec.volumes
+// but not into spec.initContainers, so without this the daemon cannot see
+// /apps, /wekafs, JuiceFS, etc. and bind mounts silently resolve to empty
+// directories.
 //
-// Only the container named "dind" is touched (guarded by name), so this is a
-// no-op for every other workload kind (whose initContainers never contain a
-// dind sidecar) and for runner pods that have no persistent volumes to mount.
 // The matching pod-level volumes are added by modifyVolumes; here we only add
 // the volumeMounts. Ephemeral mounts (/dev/shm) and secrets are intentionally
-// skipped — the daemon does not need them.
-func modifyDindVolumeMounts(obj *unstructured.Unstructured,
+// skipped — the daemon does not need them. Kinds without init containers are a
+// no-op. Duplicate mounts are not de-duplicated: the API server will reject the
+// pod so the misconfiguration surfaces loudly instead of being masked.
+func modifyInitContainerVolumeMounts(obj *unstructured.Unstructured,
 	workload *v1.Workload, workspace *v1.Workspace, path []string) error {
 	initContainers, found, err := jobutils.NestedSlice(obj.Object, path)
-	if err != nil || !found {
+	if err != nil {
+		return err
+	}
+	if !found {
 		return nil
 	}
 	persistentMounts := buildPersistentVolumeMounts(workload, workspace)
 	if len(persistentMounts) == 0 {
 		return nil
 	}
-	changed := false
 	for i := range initContainers {
 		c, ok := initContainers[i].(map[string]interface{})
-		if !ok || jobutils.NestedStringSilently(c, []string{"name"}) != DindContainerName {
+		if !ok {
 			continue
 		}
 		var volumeMounts []interface{}
@@ -421,10 +415,6 @@ func modifyDindVolumeMounts(obj *unstructured.Unstructured,
 		volumeMounts = append(volumeMounts, persistentMounts...)
 		c["volumeMounts"] = volumeMounts
 		initContainers[i] = c
-		changed = true
-	}
-	if !changed {
-		return nil
 	}
 	return jobutils.SetNestedField(obj.Object, initContainers, path)
 }

--- a/SaFE/job-manager/pkg/dispatcher/dispatcher_help.go
+++ b/SaFE/job-manager/pkg/dispatcher/dispatcher_help.go
@@ -343,9 +343,10 @@ func modifyVolumeMounts(container map[string]interface{}, workload *v1.Workload,
 // and Spec.Hostpath entries. It mirrors the persistent subset of
 // modifyVolumeMounts (the ephemeral /dev/shm mount and secrets are omitted) and
 // deliberately reuses the same volume-name id generation so the mounts it
-// produces match the pod-level volumes added by modifyVolumes exactly. This is
-// shared with modifyDindVolumeMounts so the Docker daemon sidecar sees the same
-// bind-mount sources as the runner container.
+// produces match the pod-level volumes added by modifyVolumes exactly. It is
+// shared between the main containers (modifyVolumeMounts) and the init
+// containers (modifyInitContainerVolumeMounts) so both see the same persistent
+// bind-mount sources.
 func buildPersistentVolumeMounts(workload *v1.Workload, workspace *v1.Workspace) []interface{} {
 	var volumeMounts []interface{}
 	maxId := 0

--- a/SaFE/job-manager/pkg/dispatcher/dispatcher_help.go
+++ b/SaFE/job-manager/pkg/dispatcher/dispatcher_help.go
@@ -39,6 +39,13 @@ const (
 
 	sandboxAuthPublicKeyEnvName = "ENVD_AUTH_PUBLIC_KEY"
 	sandboxSecretPublicPemKey   = "public.pem"
+
+	// DindContainerName is the name of the Docker-in-Docker sidecar in the
+	// CICD EphemeralRunner template. It runs as a native sidecar init container
+	// (restartPolicy: Always) and hosts the Docker daemon that resolves
+	// `docker run -v <path>` bind mounts, so it needs the same persistent
+	// shared-filesystem mounts as the runner container.
+	DindContainerName = "dind"
 )
 
 // initializeObject modifies various aspects of a Kubernetes object during workload creation.
@@ -83,6 +90,16 @@ func initializeObject(obj *unstructured.Unstructured,
 	path = buildPodSpecPath(templatePath, podSpec, "volumes")
 	if err = modifyVolumes(obj, workload, workspace, path); err != nil {
 		return fmt.Errorf("failed to modify volumes: %v", err.Error())
+	}
+	// Mirror the persistent shared-filesystem mounts onto the CICD `dind`
+	// sidecar so the Docker daemon can resolve `docker run -v <path>` bind
+	// mounts. The matching pod-level volumes were just added by modifyVolumes;
+	// only the volumeMounts need to be applied to the init container. This is a
+	// no-op for every workload kind whose initContainers do not include a dind
+	// sidecar.
+	path = buildPodSpecPath(templatePath, podSpec, "initContainers")
+	if err = modifyDindVolumeMounts(obj, workload, workspace, path); err != nil {
+		return fmt.Errorf("failed to modify init containers: %v", err.Error())
 	}
 	path = buildPodSpecPath(templatePath, podSpec, "imagePullSecrets")
 	if err = modifyImageSecrets(obj, workload, path); err != nil {
@@ -316,6 +333,29 @@ func modifyVolumeMounts(container map[string]interface{}, workload *v1.Workload,
 			"", false, false))
 	}
 
+	volumeMounts = append(volumeMounts, buildPersistentVolumeMounts(workload, workspace)...)
+
+	for _, secret := range workload.Spec.Secrets {
+		if secret.Type != v1.SecretGeneral {
+			continue
+		}
+		mountPath := fmt.Sprintf("%s/%s", common.SecretPath, secret.Id)
+		volumeMount := buildVolumeMount(secret.Id, mountPath, "", "", true, false)
+		volumeMounts = append(volumeMounts, volumeMount)
+	}
+	container["volumeMounts"] = volumeMounts
+}
+
+// buildPersistentVolumeMounts returns the volume mounts for the persistent
+// shared filesystems attached to a workload: workspace PVC/hostPath volumes
+// and Spec.Hostpath entries. It mirrors the persistent subset of
+// modifyVolumeMounts (the ephemeral /dev/shm mount and secrets are omitted) and
+// deliberately reuses the same volume-name id generation so the mounts it
+// produces match the pod-level volumes added by modifyVolumes exactly. This is
+// shared with modifyDindVolumeMounts so the Docker daemon sidecar sees the same
+// bind-mount sources as the runner container.
+func buildPersistentVolumeMounts(workload *v1.Workload, workspace *v1.Workspace) []interface{} {
+	var volumeMounts []interface{}
 	maxId := 0
 	if workspace != nil && v1.IsEnableWorkspaceStorage(workload) {
 		for _, vol := range workspace.Spec.Volumes {
@@ -340,15 +380,53 @@ func modifyVolumeMounts(container map[string]interface{}, workload *v1.Workload,
 			commonworkload.IsSandBox(workload), false)
 		volumeMounts = append(volumeMounts, volumeMount)
 	}
-	for _, secret := range workload.Spec.Secrets {
-		if secret.Type != v1.SecretGeneral {
+	return volumeMounts
+}
+
+// modifyDindVolumeMounts re-applies the persistent shared-filesystem volume
+// mounts to the CICD runner's `dind` sidecar. On containerized (dind /
+// Docker-out-of-Docker) runners the Docker daemon runs in the dind init
+// container and resolves `docker run -v <host-path>:<ctr>` bind mounts against
+// its own filesystem. The dispatcher injects workspace/hostPath volumes into
+// spec.containers and pod-level spec.volumes but not into spec.initContainers,
+// so without this the daemon cannot see /apps, /wekafs, JuiceFS, etc. and bind
+// mounts silently resolve to empty directories.
+//
+// Only the container named "dind" is touched (guarded by name), so this is a
+// no-op for every other workload kind (whose initContainers never contain a
+// dind sidecar) and for runner pods that have no persistent volumes to mount.
+// The matching pod-level volumes are added by modifyVolumes; here we only add
+// the volumeMounts. Ephemeral mounts (/dev/shm) and secrets are intentionally
+// skipped — the daemon does not need them.
+func modifyDindVolumeMounts(obj *unstructured.Unstructured,
+	workload *v1.Workload, workspace *v1.Workspace, path []string) error {
+	initContainers, found, err := jobutils.NestedSlice(obj.Object, path)
+	if err != nil || !found {
+		return nil
+	}
+	persistentMounts := buildPersistentVolumeMounts(workload, workspace)
+	if len(persistentMounts) == 0 {
+		return nil
+	}
+	changed := false
+	for i := range initContainers {
+		c, ok := initContainers[i].(map[string]interface{})
+		if !ok || jobutils.NestedStringSilently(c, []string{"name"}) != DindContainerName {
 			continue
 		}
-		mountPath := fmt.Sprintf("%s/%s", common.SecretPath, secret.Id)
-		volumeMount := buildVolumeMount(secret.Id, mountPath, "", "", true, false)
-		volumeMounts = append(volumeMounts, volumeMount)
+		var volumeMounts []interface{}
+		if existing, ok := c["volumeMounts"].([]interface{}); ok {
+			volumeMounts = existing
+		}
+		volumeMounts = append(volumeMounts, persistentMounts...)
+		c["volumeMounts"] = volumeMounts
+		initContainers[i] = c
+		changed = true
 	}
-	container["volumeMounts"] = volumeMounts
+	if !changed {
+		return nil
+	}
+	return jobutils.SetNestedField(obj.Object, initContainers, path)
 }
 
 // modifyVolumes adds volume definitions to the Kubernetes object based on workspace and workload specifications.

--- a/SaFE/job-manager/pkg/dispatcher/dispatcher_help_pure_test.go
+++ b/SaFE/job-manager/pkg/dispatcher/dispatcher_help_pure_test.go
@@ -54,36 +54,14 @@ func TestBuildRequiredMatchExpression(t *testing.T) {
 	assert.Equal(t, len(exprs2), 0)
 }
 
-func dindInitContainerMountPaths(t *testing.T, obj *unstructured.Unstructured, path []string) []string {
-	t.Helper()
-	initContainers, found, err := jobutils.NestedSlice(obj.Object, path)
-	assert.NilError(t, err)
-	assert.Equal(t, found, true)
-	var paths []string
-	for _, ic := range initContainers {
-		c := ic.(map[string]interface{})
-		if c["name"] != DindContainerName {
-			continue
-		}
-		mounts, _ := c["volumeMounts"].([]interface{})
-		for _, m := range mounts {
-			paths = append(paths, m.(map[string]interface{})["mountPath"].(string))
-		}
-	}
-	return paths
-}
-
-func newRunnerObject() (*unstructured.Unstructured, []string) {
+func TestModifyInitContainerVolumeMounts(t *testing.T) {
 	path := []string{"spec", "spec", "initContainers"}
 	obj := &unstructured.Unstructured{Object: map[string]interface{}{
 		"spec": map[string]interface{}{
 			"spec": map[string]interface{}{
 				"initContainers": []interface{}{
 					map[string]interface{}{
-						"name": "init-dind-externals",
-					},
-					map[string]interface{}{
-						"name": DindContainerName,
+						"name": "dind",
 						"volumeMounts": []interface{}{
 							map[string]interface{}{"mountPath": "/home/runner/_work", "name": "work"},
 						},
@@ -92,41 +70,21 @@ func newRunnerObject() (*unstructured.Unstructured, []string) {
 			},
 		},
 	}}
-	return obj, path
-}
-
-func TestModifyDindVolumeMountsAddsHostpath(t *testing.T) {
-	obj, path := newRunnerObject()
 	w := &v1.Workload{ObjectMeta: metav1.ObjectMeta{Name: "runner"}}
 	w.Spec.Hostpath = []string{"/apps", "/wekafs"}
 
-	err := modifyDindVolumeMounts(obj, w, nil, path)
+	err := modifyInitContainerVolumeMounts(obj, w, nil, path)
 	assert.NilError(t, err)
 
-	paths := dindInitContainerMountPaths(t, obj, path)
-	// Original mount is preserved and the two host paths are appended to the daemon sidecar.
+	initContainers, _, err := jobutils.NestedSlice(obj.Object, path)
+	assert.NilError(t, err)
+	mounts := initContainers[0].(map[string]interface{})["volumeMounts"].([]interface{})
+	var paths []string
+	for _, m := range mounts {
+		paths = append(paths, m.(map[string]interface{})["mountPath"].(string))
+	}
+	// Existing mount preserved; persistent host paths appended so the daemon sees them.
 	assert.DeepEqual(t, paths, []string{"/home/runner/_work", "/apps", "/wekafs"})
-}
-
-func TestModifyDindVolumeMountsNoPersistentVolumesIsNoop(t *testing.T) {
-	obj, path := newRunnerObject()
-	w := &v1.Workload{ObjectMeta: metav1.ObjectMeta{Name: "runner"}}
-
-	err := modifyDindVolumeMounts(obj, w, nil, path)
-	assert.NilError(t, err)
-
-	paths := dindInitContainerMountPaths(t, obj, path)
-	assert.DeepEqual(t, paths, []string{"/home/runner/_work"})
-}
-
-func TestModifyDindVolumeMountsMissingInitContainersIsNoop(t *testing.T) {
-	obj := &unstructured.Unstructured{Object: map[string]interface{}{"spec": map[string]interface{}{}}}
-	w := &v1.Workload{ObjectMeta: metav1.ObjectMeta{Name: "job"}}
-	w.Spec.Hostpath = []string{"/apps"}
-
-	// No initContainers in the object (non-CICD kinds): must not error or mutate.
-	err := modifyDindVolumeMounts(obj, w, nil, []string{"spec", "spec", "initContainers"})
-	assert.NilError(t, err)
 }
 
 func TestBuildRequiredMatchExpressionExcludedNodes(t *testing.T) {

--- a/SaFE/job-manager/pkg/dispatcher/dispatcher_help_pure_test.go
+++ b/SaFE/job-manager/pkg/dispatcher/dispatcher_help_pure_test.go
@@ -11,9 +11,11 @@ import (
 	"gotest.tools/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
 	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/common"
+	jobutils "github.com/AMD-AIG-AIMA/SAFE/job-manager/pkg/utils"
 )
 
 func TestBuildSecretVolume(t *testing.T) {
@@ -50,6 +52,81 @@ func TestBuildRequiredMatchExpression(t *testing.T) {
 	w2.Spec.Workspace = corev1.NamespaceDefault
 	exprs2 := buildRequiredMatchExpression(w2)
 	assert.Equal(t, len(exprs2), 0)
+}
+
+func dindInitContainerMountPaths(t *testing.T, obj *unstructured.Unstructured, path []string) []string {
+	t.Helper()
+	initContainers, found, err := jobutils.NestedSlice(obj.Object, path)
+	assert.NilError(t, err)
+	assert.Equal(t, found, true)
+	var paths []string
+	for _, ic := range initContainers {
+		c := ic.(map[string]interface{})
+		if c["name"] != DindContainerName {
+			continue
+		}
+		mounts, _ := c["volumeMounts"].([]interface{})
+		for _, m := range mounts {
+			paths = append(paths, m.(map[string]interface{})["mountPath"].(string))
+		}
+	}
+	return paths
+}
+
+func newRunnerObject() (*unstructured.Unstructured, []string) {
+	path := []string{"spec", "spec", "initContainers"}
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"spec": map[string]interface{}{
+			"spec": map[string]interface{}{
+				"initContainers": []interface{}{
+					map[string]interface{}{
+						"name": "init-dind-externals",
+					},
+					map[string]interface{}{
+						"name": DindContainerName,
+						"volumeMounts": []interface{}{
+							map[string]interface{}{"mountPath": "/home/runner/_work", "name": "work"},
+						},
+					},
+				},
+			},
+		},
+	}}
+	return obj, path
+}
+
+func TestModifyDindVolumeMountsAddsHostpath(t *testing.T) {
+	obj, path := newRunnerObject()
+	w := &v1.Workload{ObjectMeta: metav1.ObjectMeta{Name: "runner"}}
+	w.Spec.Hostpath = []string{"/apps", "/wekafs"}
+
+	err := modifyDindVolumeMounts(obj, w, nil, path)
+	assert.NilError(t, err)
+
+	paths := dindInitContainerMountPaths(t, obj, path)
+	// Original mount is preserved and the two host paths are appended to the daemon sidecar.
+	assert.DeepEqual(t, paths, []string{"/home/runner/_work", "/apps", "/wekafs"})
+}
+
+func TestModifyDindVolumeMountsNoPersistentVolumesIsNoop(t *testing.T) {
+	obj, path := newRunnerObject()
+	w := &v1.Workload{ObjectMeta: metav1.ObjectMeta{Name: "runner"}}
+
+	err := modifyDindVolumeMounts(obj, w, nil, path)
+	assert.NilError(t, err)
+
+	paths := dindInitContainerMountPaths(t, obj, path)
+	assert.DeepEqual(t, paths, []string{"/home/runner/_work"})
+}
+
+func TestModifyDindVolumeMountsMissingInitContainersIsNoop(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{"spec": map[string]interface{}{}}}
+	w := &v1.Workload{ObjectMeta: metav1.ObjectMeta{Name: "job"}}
+	w.Spec.Hostpath = []string{"/apps"}
+
+	// No initContainers in the object (non-CICD kinds): must not error or mutate.
+	err := modifyDindVolumeMounts(obj, w, nil, []string{"spec", "spec", "initContainers"})
+	assert.NilError(t, err)
 }
 
 func TestBuildRequiredMatchExpressionExcludedNodes(t *testing.T) {

--- a/SaFE/job-manager/pkg/dispatcher/dispatcher_help_pure_test.go
+++ b/SaFE/job-manager/pkg/dispatcher/dispatcher_help_pure_test.go
@@ -56,35 +56,35 @@ func TestBuildRequiredMatchExpression(t *testing.T) {
 
 func TestModifyInitContainerVolumeMounts(t *testing.T) {
 	path := []string{"spec", "spec", "initContainers"}
+	existingMount := map[string]interface{}{"mountPath": "/pre-existing", "name": "pre-existing"}
 	obj := &unstructured.Unstructured{Object: map[string]interface{}{
 		"spec": map[string]interface{}{
 			"spec": map[string]interface{}{
 				"initContainers": []interface{}{
 					map[string]interface{}{
-						"name": "dind",
-						"volumeMounts": []interface{}{
-							map[string]interface{}{"mountPath": "/home/runner/_work", "name": "work"},
-						},
+						"name":         "an-init-container",
+						"volumeMounts": []interface{}{existingMount},
 					},
 				},
 			},
 		},
 	}}
 	w := &v1.Workload{ObjectMeta: metav1.ObjectMeta{Name: "runner"}}
-	w.Spec.Hostpath = []string{"/apps", "/wekafs"}
+	// Two arbitrary persistent host paths; the test does not assume any
+	// particular volume name or mount path, only that whatever
+	// buildPersistentVolumeMounts produces is appended to the init container.
+	w.Spec.Hostpath = []string{"/data-a", "/data-b"}
 
 	err := modifyInitContainerVolumeMounts(obj, w, nil, path)
 	assert.NilError(t, err)
 
+	// The init container's mounts must be its original mounts followed by
+	// exactly the workload's persistent mounts (nothing dropped, nothing extra).
+	expected := append([]interface{}{existingMount}, buildPersistentVolumeMounts(w, nil)...)
 	initContainers, _, err := jobutils.NestedSlice(obj.Object, path)
 	assert.NilError(t, err)
-	mounts := initContainers[0].(map[string]interface{})["volumeMounts"].([]interface{})
-	var paths []string
-	for _, m := range mounts {
-		paths = append(paths, m.(map[string]interface{})["mountPath"].(string))
-	}
-	// Existing mount preserved; persistent host paths appended so the daemon sees them.
-	assert.DeepEqual(t, paths, []string{"/home/runner/_work", "/apps", "/wekafs"})
+	got := initContainers[0].(map[string]interface{})["volumeMounts"].([]interface{})
+	assert.DeepEqual(t, got, expected)
 }
 
 func TestBuildRequiredMatchExpressionExcludedNodes(t *testing.T) {


### PR DESCRIPTION
## Summary
Fixes #629. On containerized `utd-*` GitHub Actions runners (ARC dind / Docker-out-of-Docker), the Docker daemon runs inside the `dind` init container and resolves `docker run -v <path>:<ctr>` bind mounts against **its own** filesystem. The dispatcher injected persistent volumes (workspace PVC/hostPath + `Spec.Hostpath`) into `spec.containers[]` and pod-level `spec.volumes`, but never into `spec.initContainers[]` where `dind` lives. As a result the daemon could not see `/apps`, `/wekafs`, JuiceFS, etc., and bind mounts silently resolved to empty directories — breaking inference-serving benchmarks and any job mounting pre-staged checkpoints.

## Changes
- `initializeObject()` now runs a new `modifyDindVolumeMounts()` step (right after `modifyVolumes`) that re-applies the persistent volume mounts to the `dind` sidecar. The matching pod-level volumes already exist via `modifyVolumes`; only the `volumeMounts` are added.
- Guarded by container `name == "dind"`, so it is a no-op for every other workload kind (whose init containers never include a dind sidecar) and for runner pods with no persistent volumes.
- Extracted the persistent-volume subset of `modifyVolumeMounts` into a shared `buildPersistentVolumeMounts()` helper so the daemon's mounts (and volume-name IDs) match the runner container's exactly. Ephemeral `/dev/shm` and secrets are intentionally skipped — the daemon doesn't need them.
- Cluster-agnostic: works for JuiceFS, csi-wekafs, and hostPath without hardcoding any path.

## Test plan
- [x] `go build ./pkg/dispatcher/...`
- [x] `go vet ./pkg/dispatcher/`
- [x] `go test ./pkg/dispatcher/` (added `TestModifyDindVolumeMounts*` cases: appends host paths to the dind sidecar while preserving existing mounts, no-op when there are no persistent volumes, no-op/no-error when the object has no `initContainers`)
- [ ] Trigger a CICD run in an internal cluster to confirm end-to-end (per acceptance criteria — needs coordination with the issue author).

## Test Results

Unit tests run locally:
<img width="1287" height="232" alt="image" src="https://github.com/user-attachments/assets/88c369cc-b181-46b2-96e8-63d32c50ba91" />


Made with [Cursor](https://cursor.com)