### PR TITLE
fix(cicd): inject platform apikey for runners and align job-manager c…

### DIFF
--- a/SaFE/charts/primus-safe/templates/job-manager/config.yaml
+++ b/SaFE/charts/primus-safe/templates/job-manager/config.yaml
@@ -15,6 +15,12 @@ data:
       rdma_name: {{ .Values.net.rdma_name }}
       # Ingress component name selected during install.sh
       ingress: {{ .Values.net.ingress }}
+    crypto:
+      # Whether to enable crypto. Must match apiserver so platform API keys
+      # decrypt to the same plaintext the apiserver validates.
+      enable: true
+      # The path of crypto secret
+      secret_path: {{ default "/etc/secrets/crypto" (default .Values.crypto).secret_path }}
     health_check:
       # Whether to enable health check
       enable: {{ default true (default .Values.k8s).enable_health_check }}

--- a/SaFE/charts/primus-safe/templates/job-manager/deployment.yaml
+++ b/SaFE/charts/primus-safe/templates/job-manager/deployment.yaml
@@ -56,6 +56,9 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:
+            - name: crypto-secret
+              mountPath: {{ default "/etc/secrets/crypto" (default .Values.crypto).secret_path }}
+              readOnly: true
             - name: server-config
               mountPath: /opt/primus-safe/job-manager/config
               readOnly: true
@@ -98,6 +101,9 @@ spec:
               cpu: {{ .Values.job_manager.cpu }}
               memory: {{ .Values.job_manager.memory }}
       volumes:
+        - name: crypto-secret
+          secret:
+            secretName: {{ .Release.Name }}-crypto
         - name: server-config
           configMap:
             name: {{ .Release.Name }}-job-manager

--- a/SaFE/job-manager/pkg/dispatcher/dispatcher_help.go
+++ b/SaFE/job-manager/pkg/dispatcher/dispatcher_help.go
@@ -197,6 +197,12 @@ func platformKeyForUser(workload *v1.Workload) string {
 	return key
 }
 
+// platformKeyForUserFn is a seam so tests can stub the platform key lookup by
+// assignment. gomonkey cannot reliably re-patch the cross-package apikey/db
+// chain across many tests in a single package run, which made env-injection
+// tests flaky; a package var override is deterministic.
+var platformKeyForUserFn = platformKeyForUser
+
 // dispatchNodesAt returns the admin nodes assigned at the given dispatch index,
 // preferring the DB workload_dispatch_node table and falling back to the etcd
 // Status.Nodes. Best-effort: a missing db client (e.g. DB disabled) or any query
@@ -820,6 +826,16 @@ func buildEnvironment(workload *v1.Workload, workspace *v1.Workspace, resourceId
 	result = addEnvVar(result, workload, "SAFE_WORKSPACE", workload.Spec.Workspace)
 	result = addEnvVar(result, workload, "DISPLAY_NAME", v1.GetDisplayName(workload))
 	result = addEnvVar(result, workload, "DISPATCH_COUNT", strconv.Itoa(v1.GetWorkloadDispatchCnt(workload)+1))
+	// Inject the workload owner's identity + platform API key so non-CICD
+	// workloads (e.g. multi-node jobs) can authenticate downstream, mirroring
+	// updateCICDScaleSetEnvs. USER_ID is skipped if already set via Spec.Env;
+	// USER_APIKEY is best-effort (empty when DB/lookup is unavailable).
+	result = addEnvVar(result, workload, jobutils.UserIdEnv, v1.GetUserId(workload))
+	if commonworkload.IsCICD(workload) || workload.SpecKind() == common.UnifiedJobKind {
+		if platformKey := platformKeyForUserFn(workload); platformKey != "" {
+			result = addEnvVar(result, workload, jobutils.UserApiKeyEnv, platformKey)
+		}
+	}
 	if commonworkload.IsAuthoring(workload) {
 		result = addEnvVar(result, workload, jobutils.AdminControlPlaneEnv, v1.GetAdminControlPlane(workload))
 	}
@@ -1173,7 +1189,9 @@ func updateCICDScaleSetEnvs(obj *unstructured.Unstructured,
 	}
 	envs := maps.Copy(adminWorkload.Spec.Env)
 	envs[jobutils.UserIdEnv] = v1.GetUserId(adminWorkload)
-	if platformKey := platformKeyForUser(adminWorkload); platformKey != "" {
+	// CICD scale sets have their own env path (not buildEnvironment), so inject
+	// the platform API key here too; best-effort (empty when DB/lookup fails).
+	if platformKey := platformKeyForUserFn(adminWorkload); platformKey != "" {
 		envs[jobutils.UserApiKeyEnv] = platformKey
 	}
 	envs[jobutils.PriorityEnv] = strconv.Itoa(adminWorkload.Spec.Priority)

--- a/SaFE/job-manager/pkg/dispatcher/dispatcher_help_platform_key_test.go
+++ b/SaFE/job-manager/pkg/dispatcher/dispatcher_help_platform_key_test.go
@@ -88,14 +88,38 @@ func TestPlatformKeyForUser(t *testing.T) {
 	})
 }
 
