### PR TITLE
fix(safe): avoid default nginx LoadBalancer addon

### DIFF
--- a/SaFE/charts/primus-safe-cr/templates/addon_template/nginx.22.3.2.yaml
+++ b/SaFE/charts/primus-safe-cr/templates/addon_template/nginx.22.3.2.yaml
@@ -9,7 +9,6 @@ metadata:
   labels:
     primus-safe.display.name: "nginx.22.3.2"
     app.kubernetes.io/managed-by: Helm
-    primus-safe.addon.default: ""
   annotations:
     meta.helm.sh/release-name: {{ .Release.Name }}
     meta.helm.sh/release-namespace: {{ .Release.Namespace }}
@@ -21,3 +20,8 @@ spec:
   version: "22.3.2"
   type: helm
   helmDefaultNamespace: default
+  # Bitnami nginx defaults to LoadBalancer. On bare-metal clusters that can
+  # make kube-proxy bind a node's physical IP as a local service address.
+  helmDefaultValues: |
+    service:
+      type: ClusterIP

--- a/SaFE/resource-manager/pkg/resource/cluster_contoller_plane.go
+++ b/SaFE/resource-manager/pkg/resource/cluster_contoller_plane.go
@@ -40,7 +40,9 @@ const (
 	// DefaultHttpServiePort is the default port for HTTPS service
 	DefaultHttpServiePort = 443
 	// DefaultApiserverPort is the default port for Kubernetes API server
-	DefaultApiserverPort = 6443
+	DefaultApiserverPort           = 6443
+	deprecatedDefaultNginxTemplate = "nginx.22.3.2"
+	deprecatedDefaultNginxRelease  = "nginx"
 )
 
 // guaranteeClusterControlPlane ensures the cluster control plane is in the desired state.
