### PR TITLE
Paginate workload dispatch nodes and add server-side node sorting

### DIFF
--- a/SaFE/apiserver/pkg/handlers/resources/node.go
+++ b/SaFE/apiserver/pkg/handlers/resources/node.go
@@ -290,14 +290,14 @@ func (h *Handler) listNode(c *gin.Context) (interface{}, error) {
 		return nil, err
 	}
 	ctx := c.Request.Context()
-	totalCount, nodes, err := h.listNodeByQuery(c, query)
+	totalCount, nodes, allUsedResource, err := h.listNodeByQuery(c, query)
 	if err != nil {
 		return nil, err
 	}
 	if query.Brief {
 		return buildListNodeBriefResponse(totalCount, nodes)
 	}
-	return h.buildListNodeResponse(ctx, query, totalCount, nodes)
+	return h.buildListNodeResponse(ctx, query, totalCount, nodes, allUsedResource)
 }
 
 // ExportNodeToCSV writes the node information to a CSV file using the provided writer (file or response stream).
@@ -362,13 +362,13 @@ func (h *Handler) ExportNodeByQuery(c *gin.Context) {
 	}
 	ctx := c.Request.Context()
 	query.Limit = -1 // Don't need limit.
-	totalCount, nodes, err := h.listNodeByQuery(c, query)
+	totalCount, nodes, allUsedResource, err := h.listNodeByQuery(c, query)
 	if err != nil {
 		klog.ErrorS(err, "failed to query node")
 		apiutils.AbortWithApiError(c, err)
 		return
 	}