+// stubPlatformKey overrides the platformKeyForUserFn seam for a test and
+// restores it on cleanup. Assigning the package var is deterministic, unlike
+// gomonkey patching of the cross-package apikey/db chain, which proved flaky
+// when many tests patch it in a single package run.
+func stubPlatformKey(t *testing.T, key string) {
+	t.Helper()
+	orig := platformKeyForUserFn
+	platformKeyForUserFn = func(*v1.Workload) string { return key }
+	t.Cleanup(func() { platformKeyForUserFn = orig })
+}
+
+func TestBuildEnvironment_InjectsUserIdAndApiKey(t *testing.T) {
+	stubPlatformKey(t, "injected-user-api-key")
+
+	// UnifiedJob workload satisfies the buildEnvironment gate
+	// (IsCICD || UnifiedJobKind); it must get USER_ID + USER_APIKEY.
+	workload := &v1.Workload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "utd-multi-node-test",
+			Labels: map[string]string{v1.UserIdLabel: "user-1"},
+		},
+	}
+	workload.Spec.GroupVersionKind.Kind = common.UnifiedJobKind
+	workload.Spec.Workspace = "ws"
+
+	envs := buildEnvironment(workload, nil, -1)
+	assert.Equal(t, true, findEnv(envs, jobutils.UserIdEnv, "user-1"))
+	assert.Equal(t, true, findEnv(envs, jobutils.UserApiKeyEnv, "injected-user-api-key"))
+}
+
 func TestUpdateCICDScaleSetEnvs_InjectsUserApiKey(t *testing.T) {
-	patches := gomonkey.NewPatches()
-	defer patches.Reset()
-	patches.ApplyFunc(commonconfig.IsDBEnable, func() bool { return true })
-	patches.ApplyFunc(dbclient.NewClient, func() *dbclient.Client { return &dbclient.Client{} })
-	patches.ApplyFunc(apikey.GetOrCreatePlatformKey, func(context.Context, dbclient.Interface, string, string) (string, error) {
-		return "injected-user-api-key", nil
-	})
+	stubPlatformKey(t, "injected-user-api-key")
 
 	workspace := jobutils.TestWorkspaceData.DeepCopy()
 	workload := jobutils.TestWorkloadData.DeepCopy()

--- a/SaFE/job-manager/pkg/syncer/pod_handler.go
+++ b/SaFE/job-manager/pkg/syncer/pod_handler.go
@@ -138,10 +138,14 @@ func (r *SyncerReconciler) updateAdminWorkloadByPod(ctx context.Context, clientS
 			return ctrlruntime.Result{}, err
 		}
 	}
+	// CICD scaling runner sets are the only pod-driven case that owns the
+	// workload phase; carry it in the field patch so it is not dropped.
+	var extraStatusFields map[string]any
 	if commonworkload.IsCICDScalingRunnerSet(adminWorkload) {
 		updateCICDScalingRunnerSetPhase(adminWorkload, pod)
+		extraStatusFields = map[string]any{"phase": adminWorkload.Status.Phase}
 	}
