### PR TITLE
docs: document 501 addon installation node taint

### DIFF
--- a/SaFE/node-agent/pkg/monitors/scripts/README.md
+++ b/SaFE/node-agent/pkg/monitors/scripts/README.md
@@ -34,25 +34,8 @@ Currently the following monitors are supported:
 |           | Monitor PCIe error | 308 |
 |           | Monitor Wekafs CSI status * | 309 |
 |File System| Check NFS mount  | 401 |
-|System reserved| Addon installation or runtime failure * | 501 |
+|Platform   | Addon installation or runtime failure | 501 |
 
 
 
 *Kubernetes only
-
-## 501 — Addon installation or runtime failure
-
-Applied while addons are installed/updated on a node (taint key `primus-safe.501`); cleared automatically once the addon job succeeds. "Addons Installed" shows `false` while it is set.
-
-**Common symptom:** on a re-imaged node, addon DaemonSets stay in `ImagePullBackOff` with image-pull errors referencing a registry/DNS failure (the node can't resolve the Harbor hostname).
-
-**Remediation:**
-
-- Hotfix — add a static registry entry on the affected node to bypass the broken resolver, then verify:
-
-```bash
-echo "<ingress-vip> harbor.<cluster-domain>" | sudo tee -a /etc/hosts
-getent hosts harbor.<cluster-domain>
-```
-
-- Long-term — make re-imaged nodes use NodeLocal DNS (`nodelocaldns`) instead of the `systemd-resolved` stub: point `/etc/resolv.conf` at the node-local resolver and have onboard/bootstrap reapply the NodeLocal DNS plumbing. Ideally the onboard automation adds the hosts entry idempotently as a safety net.

--- a/SaFE/node-agent/pkg/monitors/scripts/README.md
+++ b/SaFE/node-agent/pkg/monitors/scripts/README.md
@@ -34,7 +34,25 @@ Currently the following monitors are supported:
 |           | Monitor PCIe error | 308 |
 |           | Monitor Wekafs CSI status * | 309 |
 |File System| Check NFS mount  | 401 |
+|System reserved| Addon installation or runtime failure * | 501 |
 
 
 
 *Kubernetes only
+
+## 501 — Addon installation or runtime failure
+
+Applied while addons are installed/updated on a node (taint key `primus-safe.501`); cleared automatically once the addon job succeeds. "Addons Installed" shows `false` while it is set.
+
+**Common symptom:** on a re-imaged node, addon DaemonSets stay in `ImagePullBackOff` with image-pull errors referencing a registry/DNS failure (the node can't resolve the Harbor hostname).
+
+**Remediation:**
+
+- Hotfix — add a static registry entry on the affected node to bypass the broken resolver, then verify:
+
+```bash
+echo "<ingress-vip> harbor.<cluster-domain>" | sudo tee -a /etc/hosts
+getent hosts harbor.<cluster-domain>
+```
+
+- Long-term — make re-imaged nodes use NodeLocal DNS (`nodelocaldns`) instead of the `systemd-resolved` stub: point `/etc/resolv.conf` at the node-local resolver and have onboard/bootstrap reapply the NodeLocal DNS plumbing. Ideally the onboard automation adds the hosts entry idempotently as a safety net.

--- a/SaFE/node-agent/pkg/monitors/scripts/README.md
+++ b/SaFE/node-agent/pkg/monitors/scripts/README.md
@@ -34,7 +34,7 @@ Currently the following monitors are supported:
 |           | Monitor PCIe error | 308 |
 |           | Monitor Wekafs CSI status * | 309 |
 |File System| Check NFS mount  | 401 |
-|Platform   | Addon installation or runtime failure | 501 |
+|Platform   | Addon installation error | 501 |
 
 
 


### PR DESCRIPTION
## Summary

Closes #607.

Adds a concise entry to the node-agent monitor docs (`SaFE/node-agent/pkg/monitors/scripts/README.md`) for the new `primus-safe.501` node taint, matching the brevity of the existing error-code documentation:

- Adds `501` to the supported-monitors table under a new **System reserved** category.
- Documents purpose (applied during addon install/update; auto-cleared on success) and the "Addons Installed = false" indicator.
- Describes the common symptom operators hit on re-imaged nodes: addon DaemonSets stuck in `ImagePullBackOff` due to registry/DNS resolution failure.
- Gives brief remediation: `/etc/hosts` hotfix + `getent` verification, plus the long-term NodeLocal DNS fix.
- Private IPs are redacted with placeholders (`<ingress-vip>`, `harbor.<cluster-domain>`) per the issue's request.

## Test plan

- [x] Confirm the README table renders correctly and the 501 section reads clearly.

Made with [Cursor](https://cursor.com)