-	result, err := h.buildListNodeResponse(ctx, query, totalCount, nodes)
+	result, err := h.buildListNodeResponse(ctx, query, totalCount, nodes, allUsedResource)
 	if err != nil {
 		klog.ErrorS(err, "failed to build node list")
 		apiutils.AbortWithApiError(c, err)
@@ -388,32 +388,32 @@ func (h *Handler) ExportNodeByQuery(c *gin.Context) {
 // listNodeByQuery retrieves nodes based on the provided query parameters.
 // Applies filtering, authorization checks, and pagination to return
 // a list of nodes that match the criteria.
-func (h *Handler) listNodeByQuery(c *gin.Context, query *view.ListNodeRequest) (int, []*v1.Node, error) {
+func (h *Handler) listNodeByQuery(c *gin.Context, query *view.ListNodeRequest) (int, []*v1.Node, map[string]*resourceInfo, error) {
 	requestUser, err := h.getAndSetUsername(c)
 	if err != nil {
-		return 0, nil, err
+		return 0, nil, nil, err
 	}
 
 	labelSelector, err := buildNodeLabelSelector(query)
 	if err != nil {
-		return 0, nil, err
+		return 0, nil, nil, err
 	}
 	var nodeList []v1.Node
 	ctx := c.Request.Context()
 	if query.NodeId == nil {
 		nodeList, err = h.getAdminNodes(ctx, labelSelector)
 		if err != nil {
-			return 0, nil, err
+			return 0, nil, nil, err
 		}
 	} else {
 		// If a nodeId is provided, you can directly get it to save time.
 		node, err := h.getAdminNode(ctx, *query.NodeId)
 		if err != nil {
-			return 0, nil, err
+			return 0, nil, nil, err
 		}
 		nodeLabels := labels.Set(node.Labels)
 		if !labelSelector.Matches(nodeLabels) {
-			return 0, nil, nil
+			return 0, nil, nil, nil
 		}
 		nodeList = append(nodeList, *node)
 	}
@@ -465,10 +465,19 @@ func (h *Handler) listNodeByQuery(c *gin.Context, query *view.ListNodeRequest) (
 	}
 	totalCount := len(nodes)
 	if totalCount == 0 {
-		return 0, nil, nil
-	} else if totalCount > 1 {
-		if err = h.sortNodes(ctx, query, nodes); err != nil {
-			return 0, nil, err
+		return 0, nil, nil, nil
+	}
+
+	var allUsedResource map[string]*resourceInfo
+	if isNodeResourceSort(query.SortBy) {
+		allUsedResource, err = h.getAllUsedResourcePerNode(ctx, query)
+		if err != nil {
+			return 0, nil, nil, err
+		}
+	}
+	if totalCount > 1 {
+		if err = h.sortNodes(ctx, query, nodes, allUsedResource); err != nil {
+			return 0, nil, nil, err
 		}
 	}
 
@@ -476,17 +485,17 @@ func (h *Handler) listNodeByQuery(c *gin.Context, query *view.ListNodeRequest) (
 		start := query.Offset
 		end := start + query.Limit
 		if start > totalCount {
-			return totalCount, nil, nil
+			return totalCount, nil, allUsedResource, nil
 		}
 		if end > totalCount {
 			end = totalCount
 		}
-		return totalCount, nodes[start:end], nil
+		return totalCount, nodes[start:end], allUsedResource, nil
 	}
-	return totalCount, nodes, nil
+	return totalCount, nodes, allUsedResource, nil
 }
 
-func (h *Handler) sortNodes(ctx context.Context, query *view.ListNodeRequest, nodes []*v1.Node) error {
+func (h *Handler) sortNodes(ctx context.Context, query *view.ListNodeRequest, nodes []*v1.Node, usedResources map[string]*resourceInfo) error {
 	sortBy := strings.TrimSpace(query.SortBy)
 	desc := query.Order == "desc" || query.Order == "descending"
 	if sortBy == "" || sortBy == "nodeId" || sortBy == "name" {
@@ -500,10 +509,6 @@ func (h *Handler) sortNodes(ctx context.Context, query *view.ListNodeRequest, no
 	}
 
 	resourceName := corev1.ResourceName(sortBy)
-	usedResources, err := h.getAllUsedResourcePerNode(ctx, query)
-	if err != nil {
-		return err
-	}
 	workspaceFlavors := make(map[string]string)
 	resolveWorkspaceFlavor := func(workspaceId string) string {
 		if workspaceId == "" {
@@ -543,6 +548,24 @@ func (h *Handler) sortNodes(ctx context.Context, query *view.ListNodeRequest, no
 	return nil
 }
 
+func isNodeResourceSort(sortBy string) bool {
+	switch sortBy {
+	case string(common.AmdGpu), "cpu", "memory", "ephemeral-storage", "rdma/hca":
+		return true
+	default:
+		return false
+	}
+}
+
+func validateNodeSortBy(sortBy string) error {
+	switch sortBy {
+	case "", "nodeId", "name", string(common.AmdGpu), "cpu", "memory", "ephemeral-storage", "rdma/hca":
+		return nil
+	default:
+		return commonerrors.NewBadRequest(fmt.Sprintf("unsupported sortBy %q", sortBy))
+	}
+}
+
 func (h *Handler) getAdminNodes(ctx context.Context, labelSelector labels.Selector) ([]v1.Node, error) {
 	nodeList := &v1.NodeList{}
 	if err := h.List(ctx, nodeList, &client.ListOptions{LabelSelector: labelSelector}); err != nil {
@@ -567,10 +590,13 @@ func buildListNodeBriefResponse(totalCount int, nodes []*v1.Node) (interface{}, 
 // buildListNodeResponse constructs a detailed response for node listings.
 // Includes comprehensive node information with resource usage and workspace details.
 func (h *Handler) buildListNodeResponse(ctx context.Context,
-	query *view.ListNodeRequest, totalCount int, nodes []*v1.Node) (interface{}, error) {
-	allUsedResource, err := h.getAllUsedResourcePerNode(ctx, query)
-	if err != nil {
-		return nil, err
+	query *view.ListNodeRequest, totalCount int, nodes []*v1.Node, allUsedResource map[string]*resourceInfo) (interface{}, error) {
+	var err error
+	if allUsedResource == nil {
+		allUsedResource, err = h.getAllUsedResourcePerNode(ctx, query)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Get GPU utilization from node_statistic table
@@ -1033,6 +1059,9 @@ func parseListNodeQuery(c *gin.Context) (*view.ListNodeRequest, error) {
 	query := &view.ListNodeRequest{}
 	if err := c.ShouldBindWith(&query, binding.Query); err != nil {
 		return nil, commonerrors.NewBadRequest("invalid query: " + err.Error())
+	}
+	if err := validateNodeSortBy(query.SortBy); err != nil {
+		return nil, err
 	}
 	if query.Limit == 0 {
 		query.Limit = view.DefaultQueryLimit

--- a/SaFE/apiserver/pkg/handlers/resources/node.go
+++ b/SaFE/apiserver/pkg/handlers/resources/node.go
@@ -467,9 +467,9 @@ func (h *Handler) listNodeByQuery(c *gin.Context, query *view.ListNodeRequest) (
 	if totalCount == 0 {
 		return 0, nil, nil
 	} else if totalCount > 1 {
-		sort.Slice(nodes, func(i, j int) bool {
-			return nodes[i].Name < nodes[j].Name
-		})
+		if err = h.sortNodes(ctx, query, nodes); err != nil {
+			return 0, nil, err
+		}
 	}
 
 	if query.Limit >= 0 {
@@ -484,6 +484,63 @@ func (h *Handler) listNodeByQuery(c *gin.Context, query *view.ListNodeRequest) (
 		return totalCount, nodes[start:end], nil
 	}
 	return totalCount, nodes, nil
+}
+
+func (h *Handler) sortNodes(ctx context.Context, query *view.ListNodeRequest, nodes []*v1.Node) error {
+	sortBy := strings.TrimSpace(query.SortBy)
+	desc := query.Order == "desc" || query.Order == "descending"
+	if sortBy == "" || sortBy == "nodeId" || sortBy == "name" {
+		sort.Slice(nodes, func(i, j int) bool {
+			if desc {
+				return nodes[i].Name > nodes[j].Name
+			}
+			return nodes[i].Name < nodes[j].Name
+		})
+		return nil
+	}
+
+	resourceName := corev1.ResourceName(sortBy)
+	usedResources, err := h.getAllUsedResourcePerNode(ctx, query)
+	if err != nil {
+		return err
+	}
+	workspaceFlavors := make(map[string]string)
+	resolveWorkspaceFlavor := func(workspaceId string) string {
+		if workspaceId == "" {
+			return ""
+		}
+		if flavor, ok := workspaceFlavors[workspaceId]; ok {
+			return flavor
+		}
+		flavor := ""
+		if workspace, wsErr := h.getAdminWorkspace(ctx, workspaceId); wsErr == nil {
+			flavor = workspace.Spec.NodeFlavor
+		}
+		workspaceFlavors[workspaceId] = flavor
+		return flavor
+	}
+	resourceValue := func(node *v1.Node) int64 {
+		avail := quantity.GetAvailableResource(node.Status.Resources)
+		if used := usedResources[node.Name]; used != nil && len(used.resource) > 0 {
+			avail = quantity.SubResource(avail, used.resource)
+		}
+		if !nodeContributesAvailable(node, resolveWorkspaceFlavor(v1.GetWorkspaceId(node))) {
+			avail = quantity.MultiResource(node.Status.Resources, 0)
+		}
+		quantityValue := quantity.NonNegative(avail)[resourceName]
+		return quantityValue.Value()
+	}
+	sort.Slice(nodes, func(i, j int) bool {
+		iv, jv := resourceValue(nodes[i]), resourceValue(nodes[j])
+		if iv == jv {
+			return nodes[i].Name < nodes[j].Name
+		}
+		if desc {
+			return iv > jv
+		}
+		return iv < jv
+	})
+	return nil
 }
 
 func (h *Handler) getAdminNodes(ctx context.Context, labelSelector labels.Selector) ([]v1.Node, error) {

--- a/SaFE/apiserver/pkg/handlers/resources/node_test.go
+++ b/SaFE/apiserver/pkg/handlers/resources/node_test.go
@@ -212,7 +212,7 @@ func TestSortNodesByNameDescending(t *testing.T) {
 		{ObjectMeta: metav1.ObjectMeta{Name: "node-c"}},
 		{ObjectMeta: metav1.ObjectMeta{Name: "node-b"}},
 	}
-	err := h.sortNodes(context.Background(), &view.ListNodeRequest{SortBy: "nodeId", Order: "desc"}, nodes)
+	err := h.sortNodes(context.Background(), &view.ListNodeRequest{SortBy: "nodeId", Order: "desc"}, nodes, nil)
 	assert.NilError(t, err)
 	assert.Equal(t, nodes[0].Name, "node-c")
 	assert.Equal(t, nodes[1].Name, "node-b")
@@ -241,10 +241,10 @@ func TestSortNodesByAvailableResourceBranches(t *testing.T) {
 		WorkspaceId: pointer.String(workspace.Name),
 		SortBy:      string(common.AmdGpu),
 		Order:       "ascending",
-	}, nodes)
+	}, nodes, nil)
 	assert.NilError(t, err)
 	assert.Equal(t, nodes[0].Name, blockedNode.Name)
-	assert.Equal(t, nodes[2].Name, freeNode.Name)
+	assert.Equal(t, nodes[2].Name, usedNode.Name)
 }
 
 func TestPatchNode(t *testing.T) {
@@ -315,6 +315,11 @@ func TestParseListNodeQuery(t *testing.T) {
 	query, err = parseListNodeQuery(c)
 	assert.NilError(t, err)
 	assert.Equal(t, query.WorkspaceId == nil, true)
+
+	c, _ = gin.CreateTestContext(rsp)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/nodes?sortBy=not-a-resource", nil)
+	_, err = parseListNodeQuery(c)
+	assert.Assert(t, err != nil)
 }
 
 func TestBuildNodeLabelSelector(t *testing.T) {

--- a/SaFE/apiserver/pkg/handlers/resources/node_test.go
+++ b/SaFE/apiserver/pkg/handlers/resources/node_test.go
@@ -205,6 +205,48 @@ func TestListNodesSortsAvailableResourceBeforePagination(t *testing.T) {
 	assert.Equal(t, result.Items[1].NodeId, mid.Name)
 }
 
+func TestSortNodesByNameDescending(t *testing.T) {
+	h := Handler{}
+	nodes := []*v1.Node{
+		{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "node-c"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "node-b"}},
+	}
+	err := h.sortNodes(context.Background(), &view.ListNodeRequest{SortBy: "nodeId", Order: "desc"}, nodes)
+	assert.NilError(t, err)
+	assert.Equal(t, nodes[0].Name, "node-c")
+	assert.Equal(t, nodes[1].Name, "node-b")
+	assert.Equal(t, nodes[2].Name, "node-a")
+}
+
+func TestSortNodesByAvailableResourceBranches(t *testing.T) {
+	clusterId := "test-cluster"
+	nodeFlavorId := "test-nodeflavor"
+	workspace := genMockWorkspace(clusterId, nodeFlavorId)
+	user := genMockUser()
+	role := genMockRole()
+
+	usedNode := genAvailableNode("node-used", clusterId, workspace.Name, nodeFlavorId, genMockNodeResource(64, 2*1024*1024*1024, 8))
+	freeNode := genAvailableNode("node-free", clusterId, workspace.Name, nodeFlavorId, genMockNodeResource(64, 2*1024*1024*1024, 6))
+	blockedNode := genAvailableNode("node-blocked", clusterId, workspace.Name, "other-flavor", genMockNodeResource(64, 2*1024*1024*1024, 100))
+	workload := genMockWorkload(clusterId, workspace.Name)
+	workload.Status.Pods = []v1.WorkloadPod{{AdminNodeName: usedNode.Name}}
+
+	fakeClient := fake.NewClientBuilder().WithObjects(workspace, usedNode, freeNode, blockedNode, workload, user, role).
+		WithStatusSubresource(workload).WithScheme(scheme.Scheme).Build()
+	h := Handler{Client: fakeClient, accessController: authority.NewAccessController(fakeClient)}
+	nodes := []*v1.Node{usedNode, freeNode, blockedNode}
+
+	err := h.sortNodes(context.Background(), &view.ListNodeRequest{
+		WorkspaceId: pointer.String(workspace.Name),
+		SortBy:      string(common.AmdGpu),
+		Order:       "ascending",
+	}, nodes)
+	assert.NilError(t, err)
+	assert.Equal(t, nodes[0].Name, blockedNode.Name)
+	assert.Equal(t, nodes[2].Name, freeNode.Name)
+}
+
 func TestPatchNode(t *testing.T) {
 	clusterId := "test-cluster"
 	nodeFlavor := genMockNodeFlavor()

--- a/SaFE/apiserver/pkg/handlers/resources/node_test.go
+++ b/SaFE/apiserver/pkg/handlers/resources/node_test.go
@@ -173,6 +173,38 @@ func TestListNodes(t *testing.T) {
 	assert.Equal(t, result.Items[1].Workloads[0].Id, workload2.Name)
 }
 
+func TestListNodesSortsAvailableResourceBeforePagination(t *testing.T) {
+	clusterId := "test-cluster"
+	nodeFlavorId := "test-nodeflavor"
+	workspace := genMockWorkspace(clusterId, nodeFlavorId)
+	user := genMockUser()
+	role := genMockRole()
+
+	low := genAvailableNode("node-a-low", clusterId, workspace.Name, nodeFlavorId, genMockNodeResource(64, 2*1024*1024*1024, 1))
+	high := genAvailableNode("node-b-high", clusterId, workspace.Name, nodeFlavorId, genMockNodeResource(64, 2*1024*1024*1024, 8))
+	mid := genAvailableNode("node-c-mid", clusterId, workspace.Name, nodeFlavorId, genMockNodeResource(64, 2*1024*1024*1024, 4))
+
+	fakeClient := fake.NewClientBuilder().WithObjects(workspace, low, high, mid, user, role).
+		WithScheme(scheme.Scheme).Build()
+	h := Handler{Client: fakeClient, accessController: authority.NewAccessController(fakeClient)}
+
+	rsp := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rsp)
+	c.Set(common.UserId, user.Name)
+	c.Request = httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/api/v1/nodes?workspaceId=%s&sortBy=%s&order=desc&limit=2&offset=0", workspace.Name, common.AmdGpu), nil)
+	h.ListNode(c)
+	assert.Equal(t, rsp.Code, http.StatusOK)
+
+	result := &view.ListNodeResponse{}
+	err := json.Unmarshal(rsp.Body.Bytes(), result)
+	assert.NilError(t, err)
+	assert.Equal(t, result.TotalCount, 3)
+	assert.Equal(t, len(result.Items), 2)
+	assert.Equal(t, result.Items[0].NodeId, high.Name)
+	assert.Equal(t, result.Items[1].NodeId, mid.Name)
+}
+
 func TestPatchNode(t *testing.T) {
 	clusterId := "test-cluster"
 	nodeFlavor := genMockNodeFlavor()

--- a/SaFE/apiserver/pkg/handlers/resources/routers.go
+++ b/SaFE/apiserver/pkg/handlers/resources/routers.go
@@ -33,6 +33,7 @@ func InitCustomRouters(e *gin.Engine, h *Handler) {
 			workloads.PATCH(fmt.Sprintf("/:%s", common.Name), middleware.Audit("workload"), h.PatchWorkload)
 			workloads.GET("", h.ListWorkload)
 			workloads.GET(fmt.Sprintf("/:%s", common.Name), h.GetWorkload)
+			workloads.GET(fmt.Sprintf("/:%s/dispatch-nodes", common.Name), h.GetWorkloadDispatchNodes)
 			workloads.GET(fmt.Sprintf("/:%s/service", common.Name), h.GetWorkloadService)
 			workloads.GET(fmt.Sprintf("/:%s/pods/:%s/logs", common.Name, common.PodId), h.GetWorkloadPodLog)
 			workloads.GET(fmt.Sprintf("/:%s/pods/:%s/containers", common.Name, common.PodId), h.GetWorkloadPodContainers)

--- a/SaFE/apiserver/pkg/handlers/resources/view/node_view.go
+++ b/SaFE/apiserver/pkg/handlers/resources/view/node_view.go
@@ -60,6 +60,10 @@ type ListNodeRequest struct {
 	Offset int `form:"offset" binding:"omitempty,min=0"`
 	// Limit the number of returned results. default: 100, -1 for all
 	Limit int `form:"limit" binding:"omitempty"`
+	// Sort field. Supports nodeId and resource keys such as amd.com/gpu, cpu, memory, ephemeral-storage, rdma/hca.
+	SortBy string `form:"sortBy" binding:"omitempty,max=128"`
+	// Sort order. Supports asc/desc and Element Plus ascending/descending values.
+	Order string `form:"order" binding:"omitempty,oneof=asc desc ascending descending"`
 }
 
 // GetWorkspaceId returns the workspace ID from the request.

--- a/SaFE/apiserver/pkg/handlers/resources/view/workload_view.go
+++ b/SaFE/apiserver/pkg/handlers/resources/view/workload_view.go
@@ -276,6 +276,26 @@ type GetWorkloadResponse struct {
 	ForceHostNetwork bool `json:"forceHostNetwork"`
 }
 
+type GetWorkloadDispatchNodesRequest struct {
+	// DispatchIndex is zero-based. It matches workload_dispatch_node.dispatch_index.
+	DispatchIndex int `form:"dispatchIndex" binding:"omitempty,min=0"`
+	// Starting offset inside the selected dispatch node list. default 0
+	Offset int `form:"offset" binding:"omitempty,min=0"`
+	// Limit the number of returned nodes. default 100
+	Limit int `form:"limit" binding:"omitempty,min=1,max=500"`
+}
+
+type GetWorkloadDispatchNodesResponse struct {
+	// TotalCount indicates the total nodes in the selected dispatch, not limited by pagination.
+	TotalCount int `json:"totalCount"`
+	// DispatchIndex is zero-based.
+	DispatchIndex int      `json:"dispatchIndex"`
+	Offset        int      `json:"offset"`
+	Limit         int      `json:"limit"`
+	Nodes         []string `json:"nodes"`
+	Ranks         []string `json:"ranks,omitempty"`
+}
+
 type WorkloadPodWrapper struct {
 	v1.WorkloadPod
 	// SSH command for direct login into the container

--- a/SaFE/apiserver/pkg/handlers/resources/workload.go
+++ b/SaFE/apiserver/pkg/handlers/resources/workload.go
@@ -7,7 +7,9 @@ package resources
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -79,6 +81,11 @@ func (h *Handler) ListWorkload(c *gin.Context) {
 // Returns complete workload information including status and configuration.
 func (h *Handler) GetWorkload(c *gin.Context) {
 	handle(c, h.getWorkload)
+}
+
+// GetWorkloadDispatchNodes retrieves a paginated node/rank list for one workload dispatch.
+func (h *Handler) GetWorkloadDispatchNodes(c *gin.Context) {
+	handle(c, h.getWorkloadDispatchNodes)
 }
 
 // DeleteWorkload handles deletion of a single workload resource.
@@ -376,6 +383,51 @@ func (h *Handler) getWorkload(c *gin.Context) (interface{}, error) {
 		return nil, err
 	}
 	return h.cvtDBWorkloadToGetResponse(ctx, requestUser, roles, dbWorkload), nil
+}
+
+func (h *Handler) getWorkloadDispatchNodes(c *gin.Context) (interface{}, error) {
+	if !commonconfig.IsDBEnable() {
+		return nil, commonerrors.NewInternalError("the database function is not enabled")
+	}
+	query := &view.GetWorkloadDispatchNodesRequest{}
+	if err := c.ShouldBindQuery(query); err != nil {
+		return nil, commonerrors.NewBadRequest(err.Error())
+	}
+	if query.Limit == 0 {
+		query.Limit = view.DefaultQueryLimit
+	}
+
+	requestUser, err := h.getAndSetUsername(c)
+	if err != nil {
+		return nil, err
+	}
+	roles := h.accessController.GetRoles(c.Request.Context(), requestUser)
+
+	name := c.GetString(common.Name)
+	ctx := c.Request.Context()
+	dbWorkload, err := h.dbClient.GetWorkload(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	adminWorkload := generateWorkloadForAuth(name, dbutils.ParseNullString(dbWorkload.UserId), dbWorkload.Workspace, dbWorkload.Cluster)
+	if err = h.authWorkloadAction(c, adminWorkload, v1.GetVerb, v1.WorkloadKind, requestUser, roles); err != nil {
+		return nil, err
+	}
+
+	nodes, ranks, err := h.getDispatchNodesAndRanks(ctx, dbWorkload, query.DispatchIndex)
+	if err != nil {
+		return nil, err
+	}
+	totalCount := len(nodes)
+	nodes, ranks = paginateNodesAndRanks(nodes, ranks, query.Offset, query.Limit)
+	return &view.GetWorkloadDispatchNodesResponse{
+		TotalCount:    totalCount,
+		DispatchIndex: query.DispatchIndex,
+		Offset:        query.Offset,
+		Limit:         query.Limit,
+		Nodes:         nodes,
+		Ranks:         ranks,
+	}, nil
 }
 
 // deleteWorkload implements single workload deletion logic.
@@ -1525,6 +1577,80 @@ func (h *Handler) listOffloadedDispatchNodes(ctx context.Context, workloadId str
 		return nil
 	}
 	return rows
+}
+
+func (h *Handler) getDispatchNodesAndRanks(ctx context.Context, dbWorkload *dbclient.Workload, dispatchIndex int) ([]string, []string, error) {
+	if dbWorkload == nil || dispatchIndex < 0 {
+		return nil, nil, nil
+	}
+	if h.dbClient != nil {
+		row, err := h.dbClient.GetWorkloadDispatchNode(ctx, dbWorkload.WorkloadId, dispatchIndex)
+		if err == nil && row != nil {
+			return decodeDispatchStringSlice(row.Nodes), decodeDispatchStringSlice(row.Ranks), nil
+		}
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return nil, nil, err
+		}
+		rows, listErr := h.dbClient.ListWorkloadDispatchNodes(ctx, dbWorkload.WorkloadId)
+		if listErr != nil {
+			klog.ErrorS(listErr, "failed to list workload dispatch nodes from DB for pagination fallback",
+				"workloadId", dbWorkload.WorkloadId)
+		} else if len(rows) > 0 {
+			return nil, nil, nil
+		}
+	}
+
+	var nodes [][]string
+	if str := dbutils.ParseNullString(dbWorkload.Nodes); str != "" {
+		json.Unmarshal([]byte(str), &nodes)
+	}
+	var ranks [][]string
+	if str := dbutils.ParseNullString(dbWorkload.Ranks); str != "" {
+		json.Unmarshal([]byte(str), &ranks)
+	}
+	var selectedNodes []string
+	if dispatchIndex < len(nodes) {
+		selectedNodes = nodes[dispatchIndex]
+	}
+	var selectedRanks []string
+	if dispatchIndex < len(ranks) {
+		selectedRanks = ranks[dispatchIndex]
+	}
+	return selectedNodes, selectedRanks, nil
+}
+
+func decodeDispatchStringSlice(value sql.NullString) []string {
+	if !value.Valid || value.String == "" {
+		return nil
+	}
+	var result []string
+	if err := json.Unmarshal([]byte(value.String), &result); err != nil {
+		return nil
+	}
+	return result
+}
+
+func paginateNodesAndRanks(nodes, ranks []string, offset, limit int) ([]string, []string) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	if offset >= len(nodes) {
+		return []string{}, []string{}
+	}
+	end := offset + limit
+	if end > len(nodes) {
+		end = len(nodes)
+	}
+	pageNodes := append([]string(nil), nodes[offset:end]...)
+	pageRanks := []string{}
+	if offset < len(ranks) {
+		rankEnd := end
+		if rankEnd > len(ranks) {
+			rankEnd = len(ranks)
+		}
+		pageRanks = append([]string(nil), ranks[offset:rankEnd]...)
+	}
+	return pageNodes, pageRanks
 }
 
 // parseCustomerLabels separates user-defined labels from node selection labels.

--- a/SaFE/apiserver/pkg/handlers/resources/workload.go
+++ b/SaFE/apiserver/pkg/handlers/resources/workload.go
@@ -1625,6 +1625,7 @@ func decodeDispatchStringSlice(value sql.NullString) []string {
 	}
 	var result []string
 	if err := json.Unmarshal([]byte(value.String), &result); err != nil {
+		klog.Warningf("failed to decode workload dispatch node JSON: %v", err)
 		return nil
 	}
 	return result

--- a/SaFE/apiserver/pkg/handlers/resources/workload_wrappers_test.go
+++ b/SaFE/apiserver/pkg/handlers/resources/workload_wrappers_test.go
@@ -7,6 +7,7 @@ package resources
 
 import (
 	"database/sql"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -89,4 +90,135 @@ func TestGetWorkloadWrapper(t *testing.T) {
 	c.Set(common.Name, "wl-1")
 	h.GetWorkload(c)
 	assert.Equal(t, http.StatusOK, rsp.Code)
+}
+
+func TestGetWorkloadDispatchNodesWrapper(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	h, user, mockDB := newWorkloadDBHandler(t, ctrl)
+	mockDB.EXPECT().GetWorkload(gomock.Any(), "wl-1").Return(&dbclient.Workload{
+		WorkloadId: "wl-1",
+		Workspace:  "ws-1",
+		Cluster:    "c1",
+		UserId:     sql.NullString{String: user.Name, Valid: true},
+	}, nil)
+	mockDB.EXPECT().GetWorkloadDispatchNode(gomock.Any(), "wl-1", 1).Return(&dbclient.WorkloadDispatchNode{
+		WorkloadId:    "wl-1",
+		DispatchIndex: 1,
+		Nodes:         sql.NullString{String: `["n1","n2","n3"]`, Valid: true},
+		Ranks:         sql.NullString{String: `["0","1","2"]`, Valid: true},
+	}, nil)
+
+	rsp := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rsp)
+	c.Request = httptest.NewRequest(http.MethodGet, "/?dispatchIndex=1&offset=1&limit=1", nil)
+	c.Set(common.UserId, user.Name)
+	c.Set(common.Name, "wl-1")
+	h.GetWorkloadDispatchNodes(c)
+	assert.Equal(t, http.StatusOK, rsp.Code)
+
+	var body map[string]interface{}
+	assert.NoError(t, json.Unmarshal(rsp.Body.Bytes(), &body))
+	assert.Equal(t, float64(3), body["totalCount"])
+	assert.Equal(t, []interface{}{"n2"}, body["nodes"])
+	assert.Equal(t, []interface{}{"1"}, body["ranks"])
+}
+
+func TestGetWorkloadDispatchNodesLegacyFallback(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	h, user, mockDB := newWorkloadDBHandler(t, ctrl)
+	mockDB.EXPECT().GetWorkload(gomock.Any(), "wl-legacy").Return(&dbclient.Workload{
+		WorkloadId: "wl-legacy",
+		Workspace:  "ws-1",
+		Cluster:    "c1",
+		UserId:     sql.NullString{String: user.Name, Valid: true},
+		Nodes:      sql.NullString{String: `[["n0"],["n1","n2","n3"]]`, Valid: true},
+		Ranks:      sql.NullString{String: `[["0"],["0","1","2"]]`, Valid: true},
+	}, nil)
+	mockDB.EXPECT().GetWorkloadDispatchNode(gomock.Any(), "wl-legacy", 1).Return(nil, sql.ErrNoRows)
+	mockDB.EXPECT().ListWorkloadDispatchNodes(gomock.Any(), "wl-legacy").Return(nil, nil)
+
+	rsp := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rsp)
+	c.Request = httptest.NewRequest(http.MethodGet, "/?dispatchIndex=1&offset=0&limit=2", nil)
+	c.Set(common.UserId, user.Name)
+	c.Set(common.Name, "wl-legacy")
+	h.GetWorkloadDispatchNodes(c)
+	assert.Equal(t, http.StatusOK, rsp.Code)
+
+	var body map[string]interface{}
+	assert.NoError(t, json.Unmarshal(rsp.Body.Bytes(), &body))
+	assert.Equal(t, float64(3), body["totalCount"])
+	assert.Equal(t, []interface{}{"n1", "n2"}, body["nodes"])
+	assert.Equal(t, []interface{}{"0", "1"}, body["ranks"])
+}
+
+func TestGetWorkloadDispatchNodesLegacyFallbackOnListError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	h, user, mockDB := newWorkloadDBHandler(t, ctrl)
+	mockDB.EXPECT().GetWorkload(gomock.Any(), "wl-legacy-list-error").Return(&dbclient.Workload{
+		WorkloadId: "wl-legacy-list-error",
+		Workspace:  "ws-1",
+		Cluster:    "c1",
+		UserId:     sql.NullString{String: user.Name, Valid: true},
+		Nodes:      sql.NullString{String: `[["n0"],["n1","n2","n3"]]`, Valid: true},
+		Ranks:      sql.NullString{String: `[["0"],["0","1","2"]]`, Valid: true},
+	}, nil)
+	mockDB.EXPECT().GetWorkloadDispatchNode(gomock.Any(), "wl-legacy-list-error", 1).Return(nil, sql.ErrNoRows)
+	mockDB.EXPECT().ListWorkloadDispatchNodes(gomock.Any(), "wl-legacy-list-error").Return(nil, sql.ErrConnDone)
+
+	rsp := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rsp)
+	c.Request = httptest.NewRequest(http.MethodGet, "/?dispatchIndex=1&offset=1&limit=1", nil)
+	c.Set(common.UserId, user.Name)
+	c.Set(common.Name, "wl-legacy-list-error")
+	h.GetWorkloadDispatchNodes(c)
+	assert.Equal(t, http.StatusOK, rsp.Code)
+
+	var body map[string]interface{}
+	assert.NoError(t, json.Unmarshal(rsp.Body.Bytes(), &body))
+	assert.Equal(t, float64(3), body["totalCount"])
+	assert.Equal(t, []interface{}{"n2"}, body["nodes"])
+	assert.Equal(t, []interface{}{"1"}, body["ranks"])
+}
+
+func TestGetWorkloadDispatchNodesNoLegacyFallbackWhenOffloadExists(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	h, user, mockDB := newWorkloadDBHandler(t, ctrl)
+	mockDB.EXPECT().GetWorkload(gomock.Any(), "wl-mixed").Return(&dbclient.Workload{
+		WorkloadId: "wl-mixed",
+		Workspace:  "ws-1",
+		Cluster:    "c1",
+		UserId:     sql.NullString{String: user.Name, Valid: true},
+		Nodes:      sql.NullString{String: `[["stale-n0"],["stale-n1"]]`, Valid: true},
+		Ranks:      sql.NullString{String: `[["0"],["1"]]`, Valid: true},
+	}, nil)
+	mockDB.EXPECT().GetWorkloadDispatchNode(gomock.Any(), "wl-mixed", 1).Return(nil, sql.ErrNoRows)
+	mockDB.EXPECT().ListWorkloadDispatchNodes(gomock.Any(), "wl-mixed").Return([]*dbclient.WorkloadDispatchNode{
+		{WorkloadId: "wl-mixed", DispatchIndex: 0, Nodes: sql.NullString{String: `["fresh-n0"]`, Valid: true}},
+	}, nil)
+
+	rsp := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rsp)
+	c.Request = httptest.NewRequest(http.MethodGet, "/?dispatchIndex=1&offset=0&limit=100", nil)
+	c.Set(common.UserId, user.Name)
+	c.Set(common.Name, "wl-mixed")
+	h.GetWorkloadDispatchNodes(c)
+	assert.Equal(t, http.StatusOK, rsp.Code)
+
+	var body map[string]interface{}
+	assert.NoError(t, json.Unmarshal(rsp.Body.Bytes(), &body))
+	assert.Equal(t, float64(0), body["totalCount"])
+	assert.Equal(t, []interface{}{}, body["nodes"])
 }

--- a/SaFE/apiserver/pkg/handlers/resources/workload_wrappers_test.go
+++ b/SaFE/apiserver/pkg/handlers/resources/workload_wrappers_test.go
@@ -6,6 +6,7 @@
 package resources
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"net/http"
@@ -126,6 +127,61 @@ func TestGetWorkloadDispatchNodesWrapper(t *testing.T) {
 	assert.Equal(t, []interface{}{"1"}, body["ranks"])
 }
 
+func TestGetWorkloadDispatchNodesDefaultLimit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	h, user, mockDB := newWorkloadDBHandler(t, ctrl)
+	mockDB.EXPECT().GetWorkload(gomock.Any(), "wl-default").Return(&dbclient.Workload{
+		WorkloadId: "wl-default",
+		Workspace:  "ws-1",
+		Cluster:    "c1",
+		UserId:     sql.NullString{String: user.Name, Valid: true},
+	}, nil)
+	mockDB.EXPECT().GetWorkloadDispatchNode(gomock.Any(), "wl-default", 0).Return(&dbclient.WorkloadDispatchNode{
+		WorkloadId:    "wl-default",
+		DispatchIndex: 0,
+		Nodes:         sql.NullString{String: `["n1"]`, Valid: true},
+	}, nil)
+
+	rsp := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rsp)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+	c.Set(common.UserId, user.Name)
+	c.Set(common.Name, "wl-default")
+	h.GetWorkloadDispatchNodes(c)
+	assert.Equal(t, http.StatusOK, rsp.Code)
+
+	var body map[string]interface{}
+	assert.NoError(t, json.Unmarshal(rsp.Body.Bytes(), &body))
+	assert.Equal(t, float64(100), body["limit"])
+}
+
+func TestGetWorkloadDispatchNodesInvalidQuery(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	h, _, _ := newWorkloadDBHandler(t, ctrl)
+	rsp := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rsp)
+	c.Request = httptest.NewRequest(http.MethodGet, "/?limit=9999", nil)
+	h.GetWorkloadDispatchNodes(c)
+	assert.Equal(t, http.StatusBadRequest, rsp.Code)
+}
+
+func TestGetWorkloadDispatchNodesDBDisabled(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	commonconfig.SetValue("db.enable", "")
+	rsp := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rsp)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+	h := &Handler{}
+	h.GetWorkloadDispatchNodes(c)
+	assert.Equal(t, http.StatusInternalServerError, rsp.Code)
+}
+
 func TestGetWorkloadDispatchNodesLegacyFallback(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	ctrl := gomock.NewController(t)
@@ -221,4 +277,50 @@ func TestGetWorkloadDispatchNodesNoLegacyFallbackWhenOffloadExists(t *testing.T)
 	assert.NoError(t, json.Unmarshal(rsp.Body.Bytes(), &body))
 	assert.Equal(t, float64(0), body["totalCount"])
 	assert.Equal(t, []interface{}{}, body["nodes"])
+}
+
+func TestGetWorkloadDispatchNodesOffloadReadError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	h, user, mockDB := newWorkloadDBHandler(t, ctrl)
+	mockDB.EXPECT().GetWorkload(gomock.Any(), "wl-offload-error").Return(&dbclient.Workload{
+		WorkloadId: "wl-offload-error",
+		Workspace:  "ws-1",
+		Cluster:    "c1",
+		UserId:     sql.NullString{String: user.Name, Valid: true},
+	}, nil)
+	mockDB.EXPECT().GetWorkloadDispatchNode(gomock.Any(), "wl-offload-error", 0).Return(nil, sql.ErrConnDone)
+
+	rsp := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rsp)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+	c.Set(common.UserId, user.Name)
+	c.Set(common.Name, "wl-offload-error")
+	h.GetWorkloadDispatchNodes(c)
+	assert.Equal(t, http.StatusInternalServerError, rsp.Code)
+}
+
+func TestDispatchNodeHelpers(t *testing.T) {
+	h := &Handler{}
+	nodes, ranks, err := h.getDispatchNodesAndRanks(context.Background(), nil, 0)
+	assert.NoError(t, err)
+	assert.Nil(t, nodes)
+	assert.Nil(t, ranks)
+
+	nodes, ranks = paginateNodesAndRanks([]string{"n1"}, []string{"0"}, 0, 0)
+	assert.Nil(t, nodes)
+	assert.Nil(t, ranks)
+
+	nodes, ranks = paginateNodesAndRanks([]string{"n1"}, nil, 10, 10)
+	assert.Equal(t, []string{}, nodes)
+	assert.Equal(t, []string{}, ranks)
+
+	nodes, ranks = paginateNodesAndRanks([]string{"n1", "n2"}, []string{"0"}, 0, 2)
+	assert.Equal(t, []string{"n1", "n2"}, nodes)
+	assert.Equal(t, []string{"0"}, ranks)
+
+	assert.Nil(t, decodeDispatchStringSlice(sql.NullString{}))
+	assert.Nil(t, decodeDispatchStringSlice(sql.NullString{String: `not-json`, Valid: true}))
 }

--- a/SaFE/apiserver/pkg/handlers/resources/workload_wrappers_test.go
+++ b/SaFE/apiserver/pkg/handlers/resources/workload_wrappers_test.go
@@ -26,6 +26,7 @@ import (
 	commonconfig "github.com/AMD-AIG-AIMA/SAFE/common/pkg/config"
 	dbclient "github.com/AMD-AIG-AIMA/SAFE/common/pkg/database/client"
 	mockdb "github.com/AMD-AIG-AIMA/SAFE/common/pkg/database/client/mock"
+	commonerrors "github.com/AMD-AIG-AIMA/SAFE/common/pkg/errors"
 )
 
 func newWorkloadDBHandler(t *testing.T, ctrl *gomock.Controller) (*Handler, *v1.User, *mockdb.MockInterface) {
@@ -174,6 +175,7 @@ func TestGetWorkloadDispatchNodesInvalidQuery(t *testing.T) {
 func TestGetWorkloadDispatchNodesDBDisabled(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	commonconfig.SetValue("db.enable", "")
+	t.Cleanup(func() { commonconfig.SetValue("db.enable", "true") })
 	rsp := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(rsp)
 	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
@@ -300,6 +302,24 @@ func TestGetWorkloadDispatchNodesOffloadReadError(t *testing.T) {
 	c.Set(common.Name, "wl-offload-error")
 	h.GetWorkloadDispatchNodes(c)
 	assert.Equal(t, http.StatusInternalServerError, rsp.Code)
+}
+
+func TestGetWorkloadDispatchNodesForbidden(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	h, user, mockDB := newWorkloadDBHandler(t, ctrl)
+	mockDB.EXPECT().GetWorkload(gomock.Any(), "wl-forbidden").
+		Return(nil, commonerrors.NewForbidden("forbidden workload"))
+
+	rsp := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rsp)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+	c.Set(common.UserId, user.Name)
+	c.Set(common.Name, "wl-forbidden")
+	h.GetWorkloadDispatchNodes(c)
+	assert.Equal(t, http.StatusForbidden, rsp.Code)
 }
 
 func TestDispatchNodeHelpers(t *testing.T) {

--- a/SaFE/common/pkg/database/client/crud_sqlx_test.go
+++ b/SaFE/common/pkg/database/client/crud_sqlx_test.go
@@ -103,6 +103,7 @@ func TestWorkloadDispatchNodeCRUD(t *testing.T) {
 	ctx := context.Background()
 
 	_ = c.UpsertWorkloadDispatchNode(ctx, &WorkloadDispatchNode{WorkloadId: "w1", DispatchIndex: 0})
+	_, _ = c.GetWorkloadDispatchNode(ctx, "w1", 0)
 	_, _ = c.ListWorkloadDispatchNodes(ctx, "w1")
 	_ = c.DeleteWorkloadDispatchNodes(ctx, "w1")
 }

--- a/SaFE/common/pkg/database/client/interface.go
+++ b/SaFE/common/pkg/database/client/interface.go
@@ -68,6 +68,7 @@ type WorkloadPodInterface interface {
 // history offloaded from the etcd Workload status (WorkloadStatus.Nodes/.Ranks).
 type WorkloadDispatchNodeInterface interface {
 	UpsertWorkloadDispatchNode(ctx context.Context, dn *WorkloadDispatchNode) error
+	GetWorkloadDispatchNode(ctx context.Context, workloadId string, dispatchIndex int) (*WorkloadDispatchNode, error)
 	ListWorkloadDispatchNodes(ctx context.Context, workloadId string) ([]*WorkloadDispatchNode, error)
 	DeleteWorkloadDispatchNodes(ctx context.Context, workloadId string) error
 }

--- a/SaFE/common/pkg/database/client/mock/mocker.go
+++ b/SaFE/common/pkg/database/client/mock/mocker.go
@@ -573,6 +573,21 @@ func (mr *MockInterfaceMockRecorder) DeleteWorkloadDispatchNodes(ctx, workloadId
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkloadDispatchNodes", reflect.TypeOf((*MockInterface)(nil).DeleteWorkloadDispatchNodes), ctx, workloadId)
 }
 
+// GetWorkloadDispatchNode mocks base method.
+func (m *MockInterface) GetWorkloadDispatchNode(ctx context.Context, workloadId string, dispatchIndex int) (*client.WorkloadDispatchNode, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWorkloadDispatchNode", ctx, workloadId, dispatchIndex)
+	ret0, _ := ret[0].(*client.WorkloadDispatchNode)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetWorkloadDispatchNode indicates an expected call of GetWorkloadDispatchNode.
+func (mr *MockInterfaceMockRecorder) GetWorkloadDispatchNode(ctx, workloadId, dispatchIndex interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkloadDispatchNode", reflect.TypeOf((*MockInterface)(nil).GetWorkloadDispatchNode), ctx, workloadId, dispatchIndex)
+}
+
 // DeleteWorkloadPods mocks base method.
 func (m *MockInterface) DeleteWorkloadPods(ctx context.Context, workloadId string) error {
 	m.ctrl.T.Helper()
@@ -2725,6 +2740,21 @@ func (m *MockWorkloadDispatchNodeInterface) DeleteWorkloadDispatchNodes(ctx cont
 func (mr *MockWorkloadDispatchNodeInterfaceMockRecorder) DeleteWorkloadDispatchNodes(ctx, workloadId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkloadDispatchNodes", reflect.TypeOf((*MockWorkloadDispatchNodeInterface)(nil).DeleteWorkloadDispatchNodes), ctx, workloadId)
+}
+
+// GetWorkloadDispatchNode mocks base method.
+func (m *MockWorkloadDispatchNodeInterface) GetWorkloadDispatchNode(ctx context.Context, workloadId string, dispatchIndex int) (*client.WorkloadDispatchNode, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWorkloadDispatchNode", ctx, workloadId, dispatchIndex)
+	ret0, _ := ret[0].(*client.WorkloadDispatchNode)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetWorkloadDispatchNode indicates an expected call of GetWorkloadDispatchNode.
+func (mr *MockWorkloadDispatchNodeInterfaceMockRecorder) GetWorkloadDispatchNode(ctx, workloadId, dispatchIndex interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkloadDispatchNode", reflect.TypeOf((*MockWorkloadDispatchNodeInterface)(nil).GetWorkloadDispatchNode), ctx, workloadId, dispatchIndex)
 }
 
 // ListWorkloadDispatchNodes mocks base method.

--- a/SaFE/common/pkg/database/client/workload_dispatch_node.go
+++ b/SaFE/common/pkg/database/client/workload_dispatch_node.go
@@ -34,6 +34,9 @@ var (
 
 	listWorkloadDispatchNodesCmd = fmt.Sprintf(
 		`SELECT * FROM %s WHERE workload_id = $1 ORDER BY dispatch_index`, TWorkloadDispatchNode)
+
+	getWorkloadDispatchNodeCmd = fmt.Sprintf(
+		`SELECT * FROM %s WHERE workload_id = $1 AND dispatch_index = $2`, TWorkloadDispatchNode)
 )
 
 // UpsertWorkloadDispatchNode inserts or updates one dispatch's node/rank row.
@@ -53,6 +56,32 @@ func (c *Client) UpsertWorkloadDispatchNode(ctx context.Context, dn *WorkloadDis
 			"workloadId", dn.WorkloadId, "dispatchIndex", dn.DispatchIndex)
 	}
 	return err
+}
+
+// GetWorkloadDispatchNode returns one dispatch row for a workload.
+func (c *Client) GetWorkloadDispatchNode(ctx context.Context, workloadId string, dispatchIndex int) (*WorkloadDispatchNode, error) {
+	if workloadId == "" {
+		return nil, commonerrors.NewBadRequest("workloadId is empty")
+	}
+	if dispatchIndex < 0 {
+		return nil, commonerrors.NewBadRequest("dispatchIndex must be greater than or equal to 0")
+	}
+	db, err := c.getDB()
+	if err != nil {
+		return nil, err
+	}
+	row := &WorkloadDispatchNode{}
+	if c.RequestTimeout > 0 {
+		ctx2, cancel := context.WithTimeout(ctx, c.RequestTimeout)
+		defer cancel()
+		err = db.GetContext(ctx2, row, getWorkloadDispatchNodeCmd, workloadId, dispatchIndex)
+	} else {
+		err = db.GetContext(ctx, row, getWorkloadDispatchNodeCmd, workloadId, dispatchIndex)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return row, nil
 }
 
 // ListWorkloadDispatchNodes returns all dispatch rows of a workload ordered by

--- a/SaFE/common/pkg/database/client/workload_dispatch_node_test.go
+++ b/SaFE/common/pkg/database/client/workload_dispatch_node_test.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+package client
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetWorkloadDispatchNodeValidation(t *testing.T) {
+	c, _ := newMockClient(t)
+	_, err := c.GetWorkloadDispatchNode(context.Background(), "", 0)
+	require.Error(t, err)
+	_, err = c.GetWorkloadDispatchNode(context.Background(), "w1", -1)
+	require.Error(t, err)
+}
+
+func TestGetWorkloadDispatchNodeSuccess(t *testing.T) {
+	c, mock := newMockClient(t)
+	mock.ExpectQuery("SELECT \\* FROM workload_dispatch_node WHERE workload_id =").
+		WithArgs("w1", 2).
+		WillReturnRows(sqlmock.NewRows([]string{"workload_id", "dispatch_index", "nodes", "ranks", "updated_at"}).
+			AddRow("w1", 2, `["n1"]`, `["0"]`, pq.NullTime{Time: time.Now(), Valid: true}))
+
+	row, err := c.GetWorkloadDispatchNode(context.Background(), "w1", 2)
+	require.NoError(t, err)
+	require.Equal(t, "w1", row.WorkloadId)
+	require.Equal(t, 2, row.DispatchIndex)
+	require.Equal(t, `["n1"]`, row.Nodes.String)
+}


### PR DESCRIPTION
## Summary
- Add a paginated workload dispatch nodes API for the workload log node table.
- Add server-side sorting for node lists by available GPU, CPU, memory, ephemeral storage, RDMA/HCA, or node name before pagination.
- Preserve legacy workload nodes/ranks fallback behavior when dispatch node offload data is unavailable.

## Test plan
- go test ./apiserver/pkg/handlers/resources -run 'TestGetWorkloadDispatchNodes|TestGetWorkloadWrapper|TestDispatchNodeHelpers|TestListNodes|TestParseListNodeQuery|TestSortNodes'
- go test ./common/pkg/database/client
- go test ./job-manager/pkg/syncer ./common/pkg/workload
- Bugbot review: no bugs found

## Frontend notes
- Workload log node tables should call GET /workloads/:name/dispatch-nodes with dispatchIndex, offset, and limit.
- Workspace node tables should pass sortBy and order to GET /nodes when sorting GPU, CPU, memory, ephemeral-storage, RDMA/HCA, or node name columns.

## Offload compatibility notes
- The dispatch nodes API reads workload_dispatch_node first.
- If checking offload rows fails, it falls back to the legacy workload.nodes/workload.ranks columns, matching the existing workload detail behavior.
- If workload_dispatch_node already has rows but the requested dispatchIndex is missing, the API returns an empty page instead of mixing in stale legacy data.