### PR TITLE
fix(apiserver): return preferredName (NTID source) from verify endpoint

### DIFF
--- a/SaFE/apiserver/pkg/handlers/authority/verify_handler.go
+++ b/SaFE/apiserver/pkg/handlers/authority/verify_handler.go
@@ -40,15 +40,18 @@ type VerifyTokenRequest struct {
 
 // VerifyTokenResponse represents the response body for token verification
 type VerifyTokenResponse struct {
-	Id          string        `json:"id"`
-	Name        string        `json:"name"`
-	Email       string        `json:"email,omitempty"`
-	Exp         int64         `json:"exp"`
-	Type        string        `json:"type"`
-	Roles       []v1.UserRole `json:"roles"`
-	ApiKeyId    int64         `json:"apiKeyId,omitempty"`
-	PlatformKey string        `json:"platformKey,omitempty"`
-	VirtualKey  string        `json:"virtualKey,omitempty"`
+	Id    string `json:"id"`
+	Name  string `json:"name"`
+	Email string `json:"email,omitempty"`
+	// PreferredName is the SSO preferred username (e.g. "chaojhou@amd.com").
+	// Downstream services derive the AMD NTID from it for LLM-gateway requests.
+	PreferredName string        `json:"preferredName,omitempty"`
+	Exp           int64         `json:"exp"`
+	Type          string        `json:"type"`
+	Roles         []v1.UserRole `json:"roles"`
+	ApiKeyId      int64         `json:"apiKeyId,omitempty"`
+	PlatformKey   string        `json:"platformKey,omitempty"`
+	VirtualKey    string        `json:"virtualKey,omitempty"`
 }
 
 // VerifyToken validates a user token and returns user information
@@ -174,13 +177,24 @@ func VerifyToken(c *gin.Context) {
 	}
 
 	resp := VerifyTokenResponse{
-		Id:       userInfo.Id,
-		Name:     userInfo.Name,
-		Email:    userInfo.Email,
-		Exp:      userInfo.Exp,
-		Type:     userType,
-		ApiKeyId: userInfo.ApiKeyId,
-		Roles:    userInfo.Roles,
+		Id:            userInfo.Id,
+		Name:          userInfo.Name,
+		Email:         userInfo.Email,
+		PreferredName: userInfo.PreferredUsername,
+		Exp:           userInfo.Exp,
+		Type:          userType,
+		ApiKeyId:      userInfo.ApiKeyId,
+		Roles:         userInfo.Roles,
+	}
+
+	// Backfill preferred name (NTID source) from the User CR when the auth path
+	// (e.g. API key) didn't carry it. Mirrors the email backfill below.
+	if resp.PreferredName == "" {
+		if tokenInst := DefaultTokenInstance(); tokenInst != nil {
+			if user, err := getUserById(c.Request.Context(), tokenInst, userInfo.Id); err == nil {
+				resp.PreferredName = v1.GetAnnotation(user, v1.UserPreferredNameAnnotation)
+			}
+		}
 	}
 
 	// Optionally include platform API key (GetOrCreate)


### PR DESCRIPTION
## Problem
The LLM gateway requires a `user` header carrying the caller's AMD NTID. Downstream services (Primus-Claw Brain) can derive that NTID from the SSO preferred username, but the token verify response never exposed it, so gateway calls failed with HTTP 400 `Missing required header: user`.

## Fix
- Add `preferredName` to `VerifyTokenResponse`, populated from `userInfo.PreferredUsername`.
- When the auth path (e.g. API key) doesn't carry it, backfill from the User CR's preferred-name annotation (`v1.UserPreferredNameAnnotation`), mirroring the existing email backfill in the same handler.

## Consumer
Primus-Claw reads `preferredName`, takes its local-part as the NTID, and sends it as the gateway `user` header (companion PR: AMD-AGI/Primus-Claw#169).

## Notes
Built and deployed to the cluster (`primussafe/apiserver:202607051134`); apiserver rolled out healthy.

## Test plan
- [ ] Call the verify endpoint (SSO token and API-key token) and confirm `preferredName` is present.
- [ ] Confirm downstream gateway calls succeed with the `user` header.

Made with [Cursor](https://cursor.com)