### PR TITLE
feat(llm-gateway): add endpoint to reveal full APIM Key

### DIFF
--- a/SaFE/apiserver/pkg/handlers/llm-gateway/handler.go
+++ b/SaFE/apiserver/pkg/handlers/llm-gateway/handler.go
@@ -87,6 +87,7 @@ func InitRoutes(engine *gin.Engine, handler *Handler) {
 		mgmt.PUT("/binding", handler.UpdateBinding)
 		mgmt.DELETE("/binding", handler.DeleteBinding)
 		mgmt.GET("/binding", handler.GetBinding)
+		mgmt.GET("/binding/apim-key", handler.RevealApimKey)
 		mgmt.GET("/usage", handler.GetUsage)
 		mgmt.GET("/summary", handler.GetSummary)
 		mgmt.GET("/budget", handler.GetBudget)
@@ -468,6 +469,41 @@ func (h *Handler) GetBinding(c *gin.Context) {
 	})
 }
 
+// RevealApimKey handles GET /api/v1/llm-gateway/binding/apim-key
+// Returns the full plaintext APIM Key for the current user; the only endpoint
+// that exposes the full key, so reveal actions can be audited here.
+func (h *Handler) RevealApimKey(c *gin.Context) {
+	email := h.getUserEmail(c)
+	if email == "" {
+		apiutils.AbortWithApiError(c, commonerrors.NewBadRequest("unable to identify user email"))
+		return
+	}
+
+	existing, err := h.dbClient.GetLLMBindingByEmail(c.Request.Context(), email)
+	if err != nil {
+		klog.ErrorS(err, "RevealApimKey: DB query failed", "email", email)
+		apiutils.AbortWithApiError(c, commonerrors.NewInternalError("service temporarily unavailable, please try again later"))
+		return
+	}
+	if existing == nil {
+		apiutils.AbortWithApiError(c, commonerrors.NewNotFoundWithMessage("no APIM Key bound for "+email))
+		return
+	}
+
+	plainKey, err := h.crypto.Decrypt(existing.ApimKey)
+	if err != nil || plainKey == "" {
+		klog.ErrorS(err, "RevealApimKey: decrypt failed", "email", email)
+		apiutils.AbortWithApiError(c, commonerrors.NewInternalError("failed to decrypt APIM Key, please try again later"))
+		return
+	}
+
+	klog.Infof("LLM Gateway: apim key revealed for %s", email)
+	c.JSON(http.StatusOK, RevealApimKeyResponse{
+		UserEmail: email,
+		ApimKey:   plainKey,
+	})
+}
+
 // GetSummary handles GET /api/v1/llm-gateway/summary
 // Returns cumulative total spend for the user (not tied to a date range).
 func (h *Handler) GetSummary(c *gin.Context) {
@@ -645,6 +681,9 @@ func (h *Handler) getUserEmail(c *gin.Context) string {
 // e.g. "abcdefghijklmnop" → "abcd********mnop"
 func maskKey(key string) string {
 	if len(key) <= 8 {
+		if len(key) <= 4 {
+			return "****"
+		}
 		return key[:2] + "****"
 	}
 	return key[:4] + "********" + key[len(key)-4:]

--- a/SaFE/apiserver/pkg/handlers/llm-gateway/handler.go
+++ b/SaFE/apiserver/pkg/handlers/llm-gateway/handler.go
@@ -470,8 +470,8 @@ func (h *Handler) GetBinding(c *gin.Context) {
 }
 
 // RevealApimKey handles GET /api/v1/llm-gateway/binding/apim-key
-// Returns the full plaintext APIM Key for the current user; the only endpoint
-// that exposes the full key, so reveal actions can be audited here.
+// Returns the full plaintext APIM Key for the current user. This is the only
+// endpoint that discloses the full key, so each reveal is audit-logged.
 func (h *Handler) RevealApimKey(c *gin.Context) {
 	email := h.getUserEmail(c)
 	if email == "" {
@@ -491,13 +491,27 @@ func (h *Handler) RevealApimKey(c *gin.Context) {
 	}
 
 	plainKey, err := h.crypto.Decrypt(existing.ApimKey)
-	if err != nil || plainKey == "" {
+	if err != nil {
 		klog.ErrorS(err, "RevealApimKey: decrypt failed", "email", email)
 		apiutils.AbortWithApiError(c, commonerrors.NewInternalError("failed to decrypt APIM Key, please try again later"))
 		return
 	}
+	if plainKey == "" {
+		klog.ErrorS(nil, "RevealApimKey: decrypted APIM Key is empty", "email", email)
+		apiutils.AbortWithApiError(c, commonerrors.NewInternalError("failed to decrypt APIM Key, please try again later"))
+		return
+	}
 
-	klog.Infof("LLM Gateway: apim key revealed for %s", email)
+	// Audit: record who revealed the full APIM Key, from where.
+	klog.InfoS("LLM Gateway audit: apim key revealed",
+		"userId", c.GetString(common.UserId),
+		"email", email,
+		"clientIP", c.ClientIP())
+
+	// Prevent the full key from being cached by browsers or intermediary proxies.
+	c.Header("Cache-Control", "no-store")
+	c.Header("Pragma", "no-cache")
+
 	c.JSON(http.StatusOK, RevealApimKeyResponse{
 		UserEmail: email,
 		ApimKey:   plainKey,

--- a/SaFE/apiserver/pkg/handlers/llm-gateway/handler_test.go
+++ b/SaFE/apiserver/pkg/handlers/llm-gateway/handler_test.go
@@ -295,6 +295,37 @@ func TestRevealApimKey_Bound(t *testing.T) {
 	assert.Equal(t, "test-apim-key-12345", resp.ApimKey)
 }
 
+func TestRevealApimKey_Bound_SetsNoStoreHeader(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := mock_client.NewMockInterface(ctrl)
+	litellm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer litellm.Close()
+
+	handler := newTestHandler(t, mockDB, litellm)
+
+	binding := &dbclient.LLMGatewayUserBinding{
+		UserEmail: "test@amd.com",
+		ApimKey:   "test-apim-key-12345",
+		KeyAlias:  "test@amd.com",
+	}
+	mockDB.EXPECT().GetLLMBindingByEmail(gomock.Any(), "test@amd.com").Return(binding, nil)
+
+	router := gin.New()
+	router.GET("/binding/apim-key", func(c *gin.Context) {
+		setUserContext(c, "user1", "test@amd.com")
+		handler.RevealApimKey(c)
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/binding/apim-key", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "no-store", w.Header().Get("Cache-Control"))
+}
+
 func TestRevealApimKey_NotBound(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -318,6 +349,65 @@ func TestRevealApimKey_NotBound(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestRevealApimKey_DBError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := mock_client.NewMockInterface(ctrl)
+	litellm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer litellm.Close()
+
+	handler := newTestHandler(t, mockDB, litellm)
+
+	mockDB.EXPECT().GetLLMBindingByEmail(gomock.Any(), "test@amd.com").Return(nil, errors.New("db unavailable"))
+
+	router := gin.New()
+	router.GET("/binding/apim-key", func(c *gin.Context) {
+		setUserContext(c, "user1", "test@amd.com")
+		handler.RevealApimKey(c)
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/binding/apim-key", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestRevealApimKey_DecryptError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := mock_client.NewMockInterface(ctrl)
+	litellm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer litellm.Close()
+
+	handler := newTestHandler(t, mockDB, litellm)
+
+	// Enable crypto with an empty key so Decrypt fails deterministically.
+	viper.Set("crypto.enable", true)
+	defer viper.Set("crypto.enable", false)
+
+	binding := &dbclient.LLMGatewayUserBinding{
+		UserEmail: "test@amd.com",
+		ApimKey:   "ciphertext",
+		KeyAlias:  "test@amd.com",
+	}
+	mockDB.EXPECT().GetLLMBindingByEmail(gomock.Any(), "test@amd.com").Return(binding, nil)
+
+	router := gin.New()
+	router.GET("/binding/apim-key", func(c *gin.Context) {
+		setUserContext(c, "user1", "test@amd.com")
+		handler.RevealApimKey(c)
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/binding/apim-key", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
 // ── CreateBinding tests ───────────────────────────────────────────────────

--- a/SaFE/apiserver/pkg/handlers/llm-gateway/handler_test.go
+++ b/SaFE/apiserver/pkg/handlers/llm-gateway/handler_test.go
@@ -169,7 +169,9 @@ func TestMaskKey(t *testing.T) {
 		input    string
 		expected string
 	}{
-		{"short key", "abc", "ab****"},
+		{"1 char key", "a", "****"},
+		{"4 char key", "abcd", "****"},
+		{"short key", "abcde", "ab****"},
 		{"8 char key", "abcdefgh", "ab****"},
 		{"normal key", "abcdefghijklmnop", "abcd********mnop"},
 		{"long key", "safe1234567890abcdefghijklmnop", "safe********mnop"},
@@ -255,6 +257,67 @@ func TestGetBinding_Bound(t *testing.T) {
 	assert.True(t, resp.HasAPIMKey)
 	assert.Equal(t, "test@amd.com", resp.KeyAlias)
 	assert.Contains(t, resp.ApimKeyHint, "****")
+}
+
+// ── RevealApimKey tests ───────────────────────────────────────────────────
+
+func TestRevealApimKey_Bound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := mock_client.NewMockInterface(ctrl)
+	litellm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer litellm.Close()
+
+	handler := newTestHandler(t, mockDB, litellm)
+
+	binding := &dbclient.LLMGatewayUserBinding{
+		UserEmail: "test@amd.com",
+		ApimKey:   "test-apim-key-12345",
+		KeyAlias:  "test@amd.com",
+	}
+	mockDB.EXPECT().GetLLMBindingByEmail(gomock.Any(), "test@amd.com").Return(binding, nil)
+
+	router := gin.New()
+	router.GET("/binding/apim-key", func(c *gin.Context) {
+		setUserContext(c, "user1", "test@amd.com")
+		handler.RevealApimKey(c)
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/binding/apim-key", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp RevealApimKeyResponse
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, "test@amd.com", resp.UserEmail)
+	assert.Equal(t, "test-apim-key-12345", resp.ApimKey)
+}
+
+func TestRevealApimKey_NotBound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := mock_client.NewMockInterface(ctrl)
+	litellm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer litellm.Close()
+
+	handler := newTestHandler(t, mockDB, litellm)
+
+	mockDB.EXPECT().GetLLMBindingByEmail(gomock.Any(), "test@amd.com").Return(nil, nil)
+
+	router := gin.New()
+	router.GET("/binding/apim-key", func(c *gin.Context) {
+		setUserContext(c, "user1", "test@amd.com")
+		handler.RevealApimKey(c)
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/binding/apim-key", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 // ── CreateBinding tests ───────────────────────────────────────────────────

--- a/SaFE/apiserver/pkg/handlers/llm-gateway/types.go
+++ b/SaFE/apiserver/pkg/handlers/llm-gateway/types.go
@@ -89,6 +89,13 @@ type BindingResponse struct {
 	UpdatedAt   string `json:"updated_at,omitempty"`
 }
 
+// RevealApimKeyResponse carries the full plaintext APIM Key, returned only by
+// the dedicated reveal endpoint so the key is never exposed by listing APIs.
+type RevealApimKeyResponse struct {
+	UserEmail string `json:"user_email"`
+	ApimKey   string `json:"apim_key"`
+}
+
 // ── Summary types ─────────────────────────────────────────────────────────
 type SummaryResponse struct {
 	UserEmail  string             `json:"user_email"`


### PR DESCRIPTION
Add GET /api/v1/llm-gateway/binding/apim-key to return the full plaintext APIM Key for the current user, so listing APIs keep exposing only the hint and the full key is only disclosed on explicit reveal (with audit log). Also harden maskKey against short keys to avoid an out-of-range panic.