### PR TITLE
Fix SaFE 0710 workflow and resource issues

### DIFF
--- a/Bootstrap/storage/ceph/README.md
+++ b/Bootstrap/storage/ceph/README.md
@@ -1,0 +1,5 @@
+# Ceph Storage Bootstrap
+
+Before applying `storageclass.yaml`, replace the `storage-rbd` Secret placeholders with a dedicated Ceph user and key.
+
+Do not deploy the manifest with `<ceph-user-id>` or `<ceph-user-key>` unchanged. The RBD CSI driver requires valid credentials for provisioning, expanding, and staging volumes.

--- a/Bootstrap/storage/ceph/storageclass.yaml
+++ b/Bootstrap/storage/ceph/storageclass.yaml
@@ -31,13 +31,14 @@ reclaimPolicy: Delete
 volumeBindingMode: Immediate
 ---
 apiVersion: v1
-data:
-  userID: YWRtaW4=
-  userKey: SECRET
 kind: Secret
 metadata:
   name: storage-rbd
   namespace: default
+stringData:
+  # Replace these placeholders with a dedicated Ceph user and key before deployment.
+  userID: "<ceph-user-id>"
+  userKey: "<ceph-user-key>"
 type: kubernetes.io/rbd
 
 

--- a/SaFE/apiserver/pkg/handlers/github-workflow/handler.go
+++ b/SaFE/apiserver/pkg/handlers/github-workflow/handler.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/AMD-AIG-AIMA/SAFE/apiserver/pkg/handlers/middleware"
 	"github.com/gin-gonic/gin"
+	"k8s.io/klog/v2"
 
 	dbclient "github.com/AMD-AIG-AIMA/SAFE/common/pkg/database/client"
 )
@@ -61,6 +62,11 @@ func getRequestDB(c *gin.Context) (*sql.DB, bool) {
 	return db, true
 }
 
