### PR TITLE
ci(build): add manual dispatch to build all modules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,12 @@ on:
       - '**'
     tags:
       - '**'
+  workflow_dispatch:
+    inputs:
+      build_all:
+        description: 'Build all modules (ignore change detection)'
+        type: boolean
+        default: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -41,6 +47,18 @@ jobs:
       id: detect-changes
       run: |
         set -e
+        
+        # Manual full build: when triggered from the Actions UI with build_all,
+        # force every module on and skip change detection.
+        if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.build_all }}" == "true" ]]; then
+          echo "Manual dispatch (build_all): building all modules"
+          for module in apiserver resource_manager job_manager preprocess \
+            cicd_runner_proxy cicd_unified_job_proxy s3_downloader a2a_gateway \
+            webhooks node_agent sync_image; do
+            echo "${module}_changed=true" >> $GITHUB_OUTPUT
+          done
+          exit 0
+        fi
         
         # Determine the base commit for comparison
         if [[ "${{ github.event_name }}" == "push" ]]; then


### PR DESCRIPTION
## Summary

- Add a `workflow_dispatch` trigger to the **Build** workflow so all modules can be built on demand from the Actions UI.
- New input `build_all` (boolean, default `true`): when triggered manually with it checked, change detection is skipped and every module in the matrix is built. Unchecking it falls back to change detection on the latest commit.

## Modules covered

`apiserver`, `resource-manager`, `job-manager`, `preprocess`, `cicd-runner-proxy`, `cicd-unified-job-proxy`, `s3-downloader`, `a2a-gateway`, `webhooks`, `node-agent`, `sync-image` (matches the existing build matrix; `monarch` remains commented out).

## Usage

GitHub → Actions → **Build** → **Run workflow** → pick a branch → keep `Build all modules` checked → Run.

## Test plan

- [x] `build.yml` parses as valid YAML; triggers are `push` + `workflow_dispatch` with input `build_all`.
- [ ] Trigger the workflow manually from the Actions UI and confirm all modules appear in the build matrix.
