### PR TITLE
fix(safe): unblock balance scheduling from unbound pending reservations

### DIFF
--- a/SaFE/job-manager/pkg/scheduler/scheduler.go
+++ b/SaFE/job-manager/pkg/scheduler/scheduler.go
@@ -542,6 +542,8 @@ func (r *SchedulerReconciler) getLeftTotalResources(ctx context.Context,
 		var err error
 		if w.IsRunning() {
 			totalResource, availableResource, _, err = commonworkload.GetWorkloadResourceUsage(w, filterFunc)
+		} else if !workspace.IsEnableFifo() {
+			totalResource, availableResource, err = getBoundPendingResourceUsage(w, filterFunc)
 		} else {
 			totalResource, err = commonworkload.GetTotalResourceList(w)
 			availableResource = totalResource
@@ -564,6 +566,32 @@ func (r *SchedulerReconciler) getLeftTotalResources(ctx context.Context,
 	klog.Infof("workspace: %s, total resource: %v, total used: %v, total avail: %v, left total: %v, left avail: %v",
 		workspace.Name, totalResource, usedTotalResource, usedAvailableResource, leftTotalResource, leftAvailResource)
 	return leftAvailResource, leftTotalResource, nil
+}
+
+func getBoundPendingResourceUsage(workload *v1.Workload, filterNode func(nodeName string) bool) (
+	corev1.ResourceList, corev1.ResourceList, error) {
+	boundWorkload := workload.DeepCopy()
+	if len(boundWorkload.Status.NodeUsage) > 0 {
+		nodeUsage := boundWorkload.Status.NodeUsage[:0]
+		for _, usage := range boundWorkload.Status.NodeUsage {
+			if usage.Node == "" {
+				continue
+			}
+			nodeUsage = append(nodeUsage, usage)
+		}
+		boundWorkload.Status.NodeUsage = nodeUsage
+	} else if len(boundWorkload.Status.Pods) > 0 {
+		pods := boundWorkload.Status.Pods[:0]
+		for _, pod := range boundWorkload.Status.Pods {
+			if pod.AdminNodeName == "" {
+				continue
+			}
+			pods = append(pods, pod)
+		}
+		boundWorkload.Status.Pods = pods
+	}
+	totalResource, availableResource, _, err := commonworkload.GetWorkloadResourceUsage(boundWorkload, filterNode)
+	return totalResource, availableResource, err
 }
 
 // markAsScheduled updates a workload's status to indicate it has been scheduled.

--- a/SaFE/job-manager/pkg/scheduler/scheduler.go
+++ b/SaFE/job-manager/pkg/scheduler/scheduler.go
@@ -543,7 +543,11 @@ func (r *SchedulerReconciler) getLeftTotalResources(ctx context.Context,
 		if w.IsRunning() {
 			totalResource, availableResource, _, err = commonworkload.GetWorkloadResourceUsage(w, filterFunc)
 		} else if !workspace.IsEnableFifo() {
-			totalResource, availableResource, err = getBoundPendingResourceUsage(w, filterFunc)
+			// Balance: a scheduled-but-not-running workload only reserves resources
+			// for pods already placed on a node. Pods still waiting for a node do
+			// not keep blocking workloads queued behind it. FIFO keeps the
+			// full-spec reservation in the branch below.
+			totalResource, availableResource, err = getScheduledPendingUsage(w, filterFunc)
 		} else {
 			totalResource, err = commonworkload.GetTotalResourceList(w)
 			availableResource = totalResource
@@ -568,27 +572,46 @@ func (r *SchedulerReconciler) getLeftTotalResources(ctx context.Context,
 	return leftAvailResource, leftTotalResource, nil
 }
 
-func getBoundPendingResourceUsage(workload *v1.Workload, filterNode func(nodeName string) bool) (
+// getScheduledPendingUsage computes the resources a scheduled-but-not-running
+// workload reserves in a balance (non-FIFO) workspace.
+//
+// While the workload has been marked scheduled but its pods have not been created
+// yet (no NodeUsage/Pods status), it still reserves its full spec: this is the
+// short dispatch window and reserving prevents over-admitting other workloads
+// against it.
+//
+// Once its pods exist, only pods that have actually landed on a node are counted.
+// Pods still waiting for a node (empty admin-node name) are deliberately NOT
+// reserved so that, under balance, a workload stuck waiting for resources does
+// not keep blocking smaller workloads queued behind it (documented balance
+// semantics: "avoid blockage by the front workload in the queue"). This
+// intentionally deviates from BuildNodeUsage, which buckets unscheduled pods
+// under the empty-node key to keep exact totals.
+func getScheduledPendingUsage(workload *v1.Workload, filterNode func(nodeName string) bool) (
 	corev1.ResourceList, corev1.ResourceList, error) {
+	if len(workload.Status.NodeUsage) == 0 && len(workload.Status.Pods) == 0 {
+		total, err := commonworkload.GetTotalResourceList(workload)
+		return total, total, err
+	}
 	boundWorkload := workload.DeepCopy()
 	if len(boundWorkload.Status.NodeUsage) > 0 {
-		nodeUsage := boundWorkload.Status.NodeUsage[:0]
+		bound := boundWorkload.Status.NodeUsage[:0]
 		for _, usage := range boundWorkload.Status.NodeUsage {
 			if usage.Node == "" {
 				continue
 			}
-			nodeUsage = append(nodeUsage, usage)
+			bound = append(bound, usage)
 		}
-		boundWorkload.Status.NodeUsage = nodeUsage
-	} else if len(boundWorkload.Status.Pods) > 0 {
-		pods := boundWorkload.Status.Pods[:0]
+		boundWorkload.Status.NodeUsage = bound
+	} else {
+		bound := boundWorkload.Status.Pods[:0]
 		for _, pod := range boundWorkload.Status.Pods {
 			if pod.AdminNodeName == "" {
 				continue
 			}
-			pods = append(pods, pod)
+			bound = append(bound, pod)
 		}
-		boundWorkload.Status.Pods = pods
+		boundWorkload.Status.Pods = bound
 	}
 	totalResource, availableResource, _, err := commonworkload.GetWorkloadResourceUsage(boundWorkload, filterNode)
 	return totalResource, availableResource, err

--- a/SaFE/job-manager/pkg/scheduler/scheduler_resources_test.go
+++ b/SaFE/job-manager/pkg/scheduler/scheduler_resources_test.go
@@ -49,10 +49,82 @@ func TestGetLeftTotalResourcesWithPendingWorkload(t *testing.T) {
 
 	w := &v1.Workload{ObjectMeta: metav1.ObjectMeta{Name: "w"}}
 	w.Spec.Resources = []v1.WorkloadResource{{Replica: 1, CPU: "2", Memory: "4Gi"}}
-	// Pending (not running) -> uses GetTotalResourceList.
+	// Default (FIFO) workspace, pending (not running) -> reserves the full spec
+	// via GetTotalResourceList.
 	avail, _, err := r.getLeftTotalResources(context.Background(), ws, []*v1.Workload{w})
 	assert.NilError(t, err)
 	assert.Assert(t, avail != nil)
+}
+
+func TestGetLeftTotalResourcesFifoReservesUnboundPendingWorkload(t *testing.T) {
+	cl := ctrlfake.NewClientBuilder().WithScheme(ttlScheme(t)).Build()
+	r := &SchedulerReconciler{Client: cl}
+
+	// Default queue policy is FIFO.
+	ws := &v1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "ws"}}
+	ws.Status.AvailableResources = corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("20")}
+	ws.Status.TotalResources = corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("20")}
+
+	w := &v1.Workload{ObjectMeta: metav1.ObjectMeta{Name: "pending"}}
+	w.Spec.Resources = []v1.WorkloadResource{{Replica: 1, CPU: "10", Memory: "1Gi"}}
+	w.Status.Phase = v1.WorkloadPending
+	// Even with unbound pods, FIFO keeps the full-spec reservation.
+	w.Status.NodeUsage = []v1.NodePodUsage{{
+		Node:   "",
+		Active: map[string]int{"0": 1},
+	}}
+
+	_, total, err := r.getLeftTotalResources(context.Background(), ws, []*v1.Workload{w})
+	assert.NilError(t, err)
+	assert.Equal(t, total.Cpu().String(), "10")
+}
+
+func TestGetLeftTotalResourcesBalanceReservesScheduledWithoutPodStatus(t *testing.T) {
+	cl := ctrlfake.NewClientBuilder().WithScheme(ttlScheme(t)).Build()
+	r := &SchedulerReconciler{Client: cl}
+
+	ws := &v1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{Name: "ws"},
+		Spec:       v1.WorkspaceSpec{QueuePolicy: v1.QueueBalancePolicy},
+	}
+	ws.Status.AvailableResources = corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("20")}
+	ws.Status.TotalResources = corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("20")}
+
+	// Scheduled but pods not created yet (no NodeUsage/Pods): the short dispatch
+	// window must still reserve the full spec so balance does not over-admit.
+	w := &v1.Workload{ObjectMeta: metav1.ObjectMeta{Name: "pending"}}
+	w.Spec.Resources = []v1.WorkloadResource{{Replica: 1, CPU: "10", Memory: "1Gi"}}
+	w.Status.Phase = v1.WorkloadPending
+
+	_, total, err := r.getLeftTotalResources(context.Background(), ws, []*v1.Workload{w})
+	assert.NilError(t, err)
+	assert.Equal(t, total.Cpu().String(), "10")
+}
+
+func TestGetLeftTotalResourcesBalanceCountsBoundPendingWorkload(t *testing.T) {
+	cl := ctrlfake.NewClientBuilder().WithScheme(ttlScheme(t)).Build()
+	r := &SchedulerReconciler{Client: cl}
+
+	ws := &v1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{Name: "ws"},
+		Spec:       v1.WorkspaceSpec{QueuePolicy: v1.QueueBalancePolicy},
+	}
+	ws.Status.AvailableResources = corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("30")}
+	ws.Status.TotalResources = corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("30")}
+
+	// One pod already placed on a node, one still waiting: only the bound pod is
+	// reserved against the total pool.
+	w := &v1.Workload{ObjectMeta: metav1.ObjectMeta{Name: "pending"}}
+	w.Spec.Resources = []v1.WorkloadResource{{Replica: 2, CPU: "10", Memory: "1Gi"}}
+	w.Status.Phase = v1.WorkloadPending
+	w.Status.NodeUsage = []v1.NodePodUsage{
+		{Node: "node-a", Active: map[string]int{"0": 1}},
+		{Node: "", Active: map[string]int{"0": 1}},
+	}
+
+	_, total, err := r.getLeftTotalResources(context.Background(), ws, []*v1.Workload{w})
+	assert.NilError(t, err)
+	assert.Equal(t, total.Cpu().String(), "20")
 }
 
 func TestGetLeftTotalResourcesBalanceIgnoresUnboundPendingWorkload(t *testing.T) {

--- a/SaFE/job-manager/pkg/scheduler/scheduler_resources_test.go
+++ b/SaFE/job-manager/pkg/scheduler/scheduler_resources_test.go
@@ -11,8 +11,9 @@ import (
 
 	"gotest.tools/assert"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
@@ -52,6 +53,100 @@ func TestGetLeftTotalResourcesWithPendingWorkload(t *testing.T) {
 	avail, _, err := r.getLeftTotalResources(context.Background(), ws, []*v1.Workload{w})
 	assert.NilError(t, err)
 	assert.Assert(t, avail != nil)
+}
+
+func TestGetLeftTotalResourcesBalanceIgnoresUnboundPendingWorkload(t *testing.T) {
+	cl := ctrlfake.NewClientBuilder().WithScheme(ttlScheme(t)).Build()
+	r := &SchedulerReconciler{Client: cl}
+
+	ws := &v1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{Name: "ws"},
+		Spec:       v1.WorkspaceSpec{QueuePolicy: v1.QueueBalancePolicy},
+	}
+	ws.Status.AvailableResources = corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("20")}
+	ws.Status.TotalResources = corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("20")}
+
+	w := &v1.Workload{ObjectMeta: metav1.ObjectMeta{Name: "pending"}}
+	w.Spec.Resources = []v1.WorkloadResource{{Replica: 1, CPU: "10", Memory: "1Gi"}}
+	w.Status.Phase = v1.WorkloadPending
+	w.Status.NodeUsage = []v1.NodePodUsage{{
+		Node:   "",
+		Active: map[string]int{"0": 1},
+	}}
+
+	_, total, err := r.getLeftTotalResources(context.Background(), ws, []*v1.Workload{w})
+	assert.NilError(t, err)
+	assert.Equal(t, total.Cpu().String(), "20")
+}
+
+func TestScheduleWorkloadsBalanceSchedulesBehindUnboundPendingReservation(t *testing.T) {
+	ws := &v1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{Name: "ws"},
+		Spec: v1.WorkspaceSpec{
+			Cluster:     "cluster-1",
+			QueuePolicy: v1.QueueBalancePolicy,
+		},
+	}
+	ws.Status.AvailableResources = corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("12"),
+		corev1.ResourceMemory: resource.MustParse("12Gi"),
+	}
+	ws.Status.TotalResources = corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("12"),
+		corev1.ResourceMemory: resource.MustParse("12Gi"),
+	}
+
+	reserved := &v1.Workload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "reserved",
+			Annotations: map[string]string{
+				v1.WorkloadScheduledAnnotation: "2026-07-09T03:00:51Z",
+			},
+			Labels: map[string]string{
+				v1.ClusterIdLabel:   "cluster-1",
+				v1.WorkspaceIdLabel: "ws",
+			},
+		},
+		Spec: v1.WorkloadSpec{
+			Resources: []v1.WorkloadResource{{Replica: 1, CPU: "12", Memory: "1Gi"}},
+			Workspace: "ws",
+		},
+		Status: v1.WorkloadStatus{
+			Phase: v1.WorkloadPending,
+			NodeUsage: []v1.NodePodUsage{{
+				Node:   "",
+				Active: map[string]int{"0": 1},
+			}},
+		},
+	}
+	target := &v1.Workload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "target",
+			Labels: map[string]string{
+				v1.ClusterIdLabel:   "cluster-1",
+				v1.WorkspaceIdLabel: "ws",
+			},
+		},
+		Spec: v1.WorkloadSpec{
+			IsTolerateAll: true,
+			Resources:     []v1.WorkloadResource{{Replica: 1, CPU: "2", Memory: "1Gi"}},
+			Workspace:     "ws",
+		},
+	}
+	cl := ctrlfake.NewClientBuilder().
+		WithScheme(ttlScheme(t)).
+		WithObjects(ws, reserved, target).
+		WithStatusSubresource(&v1.Workload{}).
+		Build()
+	r := &SchedulerReconciler{Client: cl}
+
+	err := r.scheduleWorkloads(context.Background(), &SchedulerMessage{WorkspaceId: "ws"})
+	assert.NilError(t, err)
+
+	got := &v1.Workload{}
+	err = cl.Get(context.Background(), ctrlclient.ObjectKey{Name: "target"}, got)
+	assert.NilError(t, err)
+	assert.Assert(t, v1.IsWorkloadScheduled(got))
 }
 
 func TestGetUnfinishedWorkloadsEmpty(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fix balance (non-FIFO) scheduling so a workload that is already marked scheduled but whose pods cannot bind to a node (empty admin-node name) no longer holds a full-spec reservation that starves smaller workloads queued behind it. This is what made an Authoring dev box on `project1-dev` sit at `queuePosition: 4` with `In queue - insufficient resources, no cpu available`, even though the workspace uses `queuePolicy: balance`.
- Keep the reservation correct in the short dispatch window: a scheduled workload that has not produced any pod status yet still reserves its full spec, so balance does not over-admit against it across scheduling rounds.
- Only pods already placed on a node keep a reservation; pods still waiting for a node are excluded. FIFO keeps the original full-spec reservation behavior unchanged.

## Root cause

`getLeftTotalResources` treated every already-scheduled, not-yet-running workload as consuming its full spec. Large multi-node jobs (e.g. `utd-multi-node-qqcws-*`) that were dispatched but stuck with pods in `nodeUsage.node == ""` therefore reserved all their CPU/GPU at the SaFE scheduling layer. Authoring dev boxes use `isTolerateAll=true`, which is checked against `leftTotalResources`, so the phantom reservation blocked them with `no cpu available`. The balance queue-skip logic (`continue` vs `break`) was already working; the bug was purely in resource accounting.

## Changes

- `job-manager/pkg/scheduler/scheduler.go`: add `getScheduledPendingUsage`; in balance mode a scheduled-but-not-running workload reserves full spec only while it has no pod status, otherwise it reserves only pods bound to a real node.
- `job-manager/pkg/scheduler/scheduler_resources_test.go`: add coverage for the no-status reservation, mixed bound/unbound, FIFO regression, unbound-release, and an end-to-end `scheduleWorkloads` case where a small tolerate-all workload is scheduled behind an unbound pending reservation.

## Behavior notes

- Balance still respects priority: an unschedulable workload with strictly higher priority than the next one still blocks lower-priority workloads behind it.
- Under balance, multiple large jobs stuck as unbound will optimistically let smaller jobs proceed. This matches the documented balance semantics ("avoid blockage by the front workload in the queue") and the big-job-vs-utilization tradeoff that distinguishes balance from FIFO.

## Test plan

- [x] `go test ./job-manager/pkg/scheduler`
- [x] `go vet ./job-manager/pkg/scheduler`
- [x] `gofmt`
- [ ] Deploy `job-manager` to `project1-dev`, and while an unbound pending large job exists, submit a small Authoring dev box and confirm it is scheduled and reaches Running.
