### PR TITLE
fix(web): guard System admin pages with a system-admin route meta

### DIFF
--- a/Web/apps/safe/src/router/guards/clusterReady.ts
+++ b/Web/apps/safe/src/router/guards/clusterReady.ts
@@ -45,6 +45,13 @@ export default function setupClusterGuard(router: Router) {
         return next('/')
       }
 
+      // Permission check (system-admin only pages)
+      // These System pages are hidden from the nav for non-admins; also block
+      // direct URL navigation so access control is not merely client-side.
+      if (to.meta?.requiresSystemAdmin && !userStore.hasManagerAccess) {
+        return next('/')
+      }
+
       // Permission check (workspace-admin)
       if (to.meta?.requiresWorkspaceAdmin) {
         if (!wsStore.isCurrentWorkspaceAdmin() && !userStore.hasManagerAccess) {

--- a/Web/apps/safe/src/router/index.ts
+++ b/Web/apps/safe/src/router/index.ts
@@ -56,6 +56,7 @@ const router = createRouter({
           path: '/clusters',
           name: 'Clusters',
           component: () => import('../pages/Clusters/index.vue'),
+          meta: { requiresSystemAdmin: true },
         },
         {
           path: '/cluster/detail',
@@ -195,6 +196,7 @@ const router = createRouter({
           path: '/preflight',
           name: 'Diagnoser',
           component: () => import('../pages/Diagnoser/index.vue'),
+          meta: { requiresSystemAdmin: true },
         },
         {
           path: '/preflight/detail',
@@ -226,17 +228,20 @@ const router = createRouter({
           path: '/fault',
           name: 'Fault',
           component: () => import('../pages/Fault/index.vue'),
+          meta: { requiresSystemAdmin: true },
         },
         {
           path: '/nodeflavor',
           name: 'NodeFlavor',
           component: () => import('../pages/NodeFlavor/index.vue'),
+          meta: { requiresSystemAdmin: true },
         },
         {
           path: '/flavors/:id',
           name: 'nodeFlavorDetail',
           component: () => import('../pages/NodeFlavor/FlavorDetail.vue'),
           props: (route) => ({ id: route.params.id }),
+          meta: { requiresSystemAdmin: true },
         },
         {
           path: '/secrets',
@@ -247,6 +252,7 @@ const router = createRouter({
           path: '/quickstart',
           name: 'QuickStart',
           component: () => import('../pages/QuickStart/index.vue'),
+          meta: { requiresSystemAdmin: true },
         },
         {
           path: '/userquickstart',
@@ -262,6 +268,7 @@ const router = createRouter({
           path: '/registries',
           name: 'ImageReg',
           component: () => import('../pages/ImageReg/index.vue'),
+          meta: { requiresSystemAdmin: true },
         },
         {
           path: '/webshell',
@@ -282,11 +289,13 @@ const router = createRouter({
           path: '/addontemplate',
           name: 'AddonTemp',
           component: () => import('@/pages/AddonTemp/index.vue'),
+          meta: { requiresSystemAdmin: true },
         },
         {
           path: '/addons',
           name: 'Addons',
           component: () => import('@/pages/Addons/index.vue'),
+          meta: { requiresSystemAdmin: true },
         },
         {
           path: '/posttrain',
@@ -329,11 +338,13 @@ const router = createRouter({
           path: '/deploy',
           name: 'Deploy',
           component: () => import('@/pages/Deploy/index.vue'),
+          meta: { requiresSystemAdmin: true },
         },
         {
           path: '/deploy/detail',
           name: 'DeployDetail',
           component: () => import('@/pages/Deploy/DeployDetail.vue'),
+          meta: { requiresSystemAdmin: true },
         },
         {
           path: '/feedback-management',
@@ -376,11 +387,13 @@ const router = createRouter({
           path: '/auditlogs',
           name: 'AuditLogs',
           component: () => import('@/pages/AuditLogs/index.vue'),
+          meta: { requiresSystemAdmin: true },
         },
         {
           path: '/user-group',
           name: 'UserGroup',
           component: () => import('@/pages/UserGroup/index.vue'),
+          meta: { requiresSystemAdmin: true },
         },
         {
           path: '/tools',


### PR DESCRIPTION
System admin pages were hidden from the nav for non-admins but remained reachable by direct URL (e.g. /clusters, /deploy, /auditlogs), because the only route guards were authentication and a workspace-admin check. This is an access-control gap: a default user could open admin views directly.

- Add a `requiresSystemAdmin` route meta and enforce it in the cluster-ready navigation guard, redirecting non-admins (no system-admin / read-only admin role) away, mirroring the existing `requiresWorkspaceAdmin` guard.
- Apply the meta to the currently-unguarded, admin-only System pages: clusters, deploy (+detail), auditlogs, registries, addons, addontemplate (catalog), nodeflavor (+detail), fault, preflight (bench), quickstart, user-group.

Note: /nodes is intentionally left open — the nav marks it accessible to all users and the node list is scoped server-side, so guarding it would hide the scoped read-only view from workspace members. This is defense-in-depth for the frontend; server-side authorization remains the primary control.

Relates to #624