-	if err = r.persistWorkloadStatus(ctx, adminWorkload); err != nil {
+	if err = r.patchWorkloadPodStatus(ctx, adminWorkload, extraStatusFields); err != nil {
 		klog.ErrorS(err, "failed to update admin workload status", "name", adminWorkload.Name)
 		return ctrlruntime.Result{}, err
 	}
@@ -389,7 +393,7 @@ func (r *SyncerReconciler) removeWorkloadPod(ctx context.Context, message *resou
 		p.Phase = corev1.PodPhase(v1.WorkloadStopped)
 	}
 
-	if err = r.persistWorkloadStatus(ctx, adminWorkload); err != nil {
+	if err = r.patchWorkloadPodStatus(ctx, adminWorkload, nil); err != nil {
 		klog.ErrorS(err, "failed to update workload status", "name", adminWorkload.Name)
 		return err
 	}

--- a/SaFE/job-manager/pkg/syncer/syncer_status.go
+++ b/SaFE/job-manager/pkg/syncer/syncer_status.go
@@ -15,6 +15,7 @@ import (
 	commonconfig "github.com/AMD-AIG-AIMA/SAFE/common/pkg/config"
 	dbclient "github.com/AMD-AIG-AIMA/SAFE/common/pkg/database/client"
 	commonworkload "github.com/AMD-AIG-AIMA/SAFE/common/pkg/workload"
+	jobutils "github.com/AMD-AIG-AIMA/SAFE/job-manager/pkg/utils"
 )
 
 // hydrateWorkloadStatusFromDB loads per-pod and dispatch history from DB into
@@ -58,6 +59,39 @@ func (r *SyncerReconciler) persistWorkloadStatus(ctx context.Context, w *v1.Work
 	w.Status.Nodes = nil
 	w.Status.Ranks = nil
 	return r.Status().Update(ctx, w)
+}
+
+// patchWorkloadPodStatus persists only the pod-sync-owned status fields via a
+// resourceVersion-guarded merge patch instead of a full status Update. It writes
+// pods/nodes/ranks (plus the offload NodeUsage aggregate, and any caller-supplied
+// extraFields such as the CICD listener phase), so a stale local snapshot can no
+// longer clobber fields owned by other reconcilers (phase, conditions, ...). The
+// resourceVersion guard still surfaces a Conflict, so the caller keeps requeueing
+// and recomputing from fresh state.
+func (r *SyncerReconciler) patchWorkloadPodStatus(ctx context.Context, w *v1.Workload, extraFields map[string]any) error {
+	statusFields := make(map[string]any, 4+len(extraFields))
+	if !commonconfig.IsDBEnable() || r.dbClient == nil || !v1.IsWorkloadStatusOffloadEnabled(w) {
+		statusFields["pods"] = w.Status.Pods
+		statusFields["nodes"] = w.Status.Nodes
+		statusFields["ranks"] = w.Status.Ranks
+	} else {
+		if err := r.writeWorkloadStatusToDB(ctx, w); err != nil {
+			return err
+		}
+		// etcd keeps only the O(node) aggregate; clear the large per-pod arrays.
+		w.Status.NodeUsage = commonworkload.BuildNodeUsage(w)
+		w.Status.Pods = nil
+		w.Status.Nodes = nil
+		w.Status.Ranks = nil
+		statusFields["nodeUsage"] = w.Status.NodeUsage
+		statusFields["pods"] = nil
+		statusFields["nodes"] = nil
+		statusFields["ranks"] = nil
+	}
+	for k, v := range extraFields {
+		statusFields[k] = v
+	}
+	return jobutils.PatchWorkloadStatusFields(ctx, r.Client, w, statusFields)
 }
 
 // writeWorkloadStatusToDB upserts the live pod set and dispatch history rows.

--- a/SaFE/job-manager/pkg/syncer/syncer_status_test.go
+++ b/SaFE/job-manager/pkg/syncer/syncer_status_test.go
@@ -132,6 +132,109 @@ func TestPersistWorkloadStatus_Offload(t *testing.T) {
 	assert.NotEmpty(t, got.Status.NodeUsage)
 }
 
+// TestPatchWorkloadPodStatus_PreservesPhase verifies the field-scoped merge
+// patch writes pods/nodes/ranks without clobbering status.phase owned by other
+// reconcilers, even when the in-memory copy carries a stale phase.
+func TestPatchWorkloadPodStatus_PreservesPhase(t *testing.T) {
+	viper.Reset()
+	defer viper.Reset()
+
+	w := &v1.Workload{
+		ObjectMeta: metav1.ObjectMeta{Name: "w1"},
+		Status: v1.WorkloadStatus{
+			Phase: v1.WorkloadRunning,
+			Pods:  []v1.WorkloadPod{{PodId: "p1", Phase: corev1.PodRunning, AdminNodeName: "n1"}},
+		},
+	}
+	cl := ctrlfake.NewClientBuilder().WithScheme(syncerScheme(t)).WithObjects(w.DeepCopy()).WithStatusSubresource(w).Build()
+	r := &SyncerReconciler{Client: cl}
+
+	fresh := &v1.Workload{}
+	require.NoError(t, cl.Get(context.Background(), ctrlclient.ObjectKey{Name: "w1"}, fresh))
+	// Stale in-memory phase must NOT overwrite the stored phase.
+	fresh.Status.Phase = v1.WorkloadSucceeded
+	fresh.Status.Pods = []v1.WorkloadPod{{PodId: "p1", Phase: corev1.PodSucceeded, AdminNodeName: "n1"}}
+	require.NoError(t, r.patchWorkloadPodStatus(context.Background(), fresh, nil))
+
+	got := &v1.Workload{}
+	require.NoError(t, cl.Get(context.Background(), ctrlclient.ObjectKey{Name: "w1"}, got))
+	assert.Equal(t, v1.WorkloadRunning, got.Status.Phase)
+	require.Len(t, got.Status.Pods, 1)
+	assert.Equal(t, corev1.PodSucceeded, got.Status.Pods[0].Phase)
+}
+
+// TestPatchWorkloadPodStatus_ExtraFieldsSetsPhase verifies caller-supplied extra
+// fields (e.g. CICD listener phase) are merged into the status patch.
+func TestPatchWorkloadPodStatus_ExtraFieldsSetsPhase(t *testing.T) {
+	viper.Reset()
+	defer viper.Reset()
+
+	w := &v1.Workload{
+		ObjectMeta: metav1.ObjectMeta{Name: "w1"},
+		Status:     v1.WorkloadStatus{Phase: v1.WorkloadRunning},
+	}
+	cl := ctrlfake.NewClientBuilder().WithScheme(syncerScheme(t)).WithObjects(w.DeepCopy()).WithStatusSubresource(w).Build()
+	r := &SyncerReconciler{Client: cl}
+
+	fresh := &v1.Workload{}
+	require.NoError(t, cl.Get(context.Background(), ctrlclient.ObjectKey{Name: "w1"}, fresh))
+	fresh.Status.Pods = []v1.WorkloadPod{{PodId: "p1", AdminNodeName: "n1"}}
+	require.NoError(t, r.patchWorkloadPodStatus(context.Background(), fresh,
+		map[string]any{"phase": string(v1.WorkloadNotReady)}))
+
+	got := &v1.Workload{}
+	require.NoError(t, cl.Get(context.Background(), ctrlclient.ObjectKey{Name: "w1"}, got))
+	assert.Equal(t, v1.WorkloadNotReady, got.Status.Phase)
+	assert.Len(t, got.Status.Pods, 1)
+}
+
+// TestPatchWorkloadPodStatus_Offload verifies the offload path mirrors the DB,
+// clears the per-pod arrays, writes the NodeUsage aggregate, and still does not
+// clobber status.phase.
+func TestPatchWorkloadPodStatus_Offload(t *testing.T) {
+	viper.Reset()
+	viper.Set("db.enable", true)
+	defer viper.Reset()
+
+	ctrl := gomock.NewController(t)
+	mockDB := mockclient.NewMockInterface(ctrl)
+	mockDB.EXPECT().BatchUpsertWorkloadPods(gomock.Any(), gomock.Any()).Return(nil)
+	mockDB.EXPECT().DeleteWorkloadPodsNotIn(gomock.Any(), "w1", []string{"p1"}).Return(nil)
+	mockDB.EXPECT().UpsertWorkloadDispatchNode(gomock.Any(), gomock.Any()).Return(nil)
+
+	w := &v1.Workload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "w1",
+			Labels:      map[string]string{v1.WorkloadDispatchCntLabel: "1"},
+			Annotations: map[string]string{v1.WorkloadStatusOffloadAnnotation: v1.TrueStr},
+		},
+		Spec: v1.WorkloadSpec{
+			Resources: []v1.WorkloadResource{{Replica: 1, CPU: "1", GPU: "1", Memory: "1Gi"}},
+		},
+		Status: v1.WorkloadStatus{
+			Phase: v1.WorkloadRunning,
+			Pods:  []v1.WorkloadPod{{PodId: "p1", Phase: corev1.PodRunning, AdminNodeName: "n1", ResourceId: 0}},
+			Nodes: [][]string{{"n1"}},
+			Ranks: [][]string{{"0"}},
+		},
+	}
+	cl := ctrlfake.NewClientBuilder().WithScheme(syncerScheme(t)).WithObjects(w.DeepCopy()).WithStatusSubresource(w).Build()
+	r := &SyncerReconciler{Client: cl, dbClient: mockDB}
+
+	fresh := &v1.Workload{}
+	require.NoError(t, cl.Get(context.Background(), ctrlclient.ObjectKey{Name: "w1"}, fresh))
+	fresh.Status = w.Status
+	fresh.Labels = w.Labels
+	fresh.Annotations = w.Annotations
+	require.NoError(t, r.patchWorkloadPodStatus(context.Background(), fresh, nil))
+
+	got := &v1.Workload{}
+	require.NoError(t, cl.Get(context.Background(), ctrlclient.ObjectKey{Name: "w1"}, got))
+	assert.Empty(t, got.Status.Pods)
+	assert.NotEmpty(t, got.Status.NodeUsage)
+	assert.Equal(t, v1.WorkloadRunning, got.Status.Phase)
+}
+
 func TestHydrateWorkloadStatusFromDB(t *testing.T) {
 	viper.Reset()
 	viper.Set("db.enable", true)

--- a/SaFE/tools/decrypt-apikey/go.mod
+++ b/SaFE/tools/decrypt-apikey/go.mod
@@ -1,0 +1,3 @@
+module decrypt-apikey
+
+go 1.23

--- a/SaFE/tools/decrypt-apikey/main.go
+++ b/SaFE/tools/decrypt-apikey/main.go
@@ -1,0 +1,108 @@
+// Command decrypt-apikey recovers the plaintext platform API key ("ak-...")
+// from the AES-GCM ciphertext stored in the api_keys.encrypted_key column.
+//
+// It mirrors common/pkg/apikey/platform_key.go exactly:
+//   - AES key      = sha256(cryptoSecret)          (deriveAESKey)
+//   - ciphertext   = base64.RawURLEncoding(encoded) (nonce || sealed)
+//   - plaintext    = AES-GCM Open, nonce = first NonceSize bytes
+//
+// IMPORTANT: the crypto secret must be the SAME one the apiserver uses
+// (Secret "<release>-crypto", key "key"), otherwise the recovered token is
+// garbage and will fail apiserver validation.
+//
+// The api_keys.api_key column is a one-way HMAC/SHA256 hash and CANNOT be
+// decrypted; only encrypted_key is reversible.
+package main
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/sha256"
+	"encoding/base64"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+)
+
+func main() {
+	var (
+		keyStr  = flag.String("key", "", "crypto secret string (content of the 'key' file in Secret <release>-crypto)")
+		keyFile = flag.String("key-file", "", "path to a file containing the crypto secret (alternative to -key)")
+		enc     = flag.String("enc", "", "encrypted_key value (base64url) from api_keys.encrypted_key")
+		encFile = flag.String("enc-file", "", "path to a file containing the encrypted_key (alternative to -enc)")
+	)
+	flag.Parse()
+
+	secret, err := loadValue(*keyStr, *keyFile)
+	if err != nil {
+		fatalf("failed to load crypto key: %v", err)
+	}
+	ciphertext, err := loadValue(*enc, *encFile)
+	if err != nil {
+		fatalf("failed to load encrypted_key: %v", err)
+	}
+	ciphertext = strings.TrimSpace(ciphertext)
+	if ciphertext == "" {
+		fatalf("encrypted_key is empty (pass -enc or -enc-file)")
+	}
+
+	plaintext, err := decryptPlainToken(ciphertext, []byte(secret))
+	if err != nil {
+		fatalf("decrypt failed (wrong crypto key or malformed ciphertext?): %v", err)
+	}
+	fmt.Println(plaintext)
+}
+
+// loadValue returns inline when set, else the trimmed file contents.
+func loadValue(inline, path string) (string, error) {
+	if inline != "" {
+		return inline, nil
+	}
+	if path == "" {
+		return "", nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	// The crypto key file may carry a trailing newline; strip it.
+	return strings.TrimRight(string(data), "\r\n"), nil
+}
+
+// deriveAESKey matches common/pkg/apikey.deriveAESKey.
+func deriveAESKey(secret []byte) []byte {
+	hash := sha256.Sum256(secret)
+	return hash[:]
+}
+
+// decryptPlainToken matches common/pkg/apikey.decryptPlainToken.
+func decryptPlainToken(encrypted string, secret []byte) (string, error) {
+	key := deriveAESKey(secret)
+	data, err := base64.RawURLEncoding.DecodeString(encrypted)
+	if err != nil {
+		return "", fmt.Errorf("failed to decode encrypted key: %w", err)
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", fmt.Errorf("failed to create cipher: %w", err)
+	}
+	aesGCM, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("failed to create GCM: %w", err)
+	}
+	nonceSize := aesGCM.NonceSize()
+	if len(data) < nonceSize {
+		return "", fmt.Errorf("ciphertext too short")
+	}
+	plaintext, err := aesGCM.Open(nil, data[:nonceSize], data[nonceSize:], nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to decrypt: %w", err)
+	}
+	return string(plaintext), nil
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "error: "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/SaFE/tools/platform-key/go.mod
+++ b/SaFE/tools/platform-key/go.mod
@@ -1,0 +1,5 @@
+module platform-key
+
+go 1.23
+
+require github.com/lib/pq v1.11.2

--- a/SaFE/tools/platform-key/go.sum
+++ b/SaFE/tools/platform-key/go.sum
@@ -1,0 +1,2 @@
+github.com/lib/pq v1.11.2 h1:x6gxUeu39V0BHZiugWe8LXZYZ+Utk7hSJGThs8sdzfs=
+github.com/lib/pq v1.11.2/go.mod h1:/p+8NSbOcwzAEI7wiMXFlgydTwcgTr3OSKMsD2BitpA=

--- a/SaFE/tools/platform-key/main.go
+++ b/SaFE/tools/platform-key/main.go
@@ -1,0 +1,292 @@
+// Command platform-key mirrors common/pkg/apikey.GetOrCreatePlatformKey against
+// the api_keys table directly, so an operator can fetch (or mint) a user's
+// platform API key ("ak-...") by user id without any user credential.
+//
+// Behavior (identical to the server):
+//   - If an active platform key exists, its encrypted_key is AES-GCM decrypted
+//     and the plaintext is printed.
+//   - If none exists and --create is set, a new plaintext is generated, hashed
+//     (api_key column) and encrypted (encrypted_key column), inserted, and the
+//     plaintext printed.
+//
+// The crypto key MUST be the same one the apiserver uses (Secret
+// <release>-crypto, key "key"), otherwise the minted/decrypted token will not
+// validate.
+//
+// WARNING: --create WRITES a row into the production api_keys table.
+package main
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/lib/pq"
+)
+
+const (
+	tokenPrefix     = "ak-"
+	tokenLength     = 32
+	keyTypePlatform = "platform"
+	platformKeyName = "platform-key"
+)
+
+func main() {
+	var (
+		userID   = flag.String("user-id", "", "target user id (required)")
+		userName = flag.String("user-name", "", "target user name (stored on create)")
+		create   = flag.Bool("create", false, "mint a new platform key if none exists (WRITES to DB)")
+
+		cryptoKey     = flag.String("crypto-key", "", "crypto secret string")
+		cryptoKeyFile = flag.String("crypto-key-file", "", "file containing the crypto secret")
+
+		dbHost     = flag.String("db-host", "", "postgres host (required)")
+		dbPort     = flag.String("db-port", "5432", "postgres port")
+		dbName     = flag.String("db-name", "", "postgres database name (required)")
+		dbUser     = flag.String("db-user", "", "postgres user (required)")
+		dbPass     = flag.String("db-password", "", "postgres password")
+		dbPassFile = flag.String("db-password-file", "", "file containing the postgres password")
+		sslMode    = flag.String("ssl-mode", "require", "postgres sslmode")
+	)
+	flag.Parse()
+
+	if *userID == "" || *dbHost == "" || *dbName == "" || *dbUser == "" {
+		fatalf("required: --user-id, --db-host, --db-name, --db-user")
+	}
+
+	secret, err := loadValue(*cryptoKey, *cryptoKeyFile)
+	if err != nil {
+		fatalf("failed to load crypto key: %v", err)
+	}
+	password, err := loadValue(*dbPass, *dbPassFile)
+	if err != nil {
+		fatalf("failed to load db password: %v", err)
+	}
+
+	dsn := buildDSN(map[string]string{
+		"host":     *dbHost,
+		"port":     *dbPort,
+		"dbname":   *dbName,
+		"user":     *dbUser,
+		"password": password,
+		"sslmode":  *sslMode,
+	})
+
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		fatalf("failed to open db: %v", err)
+	}
+	defer db.Close()
+
+	plaintext, minted, err := getOrCreate(db, *userID, *userName, []byte(secret), *create)
+	if err != nil {
+		fatalf("%v", err)
+	}
+	if minted {
+		fmt.Fprintln(os.Stderr, "note: a new platform key was created and stored")
+	}
+	fmt.Println(plaintext)
+}
+
+// getOrCreate mirrors apikey.GetOrCreatePlatformKey.
+func getOrCreate(db *sql.DB, userID, userName string, secret []byte, allowCreate bool) (string, bool, error) {
+	enc, found, err := selectEncryptedKey(db, userID)
+	if err != nil {
+		return "", false, fmt.Errorf("query platform key failed: %w", err)
+	}
+	if found {
+		if enc == "" {
+			return "", false, errors.New("platform key row has empty encrypted_key")
+		}
+		pt, err := decryptPlainToken(enc, secret)
+		if err != nil {
+			return "", false, fmt.Errorf("decrypt failed (wrong crypto key?): %w", err)
+		}
+		return pt, false, nil
+	}
+
+	if !allowCreate {
+		return "", false, errors.New("no active platform key for this user; pass --create to mint one (writes to DB)")
+	}
+
+	plain, err := generatePlainToken()
+	if err != nil {
+		return "", false, err
+	}
+	hashed := hashPlainToken(plain, secret)
+	hint := generateKeyHint(plain)
+	encrypted, err := encryptPlainToken(plain, secret)
+	if err != nil {
+		return "", false, err
+	}
+	if err := insertPlatformKey(db, userID, userName, hashed, hint, encrypted); err != nil {
+		// On unique conflict another writer won the race; re-read and decrypt.
+		if isUniqueViolation(err) {
+			enc, found, qerr := selectEncryptedKey(db, userID)
+			if qerr == nil && found && enc != "" {
+				if pt, derr := decryptPlainToken(enc, secret); derr == nil {
+					return pt, false, nil
+				}
+			}
+		}
+		return "", false, fmt.Errorf("insert platform key failed: %w", err)
+	}
+	return plain, true, nil
+}
+
+func selectEncryptedKey(db *sql.DB, userID string) (string, bool, error) {
+	const q = `SELECT encrypted_key FROM api_keys
+	           WHERE user_id=$1 AND key_type='platform' AND deleted=false LIMIT 1`
+	var enc sql.NullString
+	err := db.QueryRow(q, userID).Scan(&enc)
+	if err == sql.ErrNoRows {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return enc.String, true, nil
+}
+
+func insertPlatformKey(db *sql.DB, userID, userName, hashedKey, keyHint, encryptedKey string) error {
+	const q = `INSERT INTO api_keys
+	           (name, user_id, user_name, api_key, key_hint, expiration_time,
+	            creation_time, whitelist, deleted, key_type, encrypted_key)
+	           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`
+	farFuture := time.Date(9999, 12, 31, 23, 59, 59, 0, time.UTC)
+	now := time.Now().UTC()
+	_, err := db.Exec(q,
+		platformKeyName, userID, userName, hashedKey, keyHint, farFuture,
+		now, "[]", false, keyTypePlatform, encryptedKey,
+	)
+	return err
+}
+
+// --- crypto helpers: byte-for-byte identical to common/pkg/apikey ---
+
+func generatePlainToken() (string, error) {
+	b := make([]byte, tokenLength)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("failed to generate random bytes: %w", err)
+	}
+	return tokenPrefix + base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+func hashPlainToken(plainToken string, secret []byte) string {
+	if len(secret) == 0 {
+		h := sha256.Sum256([]byte(plainToken))
+		return hex.EncodeToString(h[:])
+	}
+	h := hmac.New(sha256.New, secret)
+	h.Write([]byte(plainToken))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func generateKeyHint(plainToken string) string {
+	body := strings.TrimPrefix(plainToken, tokenPrefix)
+	if len(body) < 6 {
+		return tokenPrefix + body
+	}
+	return tokenPrefix + body[:2] + "****" + body[len(body)-4:]
+}
+
+func deriveAESKey(secret []byte) []byte {
+	h := sha256.Sum256(secret)
+	return h[:]
+}
+
+func encryptPlainToken(plaintext string, secret []byte) (string, error) {
+	block, err := aes.NewCipher(deriveAESKey(secret))
+	if err != nil {
+		return "", err
+	}
+	aesGCM, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+	nonce := make([]byte, aesGCM.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+	ct := aesGCM.Seal(nonce, nonce, []byte(plaintext), nil)
+	return base64.RawURLEncoding.EncodeToString(ct), nil
+}
+
+func decryptPlainToken(encrypted string, secret []byte) (string, error) {
+	data, err := base64.RawURLEncoding.DecodeString(encrypted)
+	if err != nil {
+		return "", fmt.Errorf("failed to decode encrypted key: %w", err)
+	}
+	block, err := aes.NewCipher(deriveAESKey(secret))
+	if err != nil {
+		return "", err
+	}
+	aesGCM, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+	ns := aesGCM.NonceSize()
+	if len(data) < ns {
+		return "", errors.New("ciphertext too short")
+	}
+	pt, err := aesGCM.Open(nil, data[:ns], data[ns:], nil)
+	if err != nil {
+		return "", err
+	}
+	return string(pt), nil
+}
+
+// --- misc ---
+
+func isUniqueViolation(err error) bool {
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) {
+		return pqErr.Code == "23505"
+	}
+	return false
+}
+
+func loadValue(inline, path string) (string, error) {
+	if inline != "" {
+		return inline, nil
+	}
+	if path == "" {
+		return "", nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(string(data), "\r\n"), nil
+}
+
+// buildDSN renders a lib/pq keyword/value DSN with proper escaping.
+func buildDSN(kv map[string]string) string {
+	var parts []string
+	for k, v := range kv {
+		if v == "" {
+			continue
+		}
+		escaped := strings.ReplaceAll(v, `\`, `\\`)
+		escaped = strings.ReplaceAll(escaped, `'`, `\'`)
+		parts = append(parts, fmt.Sprintf("%s='%s'", k, escaped))
+	}
+	return strings.Join(parts, " ")
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "error: "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/SaFE/tools/platform-key/run.sh
+++ b/SaFE/tools/platform-key/run.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Fetch (or mint) a user's platform API key ("ak-...") end to end:
+#   - pulls the crypto key + DB password from cluster secrets
+#   - port-forwards Postgres locally
+#   - runs the platform-key tool (mirrors GetOrCreatePlatformKey)
+#
+# Usage:
+#   ./run.sh                          # interactive: prompts for user id/name
+#   ./run.sh <user-id> [user-name]    # non-interactive inputs
+#   CREATE=1 ./run.sh <user-id> <name>  # mint if missing (WRITES to api_keys)
+#
+# Env overrides (defaults target the primus-safe release):
+#   NS, CRYPTO_SECRET, DB_SECRET, PG_SVC, DB_NAME, DB_USER, LOCAL_PORT
+set -euo pipefail
+
+NS="${NS:-primus-safe}"
+CRYPTO_SECRET="${CRYPTO_SECRET:-primus-safe-crypto}"
+DB_SECRET="${DB_SECRET:-primus-safe-pguser-primus-safe}"
+# CrunchyData's *-primary service is selectorless, so port-forward targets the
+# master POD instead (resolved via the operator's role label). Override PG_POD
+# to pin a specific pod.
+PG_POD="${PG_POD:-}"
+PG_MASTER_SELECTOR="${PG_MASTER_SELECTOR:-postgres-operator.crunchydata.com/role=master}"
+DB_NAME="${DB_NAME:-primus-safe-db}"
+DB_USER="${DB_USER:-primus-safe}"
+LOCAL_PORT="${LOCAL_PORT:-15432}"
+SSL_MODE="${SSL_MODE:-require}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Inputs: args first, else prompt.
+USER_ID="${1:-}"
+USER_NAME="${2:-}"
+if [ -z "$USER_ID" ]; then
+  read -r -p "User ID: " USER_ID
+fi
+if [ -z "$USER_ID" ]; then
+  echo "error: user id is required" >&2
+  exit 1
+fi
+if [ -z "$USER_NAME" ]; then
+  read -r -p "User name (optional, stored on create): " USER_NAME
+fi
+
+# Confirm minting when requested (writes to the production DB).
+CREATE_FLAG=""
+if [ "${CREATE:-0}" = "1" ]; then
+  read -r -p "CREATE=1 will WRITE a platform key row for '$USER_ID'. Proceed? [y/N] " ans
+  case "$ans" in
+    y | Y | yes | YES) CREATE_FLAG="--create" ;;
+    *) echo "aborted (running read-only)"; CREATE_FLAG="" ;;
+  esac
+fi
+
+WORKDIR="$(mktemp -d)"
+CRYPTO_FILE="$WORKDIR/crypto.key"
+PASS_FILE="$WORKDIR/db.pass"
+PF_LOG="$WORKDIR/pf.log"
+PF_PID=""
+cleanup() {
+  [ -n "$PF_PID" ] && kill "$PF_PID" >/dev/null 2>&1 || true
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+echo "==> fetching crypto key from secret/$CRYPTO_SECRET" >&2
+kubectl get secret "$CRYPTO_SECRET" -n "$NS" -o jsonpath='{.data.key}' | base64 -d > "$CRYPTO_FILE"
+echo "==> fetching db password from secret/$DB_SECRET" >&2
+kubectl get secret "$DB_SECRET" -n "$NS" -o jsonpath='{.data.password}' | base64 -d > "$PASS_FILE"
+
+# Default: this script starts its own port-forward on 127.0.0.1:$LOCAL_PORT.
+# Set NO_PORT_FORWARD=1 (and DB_HOST/DB_PORT) to reuse an existing connection
+# (e.g. a port-forward you started yourself, or in-cluster direct access).
+DB_HOST="${DB_HOST:-127.0.0.1}"
+DB_PORT="${DB_PORT:-$LOCAL_PORT}"
+
+if [ "${NO_PORT_FORWARD:-0}" != "1" ]; then
+  if [ -z "$PG_POD" ]; then
+    PG_POD="$(kubectl get pods -n "$NS" -l "$PG_MASTER_SELECTOR" \
+      -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+  fi
+  if [ -z "$PG_POD" ]; then
+    echo "error: could not resolve master pg pod (selector: $PG_MASTER_SELECTOR)." >&2
+    echo "hint: set PG_POD=<pod> explicitly, or use NO_PORT_FORWARD=1 with DB_HOST/DB_PORT." >&2
+    exit 1
+  fi
+  echo "==> port-forwarding pod/$PG_POD $LOCAL_PORT:5432 (log: $PF_LOG)" >&2
+  kubectl port-forward -n "$NS" "pod/$PG_POD" "$LOCAL_PORT:5432" >"$PF_LOG" 2>&1 &
+  PF_PID=$!
+  DB_HOST="127.0.0.1"
+  DB_PORT="$LOCAL_PORT"
+
+  # Readiness: wait for kubectl to log "Forwarding from ...:<port>" (up to ~30s).
+  ready=0
+  for _ in $(seq 1 60); do
+    if ! kill -0 "$PF_PID" >/dev/null 2>&1; then
+      echo "error: port-forward exited early. log:" >&2
+      cat "$PF_LOG" >&2
+      exit 1
+    fi
+    if grep -q "Forwarding from .*:$LOCAL_PORT" "$PF_LOG" 2>/dev/null; then
+      ready=1
+      break
+    fi
+    sleep 0.5
+  done
+  if [ "$ready" != "1" ]; then
+    echo "error: port-forward not ready after 30s. log:" >&2
+    cat "$PF_LOG" >&2
+    echo "hint: is LOCAL_PORT=$LOCAL_PORT already in use? try LOCAL_PORT=25432 ./run.sh ..." >&2
+    exit 1
+  fi
+fi
+
+echo "==> resolving platform key for user $USER_ID (db $DB_HOST:$DB_PORT)" >&2
+export GOWORK=off
+go -C "$SCRIPT_DIR" run . \
+  --user-id "$USER_ID" \
+  --user-name "$USER_NAME" \
+  $CREATE_FLAG \
+  --db-host "$DB_HOST" --db-port "$DB_PORT" \
+  --db-name "$DB_NAME" --db-user "$DB_USER" \
+  --db-password-file "$PASS_FILE" \
+  --crypto-key-file "$CRYPTO_FILE" \
+  --ssl-mode "$SSL_MODE"


### PR DESCRIPTION
…rypto

CICD EphemeralRunners got HTTP 401 (invalid token) because USER_APIKEY was missing/invalid in the runner env, causing pods to crash-loop.

- dispatcher: restore USER_APIKEY injection in updateCICDScaleSetEnvs (the EphemeralRunner path) and inject USER_ID/USER_APIKEY in buildEnvironment (gated on IsCICD || UnifiedJobKind). Add platformKeyForUserFn seam.
- charts: mount the <release>-crypto secret into job-manager and add the crypto config block (mirrors apiserver) so GetCryptoKey() matches apiserver; otherwise minted/decrypted platform keys fail apiserver validation.
- syncer: persist pod status via a field-scoped merge patch to stop the optimistic-lock conflict retry storm.
- tests: make platform-key tests deterministic via the seam (no gomonkey).
- tools: add platform-key (get/create a user's platform key by id) and decrypt-apikey (decrypt api_keys.encrypted_key).