@@ -702,6 +704,10 @@ func (r *ClusterReconciler) guaranteeNamespace(ctx context.Context, client kuber
 // guaranteeDefaultAddon ensures default addons are installed in the cluster.
 // Creates Addon resources based on cluster configuration.
 func (r *ClusterReconciler) guaranteeDefaultAddon(ctx context.Context, cluster *v1.Cluster) (ctrlruntime.Result, error) {
+	if err := r.cleanupDeprecatedDefaultNginxAddon(ctx, cluster); err != nil {
+		return reconcile.Result{}, err
+	}
+
 	selector := labels.NewSelector()
 	labelsArr := []string{""}
 	if cluster.Spec.ControlPlane.KubeVersion != nil {
@@ -810,6 +816,46 @@ func (r *ClusterReconciler) guaranteeDefaultAddon(ctx context.Context, cluster *
 		}
 	}
 	return reconcile.Result{}, nil
+}
+
+// cleanupDeprecatedDefaultNginxAddon removes the legacy nginx addon that older
+// SaFE releases auto-created for every cluster. The upstream chart defaults its
+// Service to LoadBalancer, which is unsafe on bare-metal clusters because
+// kube-proxy can bind a node's physical IP as a local service address.
+func (r *ClusterReconciler) cleanupDeprecatedDefaultNginxAddon(ctx context.Context, cluster *v1.Cluster) error {
+	addon := &v1.Addon{}
+	name := fmt.Sprintf("%s-%s", cluster.Name, deprecatedDefaultNginxRelease)
+	if err := r.Get(ctx, types.NamespacedName{Name: name}, addon); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	if !isLegacyAutoNginxAddon(cluster, addon) {
+		return nil
+	}
+	if err := r.Delete(ctx, addon); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	klog.Infof("[addon] deleted legacy default nginx addon %s for cluster %s", addon.Name, cluster.Name)
+	return nil
+}
+
+func isLegacyAutoNginxAddon(cluster *v1.Cluster, addon *v1.Addon) bool {
+	if !isOwnedByCluster(cluster, addon.OwnerReferences) {
+		return false
+	}
+	helm := addon.Spec.AddonSource.HelmRepository
+	if helm == nil || helm.ReleaseName != deprecatedDefaultNginxRelease || helm.Values != "" {
+		return false
+	}
+	return helm.Template != nil && helm.Template.Name == deprecatedDefaultNginxTemplate
+}
+
+func isOwnedByCluster(cluster *v1.Cluster, refs []metav1.OwnerReference) bool {
+	for _, ref := range refs {
+		if ref.Kind == cluster.Kind && ref.Name == cluster.Name && ref.UID == cluster.UID {
+			return true
+		}
+	}
+	return false
 }
 
 // getComponentName extracts the component name from a full name by removing the part after the first dot.

--- a/SaFE/resource-manager/pkg/resource/cluster_plane_extra_test.go
+++ b/SaFE/resource-manager/pkg/resource/cluster_plane_extra_test.go
@@ -231,6 +231,64 @@ func TestGuaranteeDefaultAddonCreatesAddon(t *testing.T) {
 	assert.NoError(t, r.Get(context.Background(), client.ObjectKey{Name: "c1-infera-operator"}, addon))
 }
 
+func TestGuaranteeDefaultAddonDeletesLegacyAutoNginx(t *testing.T) {
+	cluster := testCluster("c1")
+	cluster.UID = "uid-c1"
+	template := &v1.AddonTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "infera-operator.0.1.0",
+			Labels: map[string]string{v1.AddonDefaultLabel: ""},
+		},
+	}
+	nginx := legacyAutoNginxAddon(cluster, "")
+	r := newPlaneReconciler(t, cluster, template, nginx)
+
+	_, err := r.guaranteeDefaultAddon(context.Background(), cluster)
+	assert.NoError(t, err)
+
+	addon := &v1.Addon{}
+	assert.NoError(t, r.Get(context.Background(), client.ObjectKey{Name: "c1-infera-operator"}, addon))
+	assert.Error(t, r.Get(context.Background(), client.ObjectKey{Name: "c1-nginx"}, &v1.Addon{}))
+}
+
+func TestGuaranteeDefaultAddonKeepsCustomizedNginx(t *testing.T) {
+	cluster := testCluster("c1")
+	cluster.UID = "uid-c1"
+	nginx := legacyAutoNginxAddon(cluster, "service:\n  type: NodePort\n")
+	r := newPlaneReconciler(t, cluster, nginx)
+
+	_, err := r.guaranteeDefaultAddon(context.Background(), cluster)
+	assert.NoError(t, err)
+
+	addon := &v1.Addon{}
+	assert.NoError(t, r.Get(context.Background(), client.ObjectKey{Name: "c1-nginx"}, addon))
+}
+
+func legacyAutoNginxAddon(cluster *v1.Cluster, values string) *v1.Addon {
+	return &v1.Addon{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: cluster.Name + "-nginx",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: cluster.APIVersion,
+				Kind:       cluster.Kind,
+				Name:       cluster.Name,
+				UID:        cluster.UID,
+			}},
+		},
+		Spec: v1.AddonSpec{
+			AddonSource: v1.AddonSource{
+				HelmRepository: &v1.HelmRepository{
+					ReleaseName: deprecatedDefaultNginxRelease,
+					Values:      values,
+					Template: &corev1.ObjectReference{
+						Name: deprecatedDefaultNginxTemplate,
+					},
+				},
+			},
+		},
+	}
+}
+
 func TestUpdateClusterKubeConfigNilConfig(t *testing.T) {
 	cluster := testCluster("c1")
 	r := newPlaneReconciler(t, cluster)


### PR DESCRIPTION
## Summary
- Stop auto-installing the nginx addon on every registered cluster by removing its default addon label.
- Override manual nginx addon installs to use `ClusterIP` instead of the chart's default `LoadBalancer`, avoiding kube-proxy binding node physical IPs on bare-metal clusters.
- Clean up legacy auto-created `<cluster>-nginx` addons during default addon reconciliation when they still reference the deprecated nginx template and have no user-provided Helm values.

## Test plan
- `git diff --check`
- `go test ./pkg/resource -run 'TestGuaranteeDefaultAddon' -count=1` from `SaFE/resource-manager`
- `ReadLints` on edited resource-manager files and `nginx.22.3.2.yaml`
- Inspected `oci://registry-1.docker.io/primussafe/nginx --version 22.3.2` chart defaults and confirmed upstream default `service.type: LoadBalancer`.