+func writeInternalError(c *gin.Context, err error) {
+	klog.ErrorS(err, "github workflow handler error")
+	c.JSON(500, gin.H{"error": "internal server error"})
+}
+
 func parseIntQuery(c *gin.Context, name string, defaultValue, minValue, maxValue int) (int, bool) {
 	raw := c.Query(name)
 	if raw == "" {
@@ -84,7 +90,7 @@ func handleListConfigs(c *gin.Context) {
 		       file_patterns, COALESCE(display_settings::text, '{}'), enabled, COALESCE(created_by, ''), created_at, updated_at
 		FROM github_collection_configs ORDER BY name`)
 	if err != nil {
-		c.JSON(500, gin.H{"error": err.Error()})
+		writeInternalError(c, err)
 		return
 	}
 	defer rows.Close()
@@ -96,7 +102,7 @@ func handleListConfigs(c *gin.Context) {
 		var enabled bool
 		var createdAt, updatedAt time.Time
 		if err := rows.Scan(&id, &name, &owner, &repo, &wp, &bp, &fp, &ds, &enabled, &createdBy, &createdAt, &updatedAt); err != nil {
-			c.JSON(500, gin.H{"error": err.Error()})
+			writeInternalError(c, err)
 			return
 		}
 		var displaySettings interface{}
@@ -109,7 +115,7 @@ func handleListConfigs(c *gin.Context) {
 		})
 	}
 	if err := rows.Err(); err != nil {
-		c.JSON(500, gin.H{"error": err.Error()})
+		writeInternalError(c, err)
 		return
 	}
 	c.JSON(200, gin.H{"configs": configs, "count": len(configs)})
@@ -151,7 +157,7 @@ func handleCreateConfig(c *gin.Context) {
 		sliceToArr(req.WorkflowPatterns), sliceToArr(req.BranchPatterns), sliceToArr(req.FilePatterns),
 		displayJSON, enabled)
 	if err != nil {
-		c.JSON(500, gin.H{"error": err.Error()})
+		writeInternalError(c, err)
 		return
 	}
 	c.JSON(201, gin.H{"created": req.Name})
@@ -163,8 +169,18 @@ func handleDeleteConfig(c *gin.Context) {
 	if !ok {
 		return
 	}
-	if _, err := db.ExecContext(c.Request.Context(), `DELETE FROM github_collection_configs WHERE id = $1`, id); err != nil {
-		c.JSON(500, gin.H{"error": err.Error()})
+	result, err := db.ExecContext(c.Request.Context(), `DELETE FROM github_collection_configs WHERE id = $1`, id)
+	if err != nil {
+		writeInternalError(c, err)
+		return
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		writeInternalError(c, err)
+		return
+	}
+	if affected == 0 {
+		c.JSON(404, gin.H{"error": "config not found"})
 		return
 	}
 	c.JSON(200, gin.H{"deleted": id})
@@ -215,7 +231,7 @@ func handleListRuns(c *gin.Context) {
 
 	rows, err := db.QueryContext(c.Request.Context(), query, args...)
 	if err != nil {
-		c.JSON(500, gin.H{"error": err.Error()})
+		writeInternalError(c, err)
 		return
 	}
 	defer rows.Close()
@@ -230,7 +246,7 @@ func handleListRuns(c *gin.Context) {
 		if err := rows.Scan(&id, &wid, &cluster, &ghRunID, &ghJobID, &wfName,
 			&ghOwner, &ghRepo, &branch, &sha, &st, &conclusion,
 			&syncSt, &startedAt, &completedAt, &createdAt); err != nil {
-			c.JSON(500, gin.H{"error": err.Error()})
+			writeInternalError(c, err)
 			return
 		}
 		run := map[string]interface{}{
@@ -250,7 +266,7 @@ func handleListRuns(c *gin.Context) {
 		runs = append(runs, run)
 	}
 	if err := rows.Err(); err != nil {
-		c.JSON(500, gin.H{"error": err.Error()})
+		writeInternalError(c, err)
 		return
 	}
 	c.JSON(200, gin.H{"runs": runs, "count": len(runs)})
@@ -275,6 +291,10 @@ func handleGetRun(c *gin.Context) {
 		Scan(&wid, &cluster, &ghRunID, &ghJobID, &wfName, &ghOwner, &ghRepo,
 			&branch, &sha, &st, &conclusion, &syncSt, &startedAt, &completedAt, &createdAt)
 	if err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			writeInternalError(c, err)
+			return
+		}
 		c.JSON(404, gin.H{"error": "run not found"})
 		return
 	}
@@ -299,7 +319,7 @@ func handleGetRun(c *gin.Context) {
 	var detailsRaw []byte
 	err = db.QueryRowContext(c.Request.Context(), `SELECT raw_data FROM github_workflow_run_details WHERE run_id = $1`, id).Scan(&detailsRaw)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		c.JSON(500, gin.H{"error": err.Error()})
+		writeInternalError(c, err)
 		return
 	}
 	if len(detailsRaw) > 0 {
@@ -324,7 +344,7 @@ func handleGetRunJobs(c *gin.Context) {
 		FROM github_workflow_jobs j WHERE j.run_id = $1
 		ORDER BY j.started_at`, id)
 	if err != nil {
-		c.JSON(500, gin.H{"error": err.Error()})
+		writeInternalError(c, err)
 		return
 	}
 	defer rows.Close()
@@ -336,7 +356,7 @@ func handleGetRunJobs(c *gin.Context) {
 		var name, status, conclusion, runnerName string
 		var startedAt, completedAt sql.NullTime
 		if err := rows.Scan(&jid, &ghJobID, &name, &status, &conclusion, &startedAt, &completedAt, &runnerName); err != nil {
-			c.JSON(500, gin.H{"error": err.Error()})
+			writeInternalError(c, err)
 			return
 		}
 
@@ -355,7 +375,7 @@ func handleGetRunJobs(c *gin.Context) {
 			SELECT step_number, name, status, conclusion, duration_seconds
 			FROM github_workflow_steps WHERE job_id = $1 ORDER BY step_number`, jid)
 		if err != nil {
-			c.JSON(500, gin.H{"error": err.Error()})
+			writeInternalError(c, err)
 			return
 		}
 		var steps []map[string]interface{}
@@ -364,7 +384,7 @@ func handleGetRunJobs(c *gin.Context) {
 			var sname, sstatus, sconclusion string
 			if err := stepRows.Scan(&sn, &sname, &sstatus, &sconclusion, &dur); err != nil {
 				stepRows.Close()
-				c.JSON(500, gin.H{"error": err.Error()})
+				writeInternalError(c, err)
 				return
 			}
 			steps = append(steps, map[string]interface{}{
@@ -374,7 +394,7 @@ func handleGetRunJobs(c *gin.Context) {
 		}
 		if err := stepRows.Err(); err != nil {
 			stepRows.Close()
-			c.JSON(500, gin.H{"error": err.Error()})
+			writeInternalError(c, err)
 			return
 		}
 		stepRows.Close()
@@ -382,7 +402,7 @@ func handleGetRunJobs(c *gin.Context) {
 		jobs = append(jobs, job)
 	}
 	if err := rows.Err(); err != nil {
-		c.JSON(500, gin.H{"error": err.Error()})
+		writeInternalError(c, err)
 		return
 	}
 
@@ -401,7 +421,7 @@ func handleGetRunMetrics(c *gin.Context) {
 		FROM github_workflow_metrics WHERE run_id = $1
 		ORDER BY created_at`, id)
 	if err != nil {
-		c.JSON(500, gin.H{"error": err.Error()})
+		writeInternalError(c, err)
 		return
 	}
 	defer rows.Close()
@@ -415,7 +435,7 @@ func handleGetRunMetrics(c *gin.Context) {
 		var ts sql.NullTime
 		var createdAt time.Time
 		if err := rows.Scan(&mid, &configID, &sourceFile, &rowDataBytes, &ts, &dims, &mets, &createdAt); err != nil {
-			c.JSON(500, gin.H{"error": err.Error()})
+			writeInternalError(c, err)
 			return
 		}
 		m := map[string]interface{}{
@@ -449,7 +469,7 @@ func handleGetRunMetrics(c *gin.Context) {
 		metrics = append(metrics, m)
 	}
 	if err := rows.Err(); err != nil {
-		c.JSON(500, gin.H{"error": err.Error()})
+		writeInternalError(c, err)
 		return
 	}
 
@@ -496,19 +516,19 @@ func handleStats(c *gin.Context) {
 	}
 	var total, running, completed, failed int
 	if err := db.QueryRowContext(c.Request.Context(), `SELECT COUNT(*) FROM github_workflow_runs`).Scan(&total); err != nil {
-		c.JSON(500, gin.H{"error": err.Error()})
+		writeInternalError(c, err)
 		return
 	}
 	if err := db.QueryRowContext(c.Request.Context(), `SELECT COUNT(*) FROM github_workflow_runs WHERE status='running'`).Scan(&running); err != nil {
-		c.JSON(500, gin.H{"error": err.Error()})
+		writeInternalError(c, err)
 		return
 	}
 	if err := db.QueryRowContext(c.Request.Context(), `SELECT COUNT(*) FROM github_workflow_runs WHERE status='completed'`).Scan(&completed); err != nil {
-		c.JSON(500, gin.H{"error": err.Error()})
+		writeInternalError(c, err)
 		return
 	}
 	if err := db.QueryRowContext(c.Request.Context(), `SELECT COUNT(*) FROM github_workflow_runs WHERE conclusion='failure'`).Scan(&failed); err != nil {
-		c.JSON(500, gin.H{"error": err.Error()})
+		writeInternalError(c, err)
 		return
 	}
 
@@ -536,7 +556,7 @@ func handleGetFields(c *gin.Context) {
 		GROUP BY key
 		ORDER BY key`, configID)
 	if err != nil {
-		c.JSON(500, gin.H{"error": err.Error()})
+		writeInternalError(c, err)
 		return
 	}
 	defer rows.Close()
@@ -546,7 +566,7 @@ func handleGetFields(c *gin.Context) {
 		var key string
 		var total, numericCount, distinctCount int
 		if err := rows.Scan(&key, &total, &numericCount, &distinctCount); err != nil {
-			c.JSON(500, gin.H{"error": err.Error()})
+			writeInternalError(c, err)
 			return
 		}
 
@@ -569,7 +589,7 @@ func handleGetFields(c *gin.Context) {
 		})
 	}
 	if err := rows.Err(); err != nil {
-		c.JSON(500, gin.H{"error": err.Error()})
+		writeInternalError(c, err)
 		return
 	}
 
@@ -577,7 +597,7 @@ func handleGetFields(c *gin.Context) {
 	var ds string
 	if err := db.QueryRowContext(c.Request.Context(),
 		`SELECT COALESCE(display_settings::text, '{}') FROM github_collection_configs WHERE id = $1`, configID).Scan(&ds); err != nil && !errors.Is(err, sql.ErrNoRows) {
-		c.JSON(500, gin.H{"error": err.Error()})
+		writeInternalError(c, err)
 		return
 	}
 	json.Unmarshal([]byte(ds), &displaySettings)
@@ -606,7 +626,7 @@ func handleGetConfigMetrics(c *gin.Context) {
 	var total int
 	if err := db.QueryRowContext(c.Request.Context(),
 		`SELECT count(*) FROM github_workflow_metrics WHERE config_id = $1`, configID).Scan(&total); err != nil {
-		c.JSON(500, gin.H{"error": err.Error()})
+		writeInternalError(c, err)
 		return
 	}
 
@@ -617,7 +637,7 @@ func handleGetConfigMetrics(c *gin.Context) {
 		ORDER BY created_at DESC
 		LIMIT $2 OFFSET $3`, configID, limit, offset)
 	if err != nil {
-		c.JSON(500, gin.H{"error": err.Error()})
+		writeInternalError(c, err)
 		return
 	}
 	defer rows.Close()
@@ -629,7 +649,7 @@ func handleGetConfigMetrics(c *gin.Context) {
 		var rowDataBytes []byte
 		var createdAt time.Time
 		if err := rows.Scan(&mid, &sourceFile, &rowDataBytes, &createdAt); err != nil {
-			c.JSON(500, gin.H{"error": err.Error()})
+			writeInternalError(c, err)
 			return
 		}
 		m := map[string]interface{}{
@@ -647,7 +667,7 @@ func handleGetConfigMetrics(c *gin.Context) {
 		metrics = append(metrics, m)
 	}
 	if err := rows.Err(); err != nil {
-		c.JSON(500, gin.H{"error": err.Error()})
+		writeInternalError(c, err)
 		return
 	}
 
@@ -720,7 +740,7 @@ func handleUpdateConfig(c *gin.Context) {
 
 	_, err := db.ExecContext(c.Request.Context(), query, args...)
 	if err != nil {
-		c.JSON(500, gin.H{"error": err.Error()})
+		writeInternalError(c, err)
 		return
 	}
 	c.JSON(200, gin.H{"updated": id})
@@ -755,7 +775,7 @@ func handleListRepositories(c *gin.Context) {
 
 	rows, err := db.QueryContext(c.Request.Context(), query, args...)
 	if err != nil {
-		c.JSON(500, gin.H{"error": err.Error()})
+		writeInternalError(c, err)
 		return
 	}
 	defer rows.Close()
@@ -766,7 +786,7 @@ func handleListRepositories(c *gin.Context) {
 		var total, running, completed, failed int
 		var latestAt sql.NullTime
 		if err := rows.Scan(&owner, &repo, &total, &running, &completed, &failed, &latestAt); err != nil {
-			c.JSON(500, gin.H{"error": err.Error()})
+			writeInternalError(c, err)
 			return
 		}
 
@@ -787,14 +807,14 @@ func handleListRepositories(c *gin.Context) {
 		cfgRows, err := db.QueryContext(c.Request.Context(),
 			`SELECT id FROM github_collection_configs WHERE github_owner = $1 AND github_repo = $2`, owner, repo)
 		if err != nil {
-			c.JSON(500, gin.H{"error": err.Error()})
+			writeInternalError(c, err)
 			return
 		}
 		for cfgRows.Next() {
 			var cfgID int
 			if err := cfgRows.Scan(&cfgID); err != nil {
 				cfgRows.Close()
-				c.JSON(500, gin.H{"error": err.Error()})
+				writeInternalError(c, err)
 				return
 			}
 			configIDs = append(configIDs, cfgID)
@@ -802,7 +822,7 @@ func handleListRepositories(c *gin.Context) {
 		}
 		if err := cfgRows.Err(); err != nil {
 			cfgRows.Close()
-			c.JSON(500, gin.H{"error": err.Error()})
+			writeInternalError(c, err)
 			return
 		}
 		cfgRows.Close()
@@ -812,7 +832,7 @@ func handleListRepositories(c *gin.Context) {
 		repos = append(repos, r)
 	}
 	if err := rows.Err(); err != nil {
-		c.JSON(500, gin.H{"error": err.Error()})
+		writeInternalError(c, err)
 		return
 	}
 
@@ -835,7 +855,7 @@ func handleGetRepository(c *gin.Context) {
 		       count(*) FILTER (WHERE conclusion = 'failure')
 		FROM github_workflow_runs WHERE github_owner = $1 AND github_repo = $2`,
 		owner, repo).Scan(&total, &running, &completed, &failed); err != nil {
-		c.JSON(500, gin.H{"error": err.Error()})
+		writeInternalError(c, err)
 		return
 	}
 
@@ -843,7 +863,7 @@ func handleGetRepository(c *gin.Context) {
 		`SELECT DISTINCT workflow_name FROM github_workflow_runs WHERE github_owner = $1 AND github_repo = $2 AND workflow_name != ''`,
 		owner, repo)
 	if err != nil {
-		c.JSON(500, gin.H{"error": err.Error()})
+		writeInternalError(c, err)
 		return
 	}
 	var workflows []string
@@ -851,14 +871,14 @@ func handleGetRepository(c *gin.Context) {
 		var wf string
 		if err := wfRows.Scan(&wf); err != nil {
 			wfRows.Close()
-			c.JSON(500, gin.H{"error": err.Error()})
+			writeInternalError(c, err)
 			return
 		}
 		workflows = append(workflows, wf)
 	}
 	if err := wfRows.Err(); err != nil {
 		wfRows.Close()
-		c.JSON(500, gin.H{"error": err.Error()})
+		writeInternalError(c, err)
 		return
 	}
 	wfRows.Close()
@@ -869,7 +889,7 @@ func handleGetRepository(c *gin.Context) {
 		FROM github_collection_configs c
 		WHERE c.github_owner = $1 AND c.github_repo = $2`, owner, repo)
 	if err != nil {
-		c.JSON(500, gin.H{"error": err.Error()})
+		writeInternalError(c, err)
 		return
 	}
 	var configs []map[string]interface{}
@@ -878,7 +898,7 @@ func handleGetRepository(c *gin.Context) {
 		var name, dsStr string
 		if err := cfgRows.Scan(&cfgID, &name, &dsStr, &metricsCount); err != nil {
 			cfgRows.Close()
-			c.JSON(500, gin.H{"error": err.Error()})
+			writeInternalError(c, err)
 			return
 		}
 		var ds interface{}
@@ -889,7 +909,7 @@ func handleGetRepository(c *gin.Context) {
 	}
 	if err := cfgRows.Err(); err != nil {
 		cfgRows.Close()
-		c.JSON(500, gin.H{"error": err.Error()})
+		writeInternalError(c, err)
 		return
 	}
 	cfgRows.Close()

--- a/SaFE/apiserver/pkg/handlers/github-workflow/handler.go
+++ b/SaFE/apiserver/pkg/handlers/github-workflow/handler.go
@@ -13,13 +13,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/AMD-AIG-AIMA/SAFE/apiserver/pkg/handlers/middleware"
 	"github.com/gin-gonic/gin"
 
 	dbclient "github.com/AMD-AIG-AIMA/SAFE/common/pkg/database/client"
 )
 
 func RegisterRoutes(router *gin.RouterGroup) {
-	gh := router.Group("/github-workflow")
+	gh := router.Group("/github-workflow", middleware.Authorize(), middleware.Preprocess())
 	gh.GET("/collection-configs", handleListConfigs)
 	gh.POST("/collection-configs", handleCreateConfig)
 	gh.DELETE("/collection-configs/:id", handleDeleteConfig)
@@ -624,12 +625,12 @@ func handleListRepositories(c *gin.Context) {
 		rows.Scan(&owner, &repo, &total, &running, &completed, &failed, &latestAt)
 
 		r := map[string]interface{}{
-			"github_owner":  owner,
-			"github_repo":   repo,
-			"total_runs":    total,
-			"running_runs":  running,
+			"github_owner":   owner,
+			"github_repo":    repo,
+			"total_runs":     total,
+			"running_runs":   running,
 			"completed_runs": completed,
-			"failed_runs":   failed,
+			"failed_runs":    failed,
 		}
 		if latestAt.Valid {
 			r["latest_run_at"] = latestAt.Time.Format(time.RFC3339)

--- a/SaFE/apiserver/pkg/handlers/github-workflow/handler.go
+++ b/SaFE/apiserver/pkg/handlers/github-workflow/handler.go
@@ -142,7 +142,10 @@ func handleDeleteConfig(c *gin.Context) {
 	if !ok {
 		return
 	}
-	db.ExecContext(c.Request.Context(), `DELETE FROM github_collection_configs WHERE id = $1`, id)
+	if _, err := db.ExecContext(c.Request.Context(), `DELETE FROM github_collection_configs WHERE id = $1`, id); err != nil {
+		c.JSON(500, gin.H{"error": err.Error()})
+		return
+	}
 	c.JSON(200, gin.H{"deleted": id})
 }
 

--- a/SaFE/apiserver/pkg/handlers/github-workflow/handler.go
+++ b/SaFE/apiserver/pkg/handlers/github-workflow/handler.go
@@ -8,6 +8,7 @@ package githubworkflow
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -81,7 +82,10 @@ func handleListConfigs(c *gin.Context) {
 		var name, owner, repo, wp, bp, fp, ds, createdBy string
 		var enabled bool
 		var createdAt, updatedAt time.Time
-		rows.Scan(&id, &name, &owner, &repo, &wp, &bp, &fp, &ds, &enabled, &createdBy, &createdAt, &updatedAt)
+		if err := rows.Scan(&id, &name, &owner, &repo, &wp, &bp, &fp, &ds, &enabled, &createdBy, &createdAt, &updatedAt); err != nil {
+			c.JSON(500, gin.H{"error": err.Error()})
+			return
+		}
 		var displaySettings interface{}
 		json.Unmarshal([]byte(ds), &displaySettings)
 		configs = append(configs, map[string]interface{}{
@@ -90,6 +94,10 @@ func handleListConfigs(c *gin.Context) {
 			"display_settings": displaySettings, "enabled": enabled, "created_by": createdBy,
 			"created_at": createdAt.Format(time.RFC3339), "updated_at": updatedAt.Format(time.RFC3339),
 		})
+	}
+	if err := rows.Err(); err != nil {
+		c.JSON(500, gin.H{"error": err.Error()})
+		return
 	}
 	c.JSON(200, gin.H{"configs": configs, "count": len(configs)})
 }
@@ -206,9 +214,12 @@ func handleListRuns(c *gin.Context) {
 		var ghRunID, ghJobID int64
 		var startedAt, completedAt sql.NullTime
 		var createdAt time.Time
-		rows.Scan(&id, &wid, &cluster, &ghRunID, &ghJobID, &wfName,
+		if err := rows.Scan(&id, &wid, &cluster, &ghRunID, &ghJobID, &wfName,
 			&ghOwner, &ghRepo, &branch, &sha, &st, &conclusion,
-			&syncSt, &startedAt, &completedAt, &createdAt)
+			&syncSt, &startedAt, &completedAt, &createdAt); err != nil {
+			c.JSON(500, gin.H{"error": err.Error()})
+			return
+		}
 		run := map[string]interface{}{
 			"id": id, "workload_id": wid, "cluster": cluster,
 			"github_run_id": ghRunID, "github_job_id": ghJobID, "workflow_name": wfName,
@@ -224,6 +235,10 @@ func handleListRuns(c *gin.Context) {
 			run["completed_at"] = completedAt.Time.Format(time.RFC3339)
 		}
 		runs = append(runs, run)
+	}
+	if err := rows.Err(); err != nil {
+		c.JSON(500, gin.H{"error": err.Error()})
+		return
 	}
 	c.JSON(200, gin.H{"runs": runs, "count": len(runs)})
 }
@@ -269,7 +284,11 @@ func handleGetRun(c *gin.Context) {
 	}
 
 	var detailsRaw []byte
-	db.QueryRowContext(c.Request.Context(), `SELECT raw_data FROM github_workflow_run_details WHERE run_id = $1`, id).Scan(&detailsRaw)
+	err = db.QueryRowContext(c.Request.Context(), `SELECT raw_data FROM github_workflow_run_details WHERE run_id = $1`, id).Scan(&detailsRaw)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		c.JSON(500, gin.H{"error": err.Error()})
+		return
+	}
 	if len(detailsRaw) > 0 {
 		var details interface{}
 		json.Unmarshal(detailsRaw, &details)
@@ -303,7 +322,10 @@ func handleGetRunJobs(c *gin.Context) {
 		var ghJobID int64
 		var name, status, conclusion, runnerName string
 		var startedAt, completedAt sql.NullTime
-		rows.Scan(&jid, &ghJobID, &name, &status, &conclusion, &startedAt, &completedAt, &runnerName)
+		if err := rows.Scan(&jid, &ghJobID, &name, &status, &conclusion, &startedAt, &completedAt, &runnerName); err != nil {
+			c.JSON(500, gin.H{"error": err.Error()})
+			return
+		}
 
 		job := map[string]interface{}{
 			"id": jid, "github_job_id": ghJobID, "name": name,
@@ -316,24 +338,39 @@ func handleGetRunJobs(c *gin.Context) {
 			job["completed_at"] = completedAt.Time.Format(time.RFC3339)
 		}
 
-		stepRows, _ := db.QueryContext(c.Request.Context(), `
+		stepRows, err := db.QueryContext(c.Request.Context(), `
 			SELECT step_number, name, status, conclusion, duration_seconds
 			FROM github_workflow_steps WHERE job_id = $1 ORDER BY step_number`, jid)
-		var steps []map[string]interface{}
-		if stepRows != nil {
-			for stepRows.Next() {
-				var sn, dur int
-				var sname, sstatus, sconclusion string
-				stepRows.Scan(&sn, &sname, &sstatus, &sconclusion, &dur)
-				steps = append(steps, map[string]interface{}{
-					"step_number": sn, "name": sname, "status": sstatus,
-					"conclusion": sconclusion, "duration_seconds": dur,
-				})
-			}
-			stepRows.Close()
+		if err != nil {
+			c.JSON(500, gin.H{"error": err.Error()})
+			return
 		}
+		var steps []map[string]interface{}
+		for stepRows.Next() {
+			var sn, dur int
+			var sname, sstatus, sconclusion string
+			if err := stepRows.Scan(&sn, &sname, &sstatus, &sconclusion, &dur); err != nil {
+				stepRows.Close()
+				c.JSON(500, gin.H{"error": err.Error()})
+				return
+			}
+			steps = append(steps, map[string]interface{}{
+				"step_number": sn, "name": sname, "status": sstatus,
+				"conclusion": sconclusion, "duration_seconds": dur,
+			})
+		}
+		if err := stepRows.Err(); err != nil {
+			stepRows.Close()
+			c.JSON(500, gin.H{"error": err.Error()})
+			return
+		}
+		stepRows.Close()
 		job["steps"] = steps
 		jobs = append(jobs, job)
+	}
+	if err := rows.Err(); err != nil {
+		c.JSON(500, gin.H{"error": err.Error()})
+		return
 	}
 
 	c.JSON(200, gin.H{"jobs": jobs, "count": len(jobs)})
@@ -364,7 +401,10 @@ func handleGetRunMetrics(c *gin.Context) {
 		var rowDataBytes, dims, mets []byte
 		var ts sql.NullTime
 		var createdAt time.Time
-		rows.Scan(&mid, &configID, &sourceFile, &rowDataBytes, &ts, &dims, &mets, &createdAt)
+		if err := rows.Scan(&mid, &configID, &sourceFile, &rowDataBytes, &ts, &dims, &mets, &createdAt); err != nil {
+			c.JSON(500, gin.H{"error": err.Error()})
+			return
+		}
 		m := map[string]interface{}{
 			"id":         mid,
 			"created_at": createdAt.Format(time.RFC3339),
@@ -394,6 +434,10 @@ func handleGetRunMetrics(c *gin.Context) {
 			m["metrics"] = v
 		}
 		metrics = append(metrics, m)
+	}
+	if err := rows.Err(); err != nil {
+		c.JSON(500, gin.H{"error": err.Error()})
+		return
 	}
 
 	c.JSON(200, gin.H{"metrics": metrics, "count": len(metrics)})
@@ -438,10 +482,22 @@ func handleStats(c *gin.Context) {
 		return
 	}
 	var total, running, completed, failed int
-	db.QueryRowContext(c.Request.Context(), `SELECT COUNT(*) FROM github_workflow_runs`).Scan(&total)
-	db.QueryRowContext(c.Request.Context(), `SELECT COUNT(*) FROM github_workflow_runs WHERE status='running'`).Scan(&running)
-	db.QueryRowContext(c.Request.Context(), `SELECT COUNT(*) FROM github_workflow_runs WHERE status='completed'`).Scan(&completed)
-	db.QueryRowContext(c.Request.Context(), `SELECT COUNT(*) FROM github_workflow_runs WHERE conclusion='failure'`).Scan(&failed)
+	if err := db.QueryRowContext(c.Request.Context(), `SELECT COUNT(*) FROM github_workflow_runs`).Scan(&total); err != nil {
+		c.JSON(500, gin.H{"error": err.Error()})
+		return
+	}
+	if err := db.QueryRowContext(c.Request.Context(), `SELECT COUNT(*) FROM github_workflow_runs WHERE status='running'`).Scan(&running); err != nil {
+		c.JSON(500, gin.H{"error": err.Error()})
+		return
+	}
+	if err := db.QueryRowContext(c.Request.Context(), `SELECT COUNT(*) FROM github_workflow_runs WHERE status='completed'`).Scan(&completed); err != nil {
+		c.JSON(500, gin.H{"error": err.Error()})
+		return
+	}
+	if err := db.QueryRowContext(c.Request.Context(), `SELECT COUNT(*) FROM github_workflow_runs WHERE conclusion='failure'`).Scan(&failed); err != nil {
+		c.JSON(500, gin.H{"error": err.Error()})
+		return
+	}
 
 	c.JSON(200, gin.H{
 		"total": total, "running": running, "completed": completed, "failed": failed,
@@ -476,7 +532,10 @@ func handleGetFields(c *gin.Context) {
 	for rows.Next() {
 		var key string
 		var total, numericCount, distinctCount int
-		rows.Scan(&key, &total, &numericCount, &distinctCount)
+		if err := rows.Scan(&key, &total, &numericCount, &distinctCount); err != nil {
+			c.JSON(500, gin.H{"error": err.Error()})
+			return
+		}
 
 		dataType := "string"
 		if numericCount > total/2 {
@@ -496,11 +555,18 @@ func handleGetFields(c *gin.Context) {
 			"hint":           hint,
 		})
 	}
+	if err := rows.Err(); err != nil {
+		c.JSON(500, gin.H{"error": err.Error()})
+		return
+	}
 
 	var displaySettings interface{}
 	var ds string
-	db.QueryRowContext(c.Request.Context(),
-		`SELECT COALESCE(display_settings::text, '{}') FROM github_collection_configs WHERE id = $1`, configID).Scan(&ds)
+	if err := db.QueryRowContext(c.Request.Context(),
+		`SELECT COALESCE(display_settings::text, '{}') FROM github_collection_configs WHERE id = $1`, configID).Scan(&ds); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		c.JSON(500, gin.H{"error": err.Error()})
+		return
+	}
 	json.Unmarshal([]byte(ds), &displaySettings)
 
 	c.JSON(200, gin.H{
@@ -525,8 +591,11 @@ func handleGetConfigMetrics(c *gin.Context) {
 	}
 
 	var total int
-	db.QueryRowContext(c.Request.Context(),
-		`SELECT count(*) FROM github_workflow_metrics WHERE config_id = $1`, configID).Scan(&total)
+	if err := db.QueryRowContext(c.Request.Context(),
+		`SELECT count(*) FROM github_workflow_metrics WHERE config_id = $1`, configID).Scan(&total); err != nil {
+		c.JSON(500, gin.H{"error": err.Error()})
+		return
+	}
 
 	rows, err := db.QueryContext(c.Request.Context(), `
 		SELECT id, source_file, row_data, created_at
@@ -546,7 +615,10 @@ func handleGetConfigMetrics(c *gin.Context) {
 		var sourceFile sql.NullString
 		var rowDataBytes []byte
 		var createdAt time.Time
-		rows.Scan(&mid, &sourceFile, &rowDataBytes, &createdAt)
+		if err := rows.Scan(&mid, &sourceFile, &rowDataBytes, &createdAt); err != nil {
+			c.JSON(500, gin.H{"error": err.Error()})
+			return
+		}
 		m := map[string]interface{}{
 			"id":         mid,
 			"created_at": createdAt.Format(time.RFC3339),
@@ -560,6 +632,10 @@ func handleGetConfigMetrics(c *gin.Context) {
 			m["row_data"] = rd
 		}
 		metrics = append(metrics, m)
+	}
+	if err := rows.Err(); err != nil {
+		c.JSON(500, gin.H{"error": err.Error()})
+		return
 	}
 
 	c.JSON(200, gin.H{
@@ -676,7 +752,10 @@ func handleListRepositories(c *gin.Context) {
 		var owner, repo string
 		var total, running, completed, failed int
 		var latestAt sql.NullTime
-		rows.Scan(&owner, &repo, &total, &running, &completed, &failed, &latestAt)
+		if err := rows.Scan(&owner, &repo, &total, &running, &completed, &failed, &latestAt); err != nil {
+			c.JSON(500, gin.H{"error": err.Error()})
+			return
+		}
 
 		r := map[string]interface{}{
 			"github_owner":   owner,
@@ -692,21 +771,36 @@ func handleListRepositories(c *gin.Context) {
 
 		var configCount int
 		var configIDs []int
-		cfgRows, _ := db.QueryContext(c.Request.Context(),
+		cfgRows, err := db.QueryContext(c.Request.Context(),
 			`SELECT id FROM github_collection_configs WHERE github_owner = $1 AND github_repo = $2`, owner, repo)
-		if cfgRows != nil {
-			for cfgRows.Next() {
-				var cfgID int
-				cfgRows.Scan(&cfgID)
-				configIDs = append(configIDs, cfgID)
-				configCount++
-			}
-			cfgRows.Close()
+		if err != nil {
+			c.JSON(500, gin.H{"error": err.Error()})
+			return
 		}
+		for cfgRows.Next() {
+			var cfgID int
+			if err := cfgRows.Scan(&cfgID); err != nil {
+				cfgRows.Close()
+				c.JSON(500, gin.H{"error": err.Error()})
+				return
+			}
+			configIDs = append(configIDs, cfgID)
+			configCount++
+		}
+		if err := cfgRows.Err(); err != nil {
+			cfgRows.Close()
+			c.JSON(500, gin.H{"error": err.Error()})
+			return
+		}
+		cfgRows.Close()
 		r["config_count"] = configCount
 		r["config_ids"] = configIDs
 
 		repos = append(repos, r)
+	}
+	if err := rows.Err(); err != nil {
+		c.JSON(500, gin.H{"error": err.Error()})
+		return
 	}
 
 	c.JSON(200, gin.H{"repositories": repos, "count": len(repos)})
@@ -721,46 +815,71 @@ func handleGetRepository(c *gin.Context) {
 	}
 
 	var total, running, completed, failed int
-	db.QueryRowContext(c.Request.Context(), `
+	if err := db.QueryRowContext(c.Request.Context(), `
 		SELECT count(*),
 		       count(*) FILTER (WHERE status = 'running'),
 		       count(*) FILTER (WHERE status = 'completed'),
 		       count(*) FILTER (WHERE conclusion = 'failure')
 		FROM github_workflow_runs WHERE github_owner = $1 AND github_repo = $2`,
-		owner, repo).Scan(&total, &running, &completed, &failed)
-
-	wfRows, _ := db.QueryContext(c.Request.Context(),
-		`SELECT DISTINCT workflow_name FROM github_workflow_runs WHERE github_owner = $1 AND github_repo = $2 AND workflow_name != ''`,
-		owner, repo)
-	var workflows []string
-	if wfRows != nil {
-		for wfRows.Next() {
-			var wf string
-			wfRows.Scan(&wf)
-			workflows = append(workflows, wf)
-		}
-		wfRows.Close()
+		owner, repo).Scan(&total, &running, &completed, &failed); err != nil {
+		c.JSON(500, gin.H{"error": err.Error()})
+		return
 	}
 
-	cfgRows, _ := db.QueryContext(c.Request.Context(), `
+	wfRows, err := db.QueryContext(c.Request.Context(),
+		`SELECT DISTINCT workflow_name FROM github_workflow_runs WHERE github_owner = $1 AND github_repo = $2 AND workflow_name != ''`,
+		owner, repo)
+	if err != nil {
+		c.JSON(500, gin.H{"error": err.Error()})
+		return
+	}
+	var workflows []string
+	for wfRows.Next() {
+		var wf string
+		if err := wfRows.Scan(&wf); err != nil {
+			wfRows.Close()
+			c.JSON(500, gin.H{"error": err.Error()})
+			return
+		}
+		workflows = append(workflows, wf)
+	}
+	if err := wfRows.Err(); err != nil {
+		wfRows.Close()
+		c.JSON(500, gin.H{"error": err.Error()})
+		return
+	}
+	wfRows.Close()
+
+	cfgRows, err := db.QueryContext(c.Request.Context(), `
 		SELECT c.id, c.name, c.display_settings::text,
 		       (SELECT count(*) FROM github_workflow_metrics m WHERE m.config_id = c.id) as metrics_count
 		FROM github_collection_configs c
 		WHERE c.github_owner = $1 AND c.github_repo = $2`, owner, repo)
-	var configs []map[string]interface{}
-	if cfgRows != nil {
-		for cfgRows.Next() {
-			var cfgID, metricsCount int
-			var name, dsStr string
-			cfgRows.Scan(&cfgID, &name, &dsStr, &metricsCount)
-			var ds interface{}
-			json.Unmarshal([]byte(dsStr), &ds)
-			configs = append(configs, map[string]interface{}{
-				"id": cfgID, "name": name, "display_settings": ds, "metrics_count": metricsCount,
-			})
-		}
-		cfgRows.Close()
+	if err != nil {
+		c.JSON(500, gin.H{"error": err.Error()})
+		return
 	}
+	var configs []map[string]interface{}
+	for cfgRows.Next() {
+		var cfgID, metricsCount int
+		var name, dsStr string
+		if err := cfgRows.Scan(&cfgID, &name, &dsStr, &metricsCount); err != nil {
+			cfgRows.Close()
+			c.JSON(500, gin.H{"error": err.Error()})
+			return
+		}
+		var ds interface{}
+		json.Unmarshal([]byte(dsStr), &ds)
+		configs = append(configs, map[string]interface{}{
+			"id": cfgID, "name": name, "display_settings": ds, "metrics_count": metricsCount,
+		})
+	}
+	if err := cfgRows.Err(); err != nil {
+		cfgRows.Close()
+		c.JSON(500, gin.H{"error": err.Error()})
+		return
+	}
+	cfgRows.Close()
 
 	c.JSON(200, gin.H{
 		"github_owner":   owner,

--- a/SaFE/apiserver/pkg/handlers/github-workflow/handler.go
+++ b/SaFE/apiserver/pkg/handlers/github-workflow/handler.go
@@ -44,12 +44,27 @@ var getDB = func() *sql.DB {
 	if err != nil {
 		return nil
 	}
-	sqlDB, _ := gormDB.DB()
+	sqlDB, err := gormDB.DB()
+	if err != nil {
+		return nil
+	}
 	return sqlDB
 }
 
-func handleListConfigs(c *gin.Context) {
+func getRequestDB(c *gin.Context) (*sql.DB, bool) {
 	db := getDB()
+	if db == nil {
+		c.JSON(500, gin.H{"error": "database connection unavailable"})
+		return nil, false
+	}
+	return db, true
+}
+
+func handleListConfigs(c *gin.Context) {
+	db, ok := getRequestDB(c)
+	if !ok {
+		return
+	}
 	rows, err := db.QueryContext(c.Request.Context(), `
 		SELECT id, name, github_owner, github_repo, workflow_patterns, branch_patterns,
 		       file_patterns, COALESCE(display_settings::text, '{}'), enabled, COALESCE(created_by, ''), created_at, updated_at
@@ -103,7 +118,10 @@ func handleCreateConfig(c *gin.Context) {
 		displayJSON = []byte("{}")
 	}
 
-	db := getDB()
+	db, ok := getRequestDB(c)
+	if !ok {
+		return
+	}
 	_, err := db.ExecContext(c.Request.Context(), `
 		INSERT INTO github_collection_configs
 			(name, github_owner, github_repo, workflow_patterns, branch_patterns, file_patterns, display_settings, enabled)
@@ -120,13 +138,19 @@ func handleCreateConfig(c *gin.Context) {
 
 func handleDeleteConfig(c *gin.Context) {
 	id := c.Param("id")
-	db := getDB()
+	db, ok := getRequestDB(c)
+	if !ok {
+		return
+	}
 	db.ExecContext(c.Request.Context(), `DELETE FROM github_collection_configs WHERE id = $1`, id)
 	c.JSON(200, gin.H{"deleted": id})
 }
 
 func handleListRuns(c *gin.Context) {
-	db := getDB()
+	db, ok := getRequestDB(c)
+	if !ok {
+		return
+	}
 	owner := c.Query("github_owner")
 	repo := c.Query("github_repo")
 	status := c.Query("status")
@@ -203,7 +227,10 @@ func handleListRuns(c *gin.Context) {
 
 func handleGetRun(c *gin.Context) {
 	id := c.Param("id")
-	db := getDB()
+	db, ok := getRequestDB(c)
+	if !ok {
+		return
+	}
 
 	var wid, cluster, wfName, ghOwner, ghRepo, branch, sha, st, conclusion, syncSt sql.NullString
 	var ghRunID, ghJobID sql.NullInt64
@@ -251,7 +278,10 @@ func handleGetRun(c *gin.Context) {
 
 func handleGetRunJobs(c *gin.Context) {
 	id := c.Param("id")
-	db := getDB()
+	db, ok := getRequestDB(c)
+	if !ok {
+		return
+	}
 
 	rows, err := db.QueryContext(c.Request.Context(), `
 		SELECT j.id, j.github_job_id, j.name, j.status, j.conclusion,
@@ -308,7 +338,10 @@ func handleGetRunJobs(c *gin.Context) {
 
 func handleGetRunMetrics(c *gin.Context) {
 	id := c.Param("id")
-	db := getDB()
+	db, ok := getRequestDB(c)
+	if !ok {
+		return
+	}
 
 	rows, err := db.QueryContext(c.Request.Context(), `
 		SELECT id, config_id, source_file, row_data, timestamp, dimensions, metrics, created_at
@@ -365,7 +398,10 @@ func handleGetRunMetrics(c *gin.Context) {
 
 func handleGetCommit(c *gin.Context) {
 	sha := c.Param("sha")
-	db := getDB()
+	db, ok := getRequestDB(c)
+	if !ok {
+		return
+	}
 
 	var message, authorName, authorEmail, ghOwner, ghRepo string
 	var authoredAt sql.NullTime
@@ -394,7 +430,10 @@ func handleGetCommit(c *gin.Context) {
 }
 
 func handleStats(c *gin.Context) {
-	db := getDB()
+	db, ok := getRequestDB(c)
+	if !ok {
+		return
+	}
 	var total, running, completed, failed int
 	db.QueryRowContext(c.Request.Context(), `SELECT COUNT(*) FROM github_workflow_runs`).Scan(&total)
 	db.QueryRowContext(c.Request.Context(), `SELECT COUNT(*) FROM github_workflow_runs WHERE status='running'`).Scan(&running)
@@ -408,7 +447,10 @@ func handleStats(c *gin.Context) {
 
 func handleGetFields(c *gin.Context) {
 	configID := c.Param("id")
-	db := getDB()
+	db, ok := getRequestDB(c)
+	if !ok {
+		return
+	}
 
 	rows, err := db.QueryContext(c.Request.Context(), `
 		SELECT key,
@@ -466,7 +508,10 @@ func handleGetFields(c *gin.Context) {
 
 func handleGetConfigMetrics(c *gin.Context) {
 	configID := c.Param("id")
-	db := getDB()
+	db, ok := getRequestDB(c)
+	if !ok {
+		return
+	}
 	limit := 500
 	if l := c.Query("limit"); l != "" {
 		limit, _ = strconv.Atoi(l)
@@ -537,7 +582,10 @@ func handleUpdateConfig(c *gin.Context) {
 		return
 	}
 
-	db := getDB()
+	db, ok := getRequestDB(c)
+	if !ok {
+		return
+	}
 	sets := []string{"updated_at = NOW()"}
 	args := []interface{}{}
 	idx := 1
@@ -587,7 +635,10 @@ func handleUpdateConfig(c *gin.Context) {
 }
 
 func handleListRepositories(c *gin.Context) {
-	db := getDB()
+	db, ok := getRequestDB(c)
+	if !ok {
+		return
+	}
 	search := c.Query("search")
 
 	query := `
@@ -661,7 +712,10 @@ func handleListRepositories(c *gin.Context) {
 func handleGetRepository(c *gin.Context) {
 	owner := c.Param("owner")
 	repo := c.Param("repo")
-	db := getDB()
+	db, ok := getRequestDB(c)
+	if !ok {
+		return
+	}
 
 	var total, running, completed, failed int
 	db.QueryRowContext(c.Request.Context(), `

--- a/SaFE/apiserver/pkg/handlers/github-workflow/handler.go
+++ b/SaFE/apiserver/pkg/handlers/github-workflow/handler.go
@@ -61,6 +61,19 @@ func getRequestDB(c *gin.Context) (*sql.DB, bool) {
 	return db, true
 }
 
+func parseIntQuery(c *gin.Context, name string, defaultValue, minValue, maxValue int) (int, bool) {
+	raw := c.Query(name)
+	if raw == "" {
+		return defaultValue, true
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil || value < minValue || value > maxValue {
+		c.JSON(400, gin.H{"error": fmt.Sprintf("%s must be between %d and %d", name, minValue, maxValue)})
+		return 0, false
+	}
+	return value, true
+}
+
 func handleListConfigs(c *gin.Context) {
 	db, ok := getRequestDB(c)
 	if !ok {
@@ -158,7 +171,7 @@ func handleDeleteConfig(c *gin.Context) {
 }
 
 func handleListRuns(c *gin.Context) {
-	db, ok := getRequestDB(c)
+	limit, ok := parseIntQuery(c, "limit", 50, 1, 500)
 	if !ok {
 		return
 	}
@@ -166,9 +179,9 @@ func handleListRuns(c *gin.Context) {
 	repo := c.Query("github_repo")
 	status := c.Query("status")
 	workflow := c.Query("workflow")
-	limit := 50
-	if l := c.Query("limit"); l != "" {
-		limit, _ = strconv.Atoi(l)
+	db, ok := getRequestDB(c)
+	if !ok {
+		return
 	}
 
 	query := `SELECT id, workload_id, cluster, github_run_id, github_job_id, workflow_name,
@@ -577,17 +590,17 @@ func handleGetFields(c *gin.Context) {
 
 func handleGetConfigMetrics(c *gin.Context) {
 	configID := c.Param("id")
-	db, ok := getRequestDB(c)
+	limit, ok := parseIntQuery(c, "limit", 500, 1, 1000)
 	if !ok {
 		return
 	}
-	limit := 500
-	if l := c.Query("limit"); l != "" {
-		limit, _ = strconv.Atoi(l)
+	offset, ok := parseIntQuery(c, "offset", 0, 0, 100000)
+	if !ok {
+		return
 	}
-	offset := 0
-	if o := c.Query("offset"); o != "" {
-		offset, _ = strconv.Atoi(o)
+	db, ok := getRequestDB(c)
+	if !ok {
+		return
 	}
 
 	var total int

--- a/SaFE/apiserver/pkg/handlers/github-workflow/handler_db_test.go
+++ b/SaFE/apiserver/pkg/handlers/github-workflow/handler_db_test.go
@@ -136,6 +136,19 @@ func TestHandleDeleteConfig(t *testing.T) {
 	}
 }
 
+func TestHandleDeleteConfigDBError(t *testing.T) {
+	mock, cleanup := withMockDB(t)
+	defer cleanup()
+	mock.ExpectExec("DELETE FROM github_collection_configs").
+		WillReturnError(sql.ErrConnDone)
+
+	c, w := ctxWith(http.MethodDelete, "/configs/5", "", gin.Params{{Key: "id", Value: "5"}}, "")
+	handleDeleteConfig(c)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+}
+
 // TestHandleListRunsSuccess verifies runs are listed with query filters applied.
 func TestHandleListRunsSuccess(t *testing.T) {
 	mock, cleanup := withMockDB(t)

--- a/SaFE/apiserver/pkg/handlers/github-workflow/handler_db_test.go
+++ b/SaFE/apiserver/pkg/handlers/github-workflow/handler_db_test.go
@@ -477,3 +477,339 @@ func TestHandleGetRepositorySuccess(t *testing.T) {
 		t.Errorf("status = %d, want 200, body=%s", w.Code, w.Body.String())
 	}
 }
+
+func TestHandleCreateConfigNilDB(t *testing.T) {
+	orig := getDB
+	getDB = func() *sql.DB { return nil }
+	defer func() { getDB = orig }()
+
+	body := `{"name":"n","github_owner":"o","github_repo":"r","file_patterns":["*.json"]}`
+	c, w := ctxWith(http.MethodPost, "/configs", body, nil, "")
+	handleCreateConfig(c)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+}
+
+func TestHandleDeleteConfigNilDB(t *testing.T) {
+	orig := getDB
+	getDB = func() *sql.DB { return nil }
+	defer func() { getDB = orig }()
+
+	c, w := ctxWith(http.MethodDelete, "/configs/5", "", gin.Params{{Key: "id", Value: "5"}}, "")
+	handleDeleteConfig(c)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+}
+
+func TestHandleListRunsScanError(t *testing.T) {
+	mock, cleanup := withMockDB(t)
+	defer cleanup()
+
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{
+		"id", "workload_id", "cluster", "github_run_id", "github_job_id", "workflow_name",
+		"github_owner", "github_repo", "head_branch", "head_sha", "status", "conclusion",
+		"sync_status", "started_at", "completed_at", "created_at",
+	}).AddRow("bad-id", "wl", "c", int64(10), int64(20), "wf", "o", "r", "main", "sha", "completed", "success", "synced", now, now, now)
+	mock.ExpectQuery("FROM github_workflow_runs WHERE").WillReturnRows(rows)
+
+	c, w := ctxWith(http.MethodGet, "/runs", "", nil, "")
+	handleListRuns(c)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+}
+
+func TestHandleGetRunNilDB(t *testing.T) {
+	orig := getDB
+	getDB = func() *sql.DB { return nil }
+	defer func() { getDB = orig }()
+
+	c, w := ctxWith(http.MethodGet, "/runs/1", "", gin.Params{{Key: "id", Value: "1"}}, "")
+	handleGetRun(c)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+}
+
+func TestHandleGetRunDetailsDBError(t *testing.T) {
+	mock, cleanup := withMockDB(t)
+	defer cleanup()
+
+	now := time.Now()
+	mock.ExpectQuery("FROM github_workflow_runs WHERE id =").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"workload_id", "cluster", "github_run_id", "github_job_id", "workflow_name",
+			"github_owner", "github_repo", "head_branch", "head_sha", "status", "conclusion",
+			"sync_status", "started_at", "completed_at", "created_at",
+		}).AddRow("wl", "c", int64(1), int64(2), "wf", "o", "r", "main", "sha",
+			"completed", "success", "synced", now, now, now))
+	mock.ExpectQuery("FROM github_workflow_run_details WHERE run_id =").
+		WillReturnError(sql.ErrConnDone)
+
+	c, w := ctxWith(http.MethodGet, "/runs/1", "", gin.Params{{Key: "id", Value: "1"}}, "")
+	handleGetRun(c)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+}
+
+func TestHandleGetRunJobsScanErrors(t *testing.T) {
+	t.Run("job scan", func(t *testing.T) {
+		mock, cleanup := withMockDB(t)
+		defer cleanup()
+
+		rows := sqlmock.NewRows([]string{
+			"id", "github_job_id", "name", "status", "conclusion",
+			"started_at", "completed_at", "runner_name",
+		}).AddRow("bad-id", int64(5), "build", "completed", "success", time.Now(), time.Now(), "runner-1")
+		mock.ExpectQuery("FROM github_workflow_jobs j WHERE j.run_id =").WillReturnRows(rows)
+
+		c, w := ctxWith(http.MethodGet, "/runs/1/jobs", "", gin.Params{{Key: "id", Value: "1"}}, "")
+		handleGetRunJobs(c)
+		if w.Code != http.StatusInternalServerError {
+			t.Errorf("status = %d, want 500", w.Code)
+		}
+	})
+
+	t.Run("step scan", func(t *testing.T) {
+		mock, cleanup := withMockDB(t)
+		defer cleanup()
+
+		now := time.Now()
+		mock.ExpectQuery("FROM github_workflow_jobs j WHERE j.run_id =").
+			WillReturnRows(sqlmock.NewRows([]string{
+				"id", "github_job_id", "name", "status", "conclusion",
+				"started_at", "completed_at", "runner_name",
+			}).AddRow(1, int64(5), "build", "completed", "success", now, now, "runner-1"))
+		mock.ExpectQuery("FROM github_workflow_steps WHERE job_id =").
+			WillReturnRows(sqlmock.NewRows([]string{
+				"step_number", "name", "status", "conclusion", "duration_seconds",
+			}).AddRow("bad-step", "checkout", "completed", "success", 12))
+
+		c, w := ctxWith(http.MethodGet, "/runs/1/jobs", "", gin.Params{{Key: "id", Value: "1"}}, "")
+		handleGetRunJobs(c)
+		if w.Code != http.StatusInternalServerError {
+			t.Errorf("status = %d, want 500", w.Code)
+		}
+	})
+}
+
+func TestHandleGetRunMetricsScanError(t *testing.T) {
+	mock, cleanup := withMockDB(t)
+	defer cleanup()
+
+	rows := sqlmock.NewRows([]string{
+		"id", "config_id", "source_file", "row_data", "timestamp", "dimensions", "metrics", "created_at",
+	}).AddRow("bad-id", int64(2), "f.json", []byte(`{"a":1}`), time.Now(), []byte(`{"d":"x"}`), []byte(`{"m":2}`), time.Now())
+	mock.ExpectQuery("FROM github_workflow_metrics WHERE run_id =").WillReturnRows(rows)
+
+	c, w := ctxWith(http.MethodGet, "/runs/1/metrics", "", gin.Params{{Key: "id", Value: "1"}}, "")
+	handleGetRunMetrics(c)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+}
+
+func TestHandleStatsLaterCountErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		failIndex int
+	}{
+		{"running", 1},
+		{"completed", 2},
+		{"failed", 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock, cleanup := withMockDB(t)
+			defer cleanup()
+
+			patterns := []string{
+				"SELECT COUNT\\(\\*\\) FROM github_workflow_runs$",
+				"status='running'",
+				"status='completed'",
+				"conclusion='failure'",
+			}
+			for i, pattern := range patterns {
+				if i == tt.failIndex {
+					mock.ExpectQuery(pattern).WillReturnError(sql.ErrConnDone)
+					break
+				}
+				mock.ExpectQuery(pattern).WillReturnRows(sqlmock.NewRows([]string{"c"}).AddRow(1))
+			}
+
+			c, w := ctxWith(http.MethodGet, "/stats", "", nil, "")
+			handleStats(c)
+			if w.Code != http.StatusInternalServerError {
+				t.Errorf("status = %d, want 500", w.Code)
+			}
+		})
+	}
+}
+
+func TestHandleGetFieldsErrors(t *testing.T) {
+	t.Run("scan error", func(t *testing.T) {
+		mock, cleanup := withMockDB(t)
+		defer cleanup()
+		mock.ExpectQuery("jsonb_each_text").
+			WillReturnRows(sqlmock.NewRows([]string{"key", "total", "numeric_count", "distinct_count"}).
+				AddRow("latency", "bad-total", 90, 50))
+
+		c, w := ctxWith(http.MethodGet, "/configs/2/fields", "", gin.Params{{Key: "id", Value: "2"}}, "")
+		handleGetFields(c)
+		if w.Code != http.StatusInternalServerError {
+			t.Errorf("status = %d, want 500", w.Code)
+		}
+	})
+
+	t.Run("display settings error", func(t *testing.T) {
+		mock, cleanup := withMockDB(t)
+		defer cleanup()
+		mock.ExpectQuery("jsonb_each_text").
+			WillReturnRows(sqlmock.NewRows([]string{"key", "total", "numeric_count", "distinct_count"}).
+				AddRow("latency", 100, 90, 50))
+		mock.ExpectQuery("FROM github_collection_configs WHERE id =").WillReturnError(sql.ErrConnDone)
+
+		c, w := ctxWith(http.MethodGet, "/configs/2/fields", "", gin.Params{{Key: "id", Value: "2"}}, "")
+		handleGetFields(c)
+		if w.Code != http.StatusInternalServerError {
+			t.Errorf("status = %d, want 500", w.Code)
+		}
+	})
+}
+
+func TestHandleGetConfigMetricsErrors(t *testing.T) {
+	t.Run("invalid limit", func(t *testing.T) {
+		c, w := ctxWith(http.MethodGet, "/configs/2/metrics", "", gin.Params{{Key: "id", Value: "2"}}, "limit=bad")
+		handleGetConfigMetrics(c)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400", w.Code)
+		}
+	})
+
+	t.Run("count error", func(t *testing.T) {
+		mock, cleanup := withMockDB(t)
+		defer cleanup()
+		mock.ExpectQuery("count\\(\\*\\) FROM github_workflow_metrics WHERE config_id =").WillReturnError(sql.ErrConnDone)
+
+		c, w := ctxWith(http.MethodGet, "/configs/2/metrics", "", gin.Params{{Key: "id", Value: "2"}}, "")
+		handleGetConfigMetrics(c)
+		if w.Code != http.StatusInternalServerError {
+			t.Errorf("status = %d, want 500", w.Code)
+		}
+	})
+
+	t.Run("scan error", func(t *testing.T) {
+		mock, cleanup := withMockDB(t)
+		defer cleanup()
+		mock.ExpectQuery("count\\(\\*\\) FROM github_workflow_metrics WHERE config_id =").
+			WillReturnRows(sqlmock.NewRows([]string{"c"}).AddRow(1))
+		mock.ExpectQuery("FROM github_workflow_metrics").
+			WillReturnRows(sqlmock.NewRows([]string{
+				"id", "source_file", "row_data", "created_at",
+			}).AddRow("bad-id", "f.json", []byte(`{"a":1}`), time.Now()))
+
+		c, w := ctxWith(http.MethodGet, "/configs/2/metrics", "", gin.Params{{Key: "id", Value: "2"}}, "")
+		handleGetConfigMetrics(c)
+		if w.Code != http.StatusInternalServerError {
+			t.Errorf("status = %d, want 500", w.Code)
+		}
+	})
+}
+
+func TestHandleUpdateConfigNilDB(t *testing.T) {
+	orig := getDB
+	getDB = func() *sql.DB { return nil }
+	defer func() { getDB = orig }()
+
+	c, w := ctxWith(http.MethodPut, "/configs/2", `{"name":"n"}`, gin.Params{{Key: "id", Value: "2"}}, "")
+	handleUpdateConfig(c)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+}
+
+func TestHandleListRepositoriesErrors(t *testing.T) {
+	t.Run("scan error", func(t *testing.T) {
+		mock, cleanup := withMockDB(t)
+		defer cleanup()
+		mock.ExpectQuery("FROM github_workflow_runs r").
+			WillReturnRows(sqlmock.NewRows([]string{
+				"github_owner", "github_repo", "total_runs", "running_runs", "completed_runs", "failed_runs", "latest_run_at",
+			}).AddRow("o", "r", "bad-total", 1, 8, 1, time.Now()))
+
+		c, w := ctxWith(http.MethodGet, "/repositories", "", nil, "")
+		handleListRepositories(c)
+		if w.Code != http.StatusInternalServerError {
+			t.Errorf("status = %d, want 500", w.Code)
+		}
+	})
+
+	t.Run("config query error", func(t *testing.T) {
+		mock, cleanup := withMockDB(t)
+		defer cleanup()
+		mock.ExpectQuery("FROM github_workflow_runs r").
+			WillReturnRows(sqlmock.NewRows([]string{
+				"github_owner", "github_repo", "total_runs", "running_runs", "completed_runs", "failed_runs", "latest_run_at",
+			}).AddRow("o", "r", 10, 1, 8, 1, time.Now()))
+		mock.ExpectQuery("SELECT id FROM github_collection_configs WHERE").WillReturnError(sql.ErrConnDone)
+
+		c, w := ctxWith(http.MethodGet, "/repositories", "", nil, "")
+		handleListRepositories(c)
+		if w.Code != http.StatusInternalServerError {
+			t.Errorf("status = %d, want 500", w.Code)
+		}
+	})
+}
+
+func TestHandleGetRepositoryErrors(t *testing.T) {
+	t.Run("count error", func(t *testing.T) {
+		mock, cleanup := withMockDB(t)
+		defer cleanup()
+		mock.ExpectQuery("FROM github_workflow_runs WHERE github_owner =").WillReturnError(sql.ErrConnDone)
+
+		c, w := ctxWith(http.MethodGet, "/repositories/o/r", "",
+			gin.Params{{Key: "owner", Value: "o"}, {Key: "repo", Value: "r"}}, "")
+		handleGetRepository(c)
+		if w.Code != http.StatusInternalServerError {
+			t.Errorf("status = %d, want 500", w.Code)
+		}
+	})
+
+	t.Run("workflow query error", func(t *testing.T) {
+		mock, cleanup := withMockDB(t)
+		defer cleanup()
+		mock.ExpectQuery("FROM github_workflow_runs WHERE github_owner =").
+			WillReturnRows(sqlmock.NewRows([]string{"total", "running", "completed", "failed"}).AddRow(5, 1, 3, 1))
+		mock.ExpectQuery("SELECT DISTINCT workflow_name FROM github_workflow_runs").WillReturnError(sql.ErrConnDone)
+
+		c, w := ctxWith(http.MethodGet, "/repositories/o/r", "",
+			gin.Params{{Key: "owner", Value: "o"}, {Key: "repo", Value: "r"}}, "")
+		handleGetRepository(c)
+		if w.Code != http.StatusInternalServerError {
+			t.Errorf("status = %d, want 500", w.Code)
+		}
+	})
+
+	t.Run("config scan error", func(t *testing.T) {
+		mock, cleanup := withMockDB(t)
+		defer cleanup()
+		mock.ExpectQuery("FROM github_workflow_runs WHERE github_owner =").
+			WillReturnRows(sqlmock.NewRows([]string{"total", "running", "completed", "failed"}).AddRow(5, 1, 3, 1))
+		mock.ExpectQuery("SELECT DISTINCT workflow_name FROM github_workflow_runs").
+			WillReturnRows(sqlmock.NewRows([]string{"workflow_name"}).AddRow("ci"))
+		mock.ExpectQuery("FROM github_collection_configs c").
+			WillReturnRows(sqlmock.NewRows([]string{"id", "name", "display_settings", "metrics_count"}).
+				AddRow("bad-id", "cfg", "{}", 7))
+
+		c, w := ctxWith(http.MethodGet, "/repositories/o/r", "",
+			gin.Params{{Key: "owner", Value: "o"}, {Key: "repo", Value: "r"}}, "")
+		handleGetRepository(c)
+		if w.Code != http.StatusInternalServerError {
+			t.Errorf("status = %d, want 500", w.Code)
+		}
+	})
+}

--- a/SaFE/apiserver/pkg/handlers/github-workflow/handler_db_test.go
+++ b/SaFE/apiserver/pkg/handlers/github-workflow/handler_db_test.go
@@ -75,6 +75,24 @@ func TestHandleListConfigsError(t *testing.T) {
 	}
 }
 
+func TestHandleListConfigsScanError(t *testing.T) {
+	mock, cleanup := withMockDB(t)
+	defer cleanup()
+
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{
+		"id", "name", "github_owner", "github_repo", "workflow_patterns", "branch_patterns",
+		"file_patterns", "display_settings", "enabled", "created_by", "created_at", "updated_at",
+	}).AddRow("bad-id", "cfg", "o", "r", "{a}", "{b}", "{c}", "{}", true, "user", now, now)
+	mock.ExpectQuery("SELECT id, name, github_owner").WillReturnRows(rows)
+
+	c, w := ctxWith(http.MethodGet, "/configs", "", nil, "")
+	handleListConfigs(c)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+}
+
 func TestHandleListConfigsNilDBReturnsError(t *testing.T) {
 	orig := getDB
 	getDB = func() *sql.DB { return nil }
@@ -267,6 +285,19 @@ func TestHandleStats(t *testing.T) {
 	}
 }
 
+func TestHandleStatsCountError(t *testing.T) {
+	mock, cleanup := withMockDB(t)
+	defer cleanup()
+
+	mock.ExpectQuery("SELECT COUNT\\(\\*\\) FROM github_workflow_runs$").WillReturnError(sql.ErrConnDone)
+
+	c, w := ctxWith(http.MethodGet, "/stats", "", nil, "")
+	handleStats(c)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+}
+
 // TestHandleGetRunJobsSuccess verifies jobs and their steps are rendered.
 func TestHandleGetRunJobsSuccess(t *testing.T) {
 	mock, cleanup := withMockDB(t)
@@ -287,6 +318,26 @@ func TestHandleGetRunJobsSuccess(t *testing.T) {
 	handleGetRunJobs(c)
 	if w.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200, body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleGetRunJobsStepQueryError(t *testing.T) {
+	mock, cleanup := withMockDB(t)
+	defer cleanup()
+
+	now := time.Now()
+	mock.ExpectQuery("FROM github_workflow_jobs j WHERE j.run_id =").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "github_job_id", "name", "status", "conclusion",
+			"started_at", "completed_at", "runner_name",
+		}).AddRow(1, int64(5), "build", "completed", "success", now, now, "runner-1"))
+	mock.ExpectQuery("FROM github_workflow_steps WHERE job_id =").
+		WillReturnError(sql.ErrConnDone)
+
+	c, w := ctxWith(http.MethodGet, "/runs/1/jobs", "", gin.Params{{Key: "id", Value: "1"}}, "")
+	handleGetRunJobs(c)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
 	}
 }
 

--- a/SaFE/apiserver/pkg/handlers/github-workflow/handler_db_test.go
+++ b/SaFE/apiserver/pkg/handlers/github-workflow/handler_db_test.go
@@ -75,6 +75,24 @@ func TestHandleListConfigsError(t *testing.T) {
 	}
 }
 
+func TestHandleListConfigsNilDBReturnsError(t *testing.T) {
+	orig := getDB
+	getDB = func() *sql.DB { return nil }
+	defer func() { getDB = orig }()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("handleListConfigs panicked with nil DB: %v", r)
+		}
+	}()
+
+	c, w := ctxWith(http.MethodGet, "/configs", "", nil, "")
+	handleListConfigs(c)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+}
+
 // TestHandleCreateConfigSuccess verifies a valid request inserts and returns 201.
 func TestHandleCreateConfigSuccess(t *testing.T) {
 	mock, cleanup := withMockDB(t)

--- a/SaFE/apiserver/pkg/handlers/github-workflow/handler_db_test.go
+++ b/SaFE/apiserver/pkg/handlers/github-workflow/handler_db_test.go
@@ -200,6 +200,22 @@ func TestHandleListRunsError(t *testing.T) {
 	}
 }
 
+func TestHandleListRunsInvalidLimit(t *testing.T) {
+	c, w := ctxWith(http.MethodGet, "/runs", "", nil, "limit=-1")
+	handleListRuns(c)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleListRunsLimitTooLarge(t *testing.T) {
+	c, w := ctxWith(http.MethodGet, "/runs", "", nil, "limit=10000")
+	handleListRuns(c)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
 // TestHandleGetRunNotFound verifies a missing run yields a 404.
 func TestHandleGetRunNotFound(t *testing.T) {
 	mock, cleanup := withMockDB(t)
@@ -376,6 +392,14 @@ func TestHandleGetConfigMetricsSuccess(t *testing.T) {
 	handleGetConfigMetrics(c)
 	if w.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200, body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleGetConfigMetricsInvalidOffset(t *testing.T) {
+	c, w := ctxWith(http.MethodGet, "/configs/2/metrics", "", gin.Params{{Key: "id", Value: "2"}}, "offset=-1")
+	handleGetConfigMetrics(c)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
 	}
 }
 

--- a/SaFE/apiserver/pkg/handlers/github-workflow/handler_db_test.go
+++ b/SaFE/apiserver/pkg/handlers/github-workflow/handler_db_test.go
@@ -167,6 +167,19 @@ func TestHandleDeleteConfigDBError(t *testing.T) {
 	}
 }
 
+func TestHandleDeleteConfigNotFound(t *testing.T) {
+	mock, cleanup := withMockDB(t)
+	defer cleanup()
+	mock.ExpectExec("DELETE FROM github_collection_configs").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	c, w := ctxWith(http.MethodDelete, "/configs/5", "", gin.Params{{Key: "id", Value: "5"}}, "")
+	handleDeleteConfig(c)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
 // TestHandleListRunsSuccess verifies runs are listed with query filters applied.
 func TestHandleListRunsSuccess(t *testing.T) {
 	mock, cleanup := withMockDB(t)
@@ -226,6 +239,18 @@ func TestHandleGetRunNotFound(t *testing.T) {
 	handleGetRun(c)
 	if w.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestHandleGetRunDBError(t *testing.T) {
+	mock, cleanup := withMockDB(t)
+	defer cleanup()
+	mock.ExpectQuery("FROM github_workflow_runs WHERE id =").WillReturnError(sql.ErrConnDone)
+
+	c, w := ctxWith(http.MethodGet, "/runs/1", "", gin.Params{{Key: "id", Value: "1"}}, "")
+	handleGetRun(c)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
 	}
 }
 

--- a/SaFE/apiserver/pkg/handlers/github-workflow/handler_test.go
+++ b/SaFE/apiserver/pkg/handlers/github-workflow/handler_test.go
@@ -37,6 +37,30 @@ func TestRegisterRoutes(t *testing.T) {
 	}
 }
 
+func TestRegisterRoutesRequiresAuthorization(t *testing.T) {
+	oldGetDB := getDB
+	dbCalled := false
+	getDB = func() *sql.DB {
+		dbCalled = true
+		return nil
+	}
+	defer func() { getDB = oldGetDB }()
+
+	engine := gin.New()
+	RegisterRoutes(&engine.RouterGroup)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/github-workflow/stats", nil)
+	engine.ServeHTTP(w, req)
+
+	if w.Code == http.StatusOK {
+		t.Fatalf("status = %d, want authorization failure", w.Code)
+	}
+	if dbCalled {
+		t.Fatal("unauthorized request reached DB handler")
+	}
+}
+
 // TestHandleCreateConfig covers the request-validation branch (no DB access).
 func TestHandleCreateConfig(t *testing.T) {
 	c, w := newCtx(http.MethodPost, `{}`)

--- a/SaFE/resource-manager/pkg/ops_job/controllers_extra_test.go
+++ b/SaFE/resource-manager/pkg/ops_job/controllers_extra_test.go
@@ -325,3 +325,52 @@ func TestRebootExecRebootViaSSH(t *testing.T) {
 	err := r.execReboot(context.Background(), "j1", "n1")
 	assert.NoError(t, err)
 }
+
+func TestRebootExecRebootSSHCommandError(t *testing.T) {
+	sshClient, cleanup := startInMemorySSHServer(t)
+	defer cleanup()
+	sshClient.Close()
+
+	node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1"}}
+	job := rebootJob("j1", "n1")
+	r := &RebootJobReconciler{OpsJobBaseReconciler: newBaseWithObjs(t, node, job)}
+
+	patches := gomonkey.ApplyFunc(rmutils.GetSSHClient,
+		func(_ context.Context, _ client.Client, _ *v1.Node) (*ssh.Client, error) {
+			return sshClient, nil
+		})
+	defer patches.Reset()
+
+	err := r.execReboot(context.Background(), "j1", "n1")
+	assert.Error(t, err)
+
+	updated := &v1.OpsJob{}
+	assert.NoError(t, r.Get(context.Background(), client.ObjectKey{Name: "j1"}, updated))
+	assert.Len(t, updated.Status.Outputs, 0)
+}
+
+func TestRebootHandleSSHCommandErrorMarksJobFailed(t *testing.T) {
+	sshClient, cleanup := startInMemorySSHServer(t)
+	defer cleanup()
+	sshClient.Close()
+
+	node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1"}}
+	job := rebootJob("j1", "n1")
+	job.Status.Phase = v1.OpsJobRunning
+	job.Status.StartedAt = &metav1.Time{Time: time.Now()}
+	r := &RebootJobReconciler{OpsJobBaseReconciler: newBaseWithObjs(t, node, job)}
+
+	patches := gomonkey.ApplyFunc(rmutils.GetSSHClient,
+		func(_ context.Context, _ client.Client, _ *v1.Node) (*ssh.Client, error) {
+			return sshClient, nil
+		})
+	defer patches.Reset()
+
+	_, err := r.handle(context.Background(), job)
+	assert.NoError(t, err)
+
+	updated := &v1.OpsJob{}
+	assert.NoError(t, r.Get(context.Background(), client.ObjectKey{Name: "j1"}, updated))
+	assert.Equal(t, v1.OpsJobFailed, updated.Status.Phase)
+	assert.Len(t, updated.Status.Outputs, 0)
+}

--- a/SaFE/resource-manager/pkg/ops_job/controllers_extra_test.go
+++ b/SaFE/resource-manager/pkg/ops_job/controllers_extra_test.go
@@ -7,6 +7,8 @@ package ops_job
 
 import (
 	"context"
+	"errors"
+	"io"
 	"testing"
 	"time"
 
@@ -346,6 +348,12 @@ func TestRebootExecRebootTreatsMissingExitStatusAsSuccess(t *testing.T) {
 	updated := &v1.OpsJob{}
 	assert.NoError(t, r.Get(context.Background(), client.ObjectKey{Name: "j1"}, updated))
 	assert.Equal(t, []v1.Parameter{{Name: v1.ParameterNode, Value: "n1"}}, updated.Status.Outputs)
+}
+
+func TestRebootExpectedDisconnectMatching(t *testing.T) {
+	assert.True(t, isExpectedRebootDisconnect(io.EOF))
+	assert.True(t, isExpectedRebootDisconnect(errors.New("read tcp: use of closed network connection")))
+	assert.False(t, isExpectedRebootDisconnect(errors.New("geo_failure")))
 }
 
 func TestRebootExecRebootSSHCommandError(t *testing.T) {

--- a/SaFE/resource-manager/pkg/ops_job/controllers_extra_test.go
+++ b/SaFE/resource-manager/pkg/ops_job/controllers_extra_test.go
@@ -374,3 +374,29 @@ func TestRebootHandleSSHCommandErrorMarksJobFailed(t *testing.T) {
 	assert.Equal(t, v1.OpsJobFailed, updated.Status.Phase)
 	assert.Len(t, updated.Status.Outputs, 0)
 }
+
+func TestRebootHandlePreservesCompletedOutputsOnLaterFailure(t *testing.T) {
+	sshClient, cleanup := startInMemorySSHServer(t)
+	defer cleanup()
+
+	node1 := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1"}}
+	node2 := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n2"}}
+	job := rebootJob("j1", "n1", "n2")
+	job.Status.Phase = v1.OpsJobRunning
+	job.Status.StartedAt = &metav1.Time{Time: time.Now()}
+	r := &RebootJobReconciler{OpsJobBaseReconciler: newBaseWithObjs(t, node1, node2, job)}
+
+	patches := gomonkey.ApplyFunc(rmutils.GetSSHClient,
+		func(_ context.Context, _ client.Client, _ *v1.Node) (*ssh.Client, error) {
+			return sshClient, nil
+		})
+	defer patches.Reset()
+
+	_, err := r.handle(context.Background(), job)
+	assert.NoError(t, err)
+
+	updated := &v1.OpsJob{}
+	assert.NoError(t, r.Get(context.Background(), client.ObjectKey{Name: "j1"}, updated))
+	assert.Equal(t, v1.OpsJobFailed, updated.Status.Phase)
+	assert.Equal(t, []v1.Parameter{{Name: v1.ParameterNode, Value: "n1"}}, updated.Status.Outputs)
+}

--- a/SaFE/resource-manager/pkg/ops_job/controllers_extra_test.go
+++ b/SaFE/resource-manager/pkg/ops_job/controllers_extra_test.go
@@ -326,6 +326,28 @@ func TestRebootExecRebootViaSSH(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestRebootExecRebootTreatsMissingExitStatusAsSuccess(t *testing.T) {
+	sshClient, cleanup := startInMemorySSHServerWithoutExitStatus(t)
+	defer cleanup()
+
+	node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1"}}
+	job := rebootJob("j1", "n1")
+	r := &RebootJobReconciler{OpsJobBaseReconciler: newBaseWithObjs(t, node, job)}
+
+	patches := gomonkey.ApplyFunc(rmutils.GetSSHClient,
+		func(_ context.Context, _ client.Client, _ *v1.Node) (*ssh.Client, error) {
+			return sshClient, nil
+		})
+	defer patches.Reset()
+
+	err := r.execReboot(context.Background(), "j1", "n1")
+	assert.NoError(t, err)
+
+	updated := &v1.OpsJob{}
+	assert.NoError(t, r.Get(context.Background(), client.ObjectKey{Name: "j1"}, updated))
+	assert.Equal(t, []v1.Parameter{{Name: v1.ParameterNode, Value: "n1"}}, updated.Status.Outputs)
+}
+
 func TestRebootExecRebootSSHCommandError(t *testing.T) {
 	sshClient, cleanup := startInMemorySSHServer(t)
 	defer cleanup()

--- a/SaFE/resource-manager/pkg/ops_job/reboot_job_controller.go
+++ b/SaFE/resource-manager/pkg/ops_job/reboot_job_controller.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -161,11 +162,13 @@ func isExpectedRebootDisconnect(err error) bool {
 	if errors.As(err, &exitMissing) {
 		return true
 	}
+	if errors.Is(err, io.EOF) {
+		return true
+	}
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "use of closed network connection") ||
 		strings.Contains(msg, "connection reset by peer") ||
-		strings.Contains(msg, "broken pipe") ||
-		strings.Contains(msg, "eof")
+		strings.Contains(msg, "broken pipe")
 }
 
 // setJobOutput sets the job output for the specified node.

--- a/SaFE/resource-manager/pkg/ops_job/reboot_job_controller.go
+++ b/SaFE/resource-manager/pkg/ops_job/reboot_job_controller.go
@@ -8,7 +8,9 @@ package ops_job
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
@@ -118,7 +120,7 @@ func (r *RebootJobReconciler) execReboot(ctx context.Context, jobId, nodeId stri
 	defer sshClient.Close()
 
 	cmd := "sudo reboot"
-	if _, err = r.executeSSHCommand(sshClient, cmd); err != nil {
+	if err = r.executeRebootCommand(sshClient, cmd); err != nil {
 		return fmt.Errorf("failed to reboot node %s: %w", node.Name, err)
 	}
 	klog.Infof("machine node %s reboot", node.Name)
@@ -136,6 +138,34 @@ func (r *RebootJobReconciler) getLatestJobOutputs(ctx context.Context, jobId str
 		return nil, err
 	}
 	return job.Status.Outputs, nil
+}
+
+func (r *RebootJobReconciler) executeRebootCommand(sshClient *ssh.Client, command string) error {
+	session, err := sshClient.NewSession()
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	if err = session.Start(command); err != nil {
+		return err
+	}
+	if err = session.Wait(); err != nil && !isExpectedRebootDisconnect(err) {
+		return err
+	}
+	return nil
+}
+
+func isExpectedRebootDisconnect(err error) bool {
+	var exitMissing *ssh.ExitMissingError
+	if errors.As(err, &exitMissing) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "use of closed network connection") ||
+		strings.Contains(msg, "connection reset by peer") ||
+		strings.Contains(msg, "broken pipe") ||
+		strings.Contains(msg, "eof")
 }
 
 // setJobOutput sets the job output for the specified node.

--- a/SaFE/resource-manager/pkg/ops_job/reboot_job_controller.go
+++ b/SaFE/resource-manager/pkg/ops_job/reboot_job_controller.go
@@ -90,6 +90,10 @@ func (r *RebootJobReconciler) handle(ctx context.Context, job *v1.OpsJob) (ctrlr
 	for _, nodeId := range nodes {
 		if err := r.execReboot(ctx, job.Name, nodeId); err != nil {
 			klog.Errorf("failed to execute reboot job %s node %s: %v", job.Name, nodeId, err)
+			if completeErr := r.setJobCompleted(ctx, job, v1.OpsJobFailed, err.Error(), job.Status.Outputs); completeErr != nil {
+				return ctrlruntime.Result{}, completeErr
+			}
+			return ctrlruntime.Result{}, nil
 		}
 	}
 
@@ -110,7 +114,9 @@ func (r *RebootJobReconciler) execReboot(ctx context.Context, jobId, nodeId stri
 	defer sshClient.Close()
 
 	cmd := "sudo reboot"
-	_, _ = r.executeSSHCommand(sshClient, cmd)
+	if _, err = r.executeSSHCommand(sshClient, cmd); err != nil {
+		return fmt.Errorf("failed to reboot node %s: %w", node.Name, err)
+	}
 	klog.Infof("machine node %s reboot", node.Name)
 
 	if err = r.setJobOutput(ctx, jobId, nodeId); err != nil {

--- a/SaFE/resource-manager/pkg/ops_job/reboot_job_controller.go
+++ b/SaFE/resource-manager/pkg/ops_job/reboot_job_controller.go
@@ -90,7 +90,11 @@ func (r *RebootJobReconciler) handle(ctx context.Context, job *v1.OpsJob) (ctrlr
 	for _, nodeId := range nodes {
 		if err := r.execReboot(ctx, job.Name, nodeId); err != nil {
 			klog.Errorf("failed to execute reboot job %s node %s: %v", job.Name, nodeId, err)
-			if completeErr := r.setJobCompleted(ctx, job, v1.OpsJobFailed, err.Error(), job.Status.Outputs); completeErr != nil {
+			outputs, outputErr := r.getLatestJobOutputs(ctx, job.Name)
+			if outputErr != nil {
+				return ctrlruntime.Result{}, outputErr
+			}
+			if completeErr := r.setJobCompleted(ctx, job, v1.OpsJobFailed, err.Error(), outputs); completeErr != nil {
 				return ctrlruntime.Result{}, completeErr
 			}
 			return ctrlruntime.Result{}, nil
@@ -124,6 +128,14 @@ func (r *RebootJobReconciler) execReboot(ctx context.Context, jobId, nodeId stri
 	}
 
 	return nil
+}
+
+func (r *RebootJobReconciler) getLatestJobOutputs(ctx context.Context, jobId string) ([]v1.Parameter, error) {
+	job := &v1.OpsJob{}
+	if err := r.Get(ctx, client.ObjectKey{Name: jobId}, job); err != nil {
+		return nil, err
+	}
+	return job.Status.Outputs, nil
 }
 
 // setJobOutput sets the job output for the specified node.

--- a/SaFE/resource-manager/pkg/ops_job/ssh_helper_test.go
+++ b/SaFE/resource-manager/pkg/ops_job/ssh_helper_test.go
@@ -20,6 +20,23 @@ import (
 // paths without a real remote host.
 func startInMemorySSHServer(t *testing.T) (*ssh.Client, func()) {
 	t.Helper()
+	return startInMemorySSHServerWithExecHandler(t, func(_ *ssh.Request, channel ssh.Channel) {
+		// Send exit-status 0 and close.
+		_, _ = channel.SendRequest("exit-status", false, []byte{0, 0, 0, 0})
+		_ = channel.Close()
+	})
+}
+
+func startInMemorySSHServerWithoutExitStatus(t *testing.T) (*ssh.Client, func()) {
+	t.Helper()
+	return startInMemorySSHServerWithExecHandler(t, func(_ *ssh.Request, channel ssh.Channel) {
+		// A real reboot can drop the SSH session before an exit status is sent.
+		_ = channel.Close()
+	})
+}
+
+func startInMemorySSHServerWithExecHandler(t *testing.T, execHandler func(*ssh.Request, ssh.Channel)) (*ssh.Client, func()) {
+	t.Helper()
 
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
@@ -49,7 +66,7 @@ func startInMemorySSHServer(t *testing.T) (*ssh.Client, func()) {
 				continue
 			}
 			go ssh.DiscardRequests(reqs)
-			go handleSSHChannels(chans)
+			go handleSSHChannels(chans, execHandler)
 			_ = sconn
 		}
 	}()
@@ -79,7 +96,7 @@ func dialOpsJobSSH() (*ssh.Client, error) {
 	return ssh.Dial("tcp", opsJobSSHAddr, clientConf)
 }
 
-func handleSSHChannels(chans <-chan ssh.NewChannel) {
+func handleSSHChannels(chans <-chan ssh.NewChannel, execHandler func(*ssh.Request, ssh.Channel)) {
 	for newChan := range chans {
 		if newChan.ChannelType() != "session" {
 			_ = newChan.Reject(ssh.UnknownChannelType, "only session supported")
@@ -96,9 +113,7 @@ func handleSSHChannels(chans <-chan ssh.NewChannel) {
 					if req.WantReply {
 						_ = req.Reply(true, nil)
 					}
-					// Send exit-status 0 and close.
-					_, _ = channel.SendRequest("exit-status", false, []byte{0, 0, 0, 0})
-					_ = channel.Close()
+					execHandler(req, channel)
 				default:
 					if req.WantReply {
 						_ = req.Reply(false, nil)

--- a/SaFE/resource-manager/pkg/resource/node_controller.go
+++ b/SaFE/resource-manager/pkg/resource/node_controller.go
@@ -772,6 +772,14 @@ func (r *NodeReconciler) manage(ctx context.Context, adminNode *v1.Node, k8sNode
 		if err = r.deletePods(ctx, adminNode.GetSpecCluster(), adminNode.Name, string(v1.ClusterScaleUpAction)); err != nil {
 			return ctrlruntime.Result{}, err
 		}
+		if v1.GetClusterId(adminNode) != adminNode.GetSpecCluster() {
+			patch := client.MergeFrom(adminNode.DeepCopy())
+			v1.SetLabel(adminNode, v1.ClusterIdLabel, adminNode.GetSpecCluster())
+			if err = r.Patch(ctx, adminNode, patch); err != nil {
+				return ctrlruntime.Result{}, err
+			}
+		}
+		adminNode.Status.ClusterStatus.Cluster = adminNode.Spec.Cluster
 		adminNode.Status.ClusterStatus.Phase = v1.NodeManaged
 		klog.Infof("managed node %s", k8sNode.Name)
 		if stringutil.StrCaseEqual(v1.GetLabel(adminNode, v1.NodeManageRebootLabel), v1.TrueStr) {
@@ -821,7 +829,7 @@ func (r *NodeReconciler) syncLabelsToK8sNode(ctx context.Context,
 		labels[v1.NodeIdLabel] = adminNode.Name
 	}
 	annotations := map[string]string{
-		v1.NodeDiskAnnotation: v1.GetAnnotation(adminNode, v1.NodeDiskAnnotation),
+		v1.NodeDiskAnnotation:   v1.GetAnnotation(adminNode, v1.NodeDiskAnnotation),
 		v1.NodeSubnetAnnotation: v1.GetAnnotation(adminNode, v1.NodeSubnetAnnotation),
 	}
 

--- a/SaFE/resource-manager/pkg/resource/node_controller_test.go
+++ b/SaFE/resource-manager/pkg/resource/node_controller_test.go
@@ -21,6 +21,7 @@ import (
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
+	ctrlruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -446,7 +447,6 @@ func TestClearConditions(t *testing.T) {
 }
 
 func TestManageNodeSuccessfully(t *testing.T) {
-	t.Skip("TODO: Test needs reconcile logic to sync cluster info from adminNode to k8sNode")
 	nodeFlavor := genMockNodeFlavor()
 	cluster := genMockCluster()
 	adminNode := genMockAdminNode("node1", "", nodeFlavor)
@@ -454,15 +454,12 @@ func TestManageNodeSuccessfully(t *testing.T) {
 	secret.Name = cluster.Name
 	adminNode.Spec.SSHSecret = commonutils.GenObjectReference(secret.TypeMeta, secret.ObjectMeta)
 	adminNode.Spec.Cluster = ptr.To(cluster.Name)
-
-	patches1 := gomonkey.ApplyFunc(ssh.Dial, func(network string, addr string, config *ssh.ClientConfig) (*ssh.Client, error) {
-		return &ssh.Client{}, nil
-	})
-	defer patches1.Reset()
-	patches2 := gomonkey.ApplyFunc(isAlreadyAuthorized, func(username string, secret *corev1.Secret, sshClient *ssh.Client) (bool, error) {
-		return true, nil
-	})
-	defer patches2.Reset()
+	now := metav1.Now()
+	adminNode.Status.MachineStatus.UpdateTime = &now
+	adminNode.Status.ClusterStatus.CommandStatus = []v1.CommandStatus{
+		{Name: utils.Authorize, Phase: v1.CommandSucceeded},
+		{Name: HarborCA, Phase: v1.CommandSucceeded},
+	}
 
 	mockScheme, err := genMockScheme()
 	assert.NilError(t, err)
@@ -474,12 +471,20 @@ func TestManageNodeSuccessfully(t *testing.T) {
 	k8sClients := commonclient.NewClientFactoryWithOnlyClient(context.Background(), cluster.Name, k8sClient)
 	r.clientManager.AddOrReplace(cluster.Name, k8sClients)
 
+	sshClient, cleanup := startInMemorySSHServer(t)
+	defer cleanup()
+	patches := gomonkeyApplyGetSSHClient(sshClient)
+	defer patches.Reset()
+
 	assert.Equal(t, v1.GetClusterId(k8sNode), "")
 	assert.Equal(t, v1.GetNodeFlavorId(k8sNode), "")
 	assert.Equal(t, adminNode.IsManaged(), false)
 	ok := isCommandSuccessful(adminNode.Status.ClusterStatus.CommandStatus, utils.Authorize)
-	assert.Equal(t, ok, false)
+	assert.Equal(t, ok, true)
 	assert.Equal(t, adminNode.Status.ClusterStatus.Cluster == nil, true)
+
+	_, err = r.Reconcile(context.Background(), ctrlruntime.Request{NamespacedName: client.ObjectKey{Name: adminNode.Name}})
+	assert.NilError(t, err)
 
 	k8sNode2, err := k8sClient.CoreV1().Nodes().Get(context.Background(), k8sNode.Name, metav1.GetOptions{})
 	assert.NilError(t, err)
@@ -519,13 +524,18 @@ func TestManagingNode(t *testing.T) {
 }
 
 func TestManagingControlPlaneNode(t *testing.T) {
-	t.Skip("TODO: Test needs reconcile logic - similar to TestManageNodeSuccessfully")
 	nodeFlavor := genMockNodeFlavor()
 	cluster := genMockCluster()
 	adminNode := genMockAdminNode("node1", "", nodeFlavor)
 	adminNode.Spec.Cluster = ptr.To(cluster.Name)
+	adminNode.Labels[v1.KubernetesControlPlane] = "true"
+	now := metav1.Now()
+	adminNode.Status.MachineStatus.UpdateTime = &now
 	adminNode.Status.ClusterStatus.CommandStatus = []v1.CommandStatus{{
 		Name:  utils.Authorize,
+		Phase: v1.CommandSucceeded,
+	}, {
+		Name:  HarborCA,
 		Phase: v1.CommandSucceeded,
 	}}
 
@@ -534,8 +544,11 @@ func TestManagingControlPlaneNode(t *testing.T) {
 	adminClient := fake.NewClientBuilder().WithObjects(adminNode, cluster).
 		WithStatusSubresource(adminNode).WithScheme(mockScheme).Build()
 	r := newMockNodeReconciler(adminClient)
+	k8sClient := k8sfake.NewClientset()
+	k8sClients := commonclient.NewClientFactoryWithOnlyClient(context.Background(), cluster.Name, k8sClient)
+	r.clientManager.AddOrReplace(cluster.Name, k8sClients)
 
-	err = r.Update(context.Background(), adminNode)
+	_, err = r.Reconcile(context.Background(), ctrlruntime.Request{NamespacedName: client.ObjectKey{Name: adminNode.Name}})
 	assert.NilError(t, err)
 	err = adminClient.Get(context.Background(), client.ObjectKey{Name: adminNode.Name}, adminNode)
 	assert.NilError(t, err)
@@ -543,14 +556,16 @@ func TestManagingControlPlaneNode(t *testing.T) {
 }
 
 func TestUnmanageNodeSuccessfully(t *testing.T) {
-	t.Skip("TODO: Test needs reconcile logic - similar to TestManageNodeSuccessfully")
 	nodeFlavor := genMockNodeFlavor()
 	cluster := genMockCluster()
 	secret := genMockSecret()
 	secret.Name = cluster.Name
 	adminNode := genMockAdminNode("node1", cluster.Name, nodeFlavor)
+	adminNode.Labels[v1.NodeUnmanageNoRebootLabel] = v1.TrueStr
 	adminNode.Spec.SSHSecret = commonutils.GenObjectReference(secret.TypeMeta, secret.ObjectMeta)
 	adminNode.Spec.Cluster = nil
+	now := metav1.Now()
+	adminNode.Status.MachineStatus.UpdateTime = &now
 	adminNode.Status.ClusterStatus = v1.NodeClusterStatus{
 		Cluster: ptr.To(cluster.Name),
 		Phase:   v1.NodeManaged,
@@ -561,8 +576,16 @@ func TestUnmanageNodeSuccessfully(t *testing.T) {
 	adminClient := fake.NewClientBuilder().WithObjects(adminNode, secret, cluster).
 		WithStatusSubresource(adminNode).WithScheme(mockScheme).Build()
 	r := newMockNodeReconciler(adminClient)
+	k8sClient := k8sfake.NewClientset()
+	k8sClients := commonclient.NewClientFactoryWithOnlyClient(context.Background(), cluster.Name, k8sClient)
+	r.clientManager.AddOrReplace(cluster.Name, k8sClients)
 
-	err = r.Update(context.Background(), adminNode)
+	sshClient, cleanup := startInMemorySSHServer(t)
+	defer cleanup()
+	patches := gomonkeyApplyGetSSHClient(sshClient)
+	defer patches.Reset()
+
+	_, err = r.Reconcile(context.Background(), ctrlruntime.Request{NamespacedName: client.ObjectKey{Name: adminNode.Name}})
 	assert.NilError(t, err)
 
 	err = adminClient.Get(context.Background(), client.ObjectKey{Name: adminNode.Name}, adminNode)


### PR DESCRIPTION
## Summary
- Secure GitHub workflow routes and harden database error handling for unavailable connections, deletes, scans, nested queries, and pagination bounds.
- Fix reboot job failure handling so real SSH failures fail the job while preserving completed node outputs and tolerating expected SSH disconnects after reboot starts.
- Replace weak Ceph credential defaults and add active node manage/unmanage reconcile coverage.

## Test plan
- go test ./apiserver/pkg/handlers/github-workflow
- go test ./resource-manager/pkg/ops_job -run 'TestReboot'
- go test ./resource-manager/pkg/resource -run 'TestManageNodeSuccessfully|TestManagingControlPlaneNode|TestUnmanageNodeSuccessfully'
- go test ./resource-manager/pkg/resource -run 'Test.*Node|TestManage|TestUnmanage|TestSyncClusterStatus|TestSyncOrCreateScale'
- Bugbot review: no bugs found

## Notes
- Full resource and ops_job package runs still have existing environment-dependent failures unrelated to this change, mainly S3-disabled or missing-fixture tests.