### PR TITLE
fix(web): address frontend audit report (auth, error handling, pagination, 403)

### DIFF
--- a/.github/workflows/block-sensitive-secrets.yml
+++ b/.github/workflows/block-sensitive-secrets.yml
@@ -83,6 +83,8 @@ jobs:
             # Frontend form field names and TypeScript type definitions, not credential values
             [[ "$path" == Web/apps/safe/src/pages/ModelSquare/Components/AddModelDialog.vue ]] && return 0
             [[ "$path" == Web/apps/safe/src/services/playground/index.ts ]] && return 0
+            # ImageParam.password is a TypeScript type field ("password: string"), not a credential value
+            [[ "$path" == Web/apps/safe/src/services/nodes/type.ts ]] && return 0
             # apiKey here is a variable/struct-field assignment (getApiKeyFromSecret / req.ApiKey / HasApiKey), not a credential value
             [[ "$path" == SaFE/apiserver/pkg/handlers/model-handlers/playground.go ]] && return 0
             # Test data: Source.ApiKey is a k8s LocalObjectReference (secret name), not a credential value

--- a/Web/apps/lens/src/pages/GithubWorkflow/Detail.vue
+++ b/Web/apps/lens/src/pages/GithubWorkflow/Detail.vue
@@ -243,18 +243,6 @@
                 <span v-else class="text-muted">-</span>
               </template>
             </el-table-column>
-            <el-table-column label="Actions" width="100" fixed="right" align="center">
-              <template #default="{ row }">
-                <el-button
-                  link
-                  type="primary"
-                  @click="retryRun(row)"
-                  :disabled="row.status !== 'failed'"
-                >
-                  Retry
-                </el-button>
-              </template>
-            </el-table-column>
           </el-table>
 
           <!-- Pagination -->
@@ -2183,11 +2171,6 @@ const updateConfig = async () => {
     console.error('Failed to update config:', error)
     ElMessage.error('Failed to update config')
   }
-}
-
-const retryRun = async (run: WorkflowRun) => {
-  // TODO: Implement retry API
-  ElMessage.info('Retry functionality coming soon')
 }
 
 const getStatusType = (status: string) => {

--- a/Web/apps/lens/src/pages/GithubWorkflow/RunSummaryDetail.vue
+++ b/Web/apps/lens/src/pages/GithubWorkflow/RunSummaryDetail.vue
@@ -165,7 +165,7 @@
             </el-button>
           </div>
         </template>
-        <el-table v-loading="jobsLoading" :data="jobsWithGithubName" style="width: 100%" @row-click="goToJobDetail">
+        <el-table v-loading="jobsLoading" :data="pagedJobs" style="width: 100%" @row-click="goToJobDetail">
           <el-table-column label="Job" min-width="280">
             <template #default="{ row }">
               <div class="job-cell">
@@ -202,6 +202,15 @@
             </template>
           </el-table-column>
         </el-table>
+        <div v-if="jobsWithGithubName.length > jobsPagination.pageSize" class="pagination-container">
+          <el-pagination
+            v-model:current-page="jobsPagination.page"
+            v-model:page-size="jobsPagination.pageSize"
+            :total="jobsWithGithubName.length"
+            :page-sizes="[10, 20, 50, 100]"
+            layout="total, sizes, prev, pager, next"
+          />
+        </div>
       </el-card>
     </template>
 
@@ -211,7 +220,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, computed } from 'vue'
+import { ref, reactive, onMounted, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { ElMessage } from 'element-plus'
 import {
@@ -265,6 +274,13 @@ const jobsWithGithubName = computed(() => {
     ...job,
     githubJobName: job.githubJobId ? githubJobNameMap.value.get(job.githubJobId) : undefined
   }))
+})
+
+// Client-side pagination for jobs table (backend returns full list)
+const jobsPagination = reactive({ page: 1, pageSize: 20 })
+const pagedJobs = computed(() => {
+  const start = (jobsPagination.page - 1) * jobsPagination.pageSize
+  return jobsWithGithubName.value.slice(start, start + jobsPagination.pageSize)
 })
 
 // Methods
@@ -364,6 +380,12 @@ onMounted(async () => {
 </script>
 
 <style scoped lang="scss">
+.pagination-container {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 16px;
+}
+
 .run-summary-detail {
   padding: 20px;
   

--- a/Web/apps/lens/src/pages/WorkflowMetrics/ConfigDetail.vue
+++ b/Web/apps/lens/src/pages/WorkflowMetrics/ConfigDetail.vue
@@ -18,7 +18,6 @@
             </el-tag>
           </div>
           <div class="info-actions">
-            <el-button :icon="Edit" @click="editConfig">Edit</el-button>
             <el-button :icon="Refresh" @click="triggerBackfillDialog">Backfill</el-button>
           </div>
         </div>
@@ -193,7 +192,7 @@
 import { ref, reactive, onMounted, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { ElMessage } from 'element-plus'
-import { ArrowLeft, Edit, Refresh, Link, Monitor, List, Histogram } from '@element-plus/icons-vue'
+import { ArrowLeft, Refresh, Link, Monitor, List, Histogram } from '@element-plus/icons-vue'
 import dayjs from 'dayjs'
 import {
   getConfig,
@@ -254,11 +253,6 @@ const fetchData = async () => {
 
 const goBack = () => {
   router.push('/workflow-metrics/configs')
-}
-
-const editConfig = () => {
-  // TODO: Open edit dialog
-  ElMessage.info('Edit functionality coming soon')
 }
 
 const goToRuns = () => {

--- a/Web/apps/lens/src/pages/useTable.ts
+++ b/Web/apps/lens/src/pages/useTable.ts
@@ -1,4 +1,5 @@
 import { ref, reactive, onMounted, shallowRef } from 'vue'
+import { ElMessage } from 'element-plus'
 
 interface Pagination {
   pageNum: number
@@ -49,6 +50,7 @@ export function usePaginatedTable<T, E extends any[]>(
       pagination.total = res.total
     } catch (e) {
       console.error('fetchData error:', e)
+      ElMessage.error('Failed to load data, please try again')
     } finally {
       loading.value = false
     }

--- a/Web/apps/lens/src/services/auth.ts
+++ b/Web/apps/lens/src/services/auth.ts
@@ -23,8 +23,6 @@ authRequest.interceptors.request.use(config => {
       }
       if (userId) {
         config.headers['X-User-Id'] = userId
-        // Temp backdoor: directly add userId header
-        config.headers['userId'] = userId
       }
     } catch (e) {
       console.error('Failed to parse auth info:', e)

--- a/Web/apps/lens/src/services/safe-api.ts
+++ b/Web/apps/lens/src/services/safe-api.ts
@@ -5,9 +5,7 @@ import type { AxiosRequestConfig } from 'axios'
 const safeRequest = axios.create({
   baseURL: '/api/v1',
   timeout: 10000,
-  headers: {
-    'userId': '21232f297a57a5a743894a0e4a801fc3' // Temp backdoor auth
-  }
+  withCredentials: true, // Authenticate via session cookie
 })
 
 // Response interceptor

--- a/Web/apps/safe/.env.example
+++ b/Web/apps/safe/.env.example
@@ -31,6 +31,10 @@
 # Agent socket.io path (default: /api/v1/agent/ops/socket.io)
 # VITE_AGENT_PATH=/api/v1/agent/ops/socket.io
 
+# Sandbox / code-interpreter base URL (default: /x-flannel/sandbox)
+# On the oci-slc cluster set this to /sandbox
+# VITE_SANDBOX_BASE_URL=/x-flannel/sandbox
+
 # ---------- Dev server proxy targets (no VITE_ prefix) ----------
 # These configure the Vite dev server reverse proxy.
 # Put actual values in .env.development.local.

--- a/Web/apps/safe/src/components/Base/DateRangeFilter.vue
+++ b/Web/apps/safe/src/components/Base/DateRangeFilter.vue
@@ -14,6 +14,11 @@
 <script lang="ts" setup>
 import { ref, onMounted } from 'vue'
 
+const props = defineProps<{
+  /** Optional initial range (e.g. restored from the URL). Falls back to the last-year default. */
+  initialRange?: { since?: string; until?: string }
+}>()
+
 const emit = defineEmits<{
   (e: 'change', val: { since: string; until: string }): void
 }>()
@@ -49,7 +54,12 @@ const refresh = () => {
 }
 
 onMounted(() => {
-  dateRange.value = getDefaultRange()
+  const init = props.initialRange
+  if (init?.since && init?.until) {
+    dateRange.value = [new Date(init.since), new Date(init.until)]
+  } else {
+    dateRange.value = getDefaultRange()
+  }
   emitChange()
 })
 

--- a/Web/apps/safe/src/components/Workload/LogTerminal.vue
+++ b/Web/apps/safe/src/components/Workload/LogTerminal.vue
@@ -24,7 +24,7 @@
         />
         <el-table
           ref="nodeTableRef"
-          :data="filteredTableRows"
+          :data="pagedTableRows"
           row-key="node"
           stripe
           border
@@ -45,16 +45,14 @@
         </el-table>
         <el-empty v-else description="no data" />
         <el-pagination
-          v-if="nodePagination.total > 0"
-          class="mt-2 justify-end"
+          v-if="filteredTableRows.length > nodePagination.pageSize"
+          v-model:current-page="nodePagination.page"
+          v-model:page-size="nodePagination.pageSize"
+          :total="filteredTableRows.length"
+          :page-sizes="[20, 50, 100]"
           size="small"
-          :current-page="nodePagination.page"
-          :page-size="nodePagination.pageSize"
-          :total="nodePagination.total"
-          :page-sizes="[50, 100, 200, 500]"
-          layout="total, sizes, prev, pager, next"
-          @current-change="handleNodePageChange"
-          @size-change="handleNodePageSizeChange"
+          layout="prev, pager, next"
+          class="mt-2 justify-end"
         />
       </el-card>
     </el-col>
@@ -188,10 +186,8 @@
 
 <script lang="ts" setup>
 import { computed, nextTick, reactive, ref, toRef, watch } from 'vue'
-import { ElMessage } from 'element-plus'
 import { InfoFilled, Search, Download, Top, Bottom } from '@element-plus/icons-vue'
 import { useLogTable, type RowData } from '@/composables/useLogTable'
-import { getWorkloadDispatchNodes } from '@/services/workload/index'
 import LogContextDialog from '@/components/Workload/LogContextDialog.vue'
 import { isLogDownloadEnabledForHost } from '@/utils'
 
@@ -211,56 +207,28 @@ const nodeSearch = ref('')
 const canDownloadLogs = computed(() =>
   isLogDownloadEnabledForHost(props.isDownload, window.location.hostname),
 )
-// Search only filters the current page (backend paginates the full node list).
 const filteredTableRows = computed(() => {
   const kw = nodeSearch.value.trim().toLowerCase()
   if (!kw) return tableRows.value
   return tableRows.value.filter((r) => r.node.toLowerCase().includes(kw))
 })
 
-// Server-side pagination for the dispatch node list.
-const nodePagination = reactive({ page: 1, pageSize: 100, total: 0 })
-const pagedNodes = ref<string[]>([])
-const pagedRanks = ref<string[]>([])
+// Client-side pagination for the node list (backend returns the full list per group)
+const nodePagination = reactive({ page: 1, pageSize: 20 })
+const pagedTableRows = computed(() => {
+  const start = (nodePagination.page - 1) * nodePagination.pageSize
+  return filteredTableRows.value.slice(start, start + nodePagination.pageSize)
+})
 
 const selectedGroup = ref<number>(props.dispatchCount ?? 0)
 
-const tableRows = computed<{ node: string; rank?: string }[]>(() =>
-  pagedNodes.value.map((node, idx) => ({ node, rank: pagedRanks.value[idx] })),
-)
-
-const fetchDispatchNodes = async () => {
-  if (!props.wlid) {
-    pagedNodes.value = []
-    pagedRanks.value = []
-    nodePagination.total = 0
-    return
-  }
-  try {
-    // dispatchCount may be absent for some workloads; default to the first group.
-    const dispatchIndex = selectedGroup.value > 0 ? selectedGroup.value - 1 : 0
-    const res = await getWorkloadDispatchNodes(props.wlid, {
-      dispatchIndex,
-      offset: (nodePagination.page - 1) * nodePagination.pageSize,
-      limit: nodePagination.pageSize,
-    })
-    pagedNodes.value = res?.nodes ?? []
-    pagedRanks.value = res?.ranks ?? []
-    nodePagination.total = res?.totalCount ?? 0
-  } catch (e) {
-    ElMessage.error((e as Error)?.message || 'Failed to load nodes')
-  }
-}
-
-const handleNodePageChange = (page: number) => {
-  nodePagination.page = page
-  fetchDispatchNodes()
-}
-const handleNodePageSizeChange = (size: number) => {
-  nodePagination.pageSize = size
-  nodePagination.page = 1
-  fetchDispatchNodes()
-}
+const tableRows = computed(() => {
+  if (!props.nodes || selectedGroup.value === 0) return []
+  const i = selectedGroup.value - 1
+  const nodes = props.nodes[i] ?? []
+  const ranks = props.ranks?.[i] ?? []
+  return nodes.map((node, idx) => ({ node, rank: ranks[idx] }))
+})
 
 const groupOptions = computed(() =>
   Array.from({ length: props.dispatchCount ?? 0 }, (_, i) => {
@@ -268,6 +236,10 @@ const groupOptions = computed(() =>
     return { label: String(idx), value: idx }
   }),
 )
+
+watch([nodeSearch, selectedGroup], () => {
+  nodePagination.page = 1
+})
 
 const {
   loading,
@@ -293,20 +265,6 @@ const {
   tableRows,
   toRef(props, 'failedNodes'),
   props.selectFirstN,
-  toRef(nodePagination, 'total'),
-)
-
-// Refetch the first page whenever the dispatch group changes; drop stale selection.
-// Declared after useLogTable so nodeTableRef is initialized before the immediate run.
-watch(
-  selectedGroup,
-  () => {
-    nodePagination.page = 1
-    nodeSearch.value = ''
-    nodeTableRef.value?.clearSelection?.()
-    fetchDispatchNodes()
-  },
-  { immediate: true },
 )
 
 searchParams.order = 'desc'

--- a/Web/apps/safe/src/components/Workload/LogTerminal.vue
+++ b/Web/apps/safe/src/components/Workload/LogTerminal.vue
@@ -24,7 +24,7 @@
         />
         <el-table
           ref="nodeTableRef"
-          :data="filteredTableRows"
+          :data="pagedTableRows"
           row-key="node"
           stripe
           border
@@ -44,6 +44,16 @@
           </el-table-column>
         </el-table>
         <el-empty v-else description="no data" />
+        <el-pagination
+          v-if="filteredTableRows.length > nodePagination.pageSize"
+          v-model:current-page="nodePagination.page"
+          v-model:page-size="nodePagination.pageSize"
+          :total="filteredTableRows.length"
+          :page-sizes="[20, 50, 100]"
+          size="small"
+          layout="prev, pager, next"
+          class="mt-2 justify-end"
+        />
       </el-card>
     </el-col>
     <el-col :span="18">
@@ -175,7 +185,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, nextTick, ref, toRef, watch } from 'vue'
+import { computed, nextTick, reactive, ref, toRef, watch } from 'vue'
 import { InfoFilled, Search, Download, Top, Bottom } from '@element-plus/icons-vue'
 import { useLogTable, type RowData } from '@/composables/useLogTable'
 import LogContextDialog from '@/components/Workload/LogContextDialog.vue'
@@ -203,6 +213,13 @@ const filteredTableRows = computed(() => {
   return tableRows.value.filter((r) => r.node.toLowerCase().includes(kw))
 })
 
+// Client-side pagination for the node list (backend returns the full list per group)
+const nodePagination = reactive({ page: 1, pageSize: 20 })
+const pagedTableRows = computed(() => {
+  const start = (nodePagination.page - 1) * nodePagination.pageSize
+  return filteredTableRows.value.slice(start, start + nodePagination.pageSize)
+})
+
 const selectedGroup = ref<number>(props.dispatchCount ?? 0)
 
 const tableRows = computed(() => {
@@ -219,6 +236,10 @@ const groupOptions = computed(() =>
     return { label: String(idx), value: idx }
   }),
 )
+
+watch([nodeSearch, selectedGroup], () => {
+  nodePagination.page = 1
+})
 
 const {
   loading,

--- a/Web/apps/safe/src/components/Workload/LogTerminal.vue
+++ b/Web/apps/safe/src/components/Workload/LogTerminal.vue
@@ -24,7 +24,7 @@
         />
         <el-table
           ref="nodeTableRef"
-          :data="pagedTableRows"
+          :data="filteredTableRows"
           row-key="node"
           stripe
           border
@@ -45,14 +45,16 @@
         </el-table>
         <el-empty v-else description="no data" />
         <el-pagination
-          v-if="filteredTableRows.length > nodePagination.pageSize"
-          v-model:current-page="nodePagination.page"
-          v-model:page-size="nodePagination.pageSize"
-          :total="filteredTableRows.length"
-          :page-sizes="[20, 50, 100]"
-          size="small"
-          layout="prev, pager, next"
+          v-if="nodePagination.total > 0"
           class="mt-2 justify-end"
+          size="small"
+          :current-page="nodePagination.page"
+          :page-size="nodePagination.pageSize"
+          :total="nodePagination.total"
+          :page-sizes="[50, 100, 200, 500]"
+          layout="total, sizes, prev, pager, next"
+          @current-change="handleNodePageChange"
+          @size-change="handleNodePageSizeChange"
         />
       </el-card>
     </el-col>
@@ -186,8 +188,10 @@
 
 <script lang="ts" setup>
 import { computed, nextTick, reactive, ref, toRef, watch } from 'vue'
+import { ElMessage } from 'element-plus'
 import { InfoFilled, Search, Download, Top, Bottom } from '@element-plus/icons-vue'
 import { useLogTable, type RowData } from '@/composables/useLogTable'
+import { getWorkloadDispatchNodes } from '@/services/workload/index'
 import LogContextDialog from '@/components/Workload/LogContextDialog.vue'
 import { isLogDownloadEnabledForHost } from '@/utils'
 
@@ -207,28 +211,56 @@ const nodeSearch = ref('')
 const canDownloadLogs = computed(() =>
   isLogDownloadEnabledForHost(props.isDownload, window.location.hostname),
 )
+// Search only filters the current page (backend paginates the full node list).
 const filteredTableRows = computed(() => {
   const kw = nodeSearch.value.trim().toLowerCase()
   if (!kw) return tableRows.value
   return tableRows.value.filter((r) => r.node.toLowerCase().includes(kw))
 })
 
-// Client-side pagination for the node list (backend returns the full list per group)
-const nodePagination = reactive({ page: 1, pageSize: 20 })
-const pagedTableRows = computed(() => {
-  const start = (nodePagination.page - 1) * nodePagination.pageSize
-  return filteredTableRows.value.slice(start, start + nodePagination.pageSize)
-})
+// Server-side pagination for the dispatch node list.
+const nodePagination = reactive({ page: 1, pageSize: 100, total: 0 })
+const pagedNodes = ref<string[]>([])
+const pagedRanks = ref<string[]>([])
 
 const selectedGroup = ref<number>(props.dispatchCount ?? 0)
 
-const tableRows = computed(() => {
-  if (!props.nodes || selectedGroup.value === 0) return []
-  const i = selectedGroup.value - 1
-  const nodes = props.nodes[i] ?? []
-  const ranks = props.ranks?.[i] ?? []
-  return nodes.map((node, idx) => ({ node, rank: ranks[idx] }))
-})
+const tableRows = computed<{ node: string; rank?: string }[]>(() =>
+  pagedNodes.value.map((node, idx) => ({ node, rank: pagedRanks.value[idx] })),
+)
+
+const fetchDispatchNodes = async () => {
+  if (!props.wlid) {
+    pagedNodes.value = []
+    pagedRanks.value = []
+    nodePagination.total = 0
+    return
+  }
+  try {
+    // dispatchCount may be absent for some workloads; default to the first group.
+    const dispatchIndex = selectedGroup.value > 0 ? selectedGroup.value - 1 : 0
+    const res = await getWorkloadDispatchNodes(props.wlid, {
+      dispatchIndex,
+      offset: (nodePagination.page - 1) * nodePagination.pageSize,
+      limit: nodePagination.pageSize,
+    })
+    pagedNodes.value = res?.nodes ?? []
+    pagedRanks.value = res?.ranks ?? []
+    nodePagination.total = res?.totalCount ?? 0
+  } catch (e) {
+    ElMessage.error((e as Error)?.message || 'Failed to load nodes')
+  }
+}
+
+const handleNodePageChange = (page: number) => {
+  nodePagination.page = page
+  fetchDispatchNodes()
+}
+const handleNodePageSizeChange = (size: number) => {
+  nodePagination.pageSize = size
+  nodePagination.page = 1
+  fetchDispatchNodes()
+}
 
 const groupOptions = computed(() =>
   Array.from({ length: props.dispatchCount ?? 0 }, (_, i) => {
@@ -236,10 +268,6 @@ const groupOptions = computed(() =>
     return { label: String(idx), value: idx }
   }),
 )
-
-watch([nodeSearch, selectedGroup], () => {
-  nodePagination.page = 1
-})
 
 const {
   loading,
@@ -265,6 +293,20 @@ const {
   tableRows,
   toRef(props, 'failedNodes'),
   props.selectFirstN,
+  toRef(nodePagination, 'total'),
+)
+
+// Refetch the first page whenever the dispatch group changes; drop stale selection.
+// Declared after useLogTable so nodeTableRef is initialized before the immediate run.
+watch(
+  selectedGroup,
+  () => {
+    nodePagination.page = 1
+    nodeSearch.value = ''
+    nodeTableRef.value?.clearSelection?.()
+    fetchDispatchNodes()
+  },
+  { immediate: true },
 )
 
 searchParams.order = 'desc'

--- a/Web/apps/safe/src/components/layout/BaseMenu.vue
+++ b/Web/apps/safe/src/components/layout/BaseMenu.vue
@@ -289,13 +289,14 @@ watchEffect(() => {
       tooltip: 'Deployment has been disabled by the administrator.',
       icon: menuIcons.deployment,
     },
-    {
-      index: '/dynamo',
-      name: 'Dynamo',
-      canAccess: canInfer.value,
-      tooltip: 'Dynamo has been disabled by the administrator.',
-      icon: menuIcons.dynamo,
-    },
+    // Temporarily hidden from the menu (page/route code kept for later re-enable)
+    // {
+    //   index: '/dynamo',
+    //   name: 'Dynamo',
+    //   canAccess: canInfer.value,
+    //   tooltip: 'Dynamo has been disabled by the administrator.',
+    //   icon: menuIcons.dynamo,
+    // },
     {
       index: '/infera',
       name: 'Infera',
@@ -426,12 +427,13 @@ const aiAgentMenuItems = shallowRef<MenuItem[]>([])
 // Watch permission changes, dynamically update AI Agent menu
 watchEffect(() => {
   const allAiAgentItems = [
-    {
-      index: '/chatbot',
-      name: 'Chatbot',
-      icon: menuIcons.chatbot,
-      canAccess: true, // Open to all users
-    },
+    // Temporarily hidden from the menu (page/route code kept for later re-enable)
+    // {
+    //   index: '/chatbot',
+    //   name: 'Chatbot',
+    //   icon: menuIcons.chatbot,
+    //   canAccess: true, // Open to all users
+    // },
     {
       index: '/qabase',
       name: 'QA Base',

--- a/Web/apps/safe/src/composables/useLogTable.ts
+++ b/Web/apps/safe/src/composables/useLogTable.ts
@@ -87,8 +87,6 @@ export function useLogTable(
   failedNodes?: Ref<string[] | undefined>,
   /** Default check first N nodes (falls back to first+last strategy if not set) */
   selectFirstN?: number,
-  /** Total node count of the current dispatch group (server-side, not just current page) */
-  totalNodeCount?: Ref<number>,
 ) {
   // Log table data
   const loading = ref(false)
@@ -206,13 +204,10 @@ export function useLogTable(
     searchParams.keywords = Array.from(new Set(val.map((s) => s.trim()).filter(Boolean)))
   }
 
-  // Remove nodeNames query param when all selected.
-  // Compare against the full group node count (server-side) rather than the
-  // current page, so selecting a full page of a multi-page group is not
-  // mistaken for "all nodes".
+  // Remove nodeNames query param when all selected
   const applyNodeNamesParam = (rows: NodeRow[], selected: string[]) => {
-    const total = totalNodeCount?.value ?? rows.length
-    const isAll = total > 0 && selected.length >= total
+    const total = rows.length
+    const isAll = total > 0 && selected.length === total
     if (isAll) {
       if ('nodeNames' in searchParams) delete (searchParams as any).nodeNames
     } else {

--- a/Web/apps/safe/src/composables/useLogTable.ts
+++ b/Web/apps/safe/src/composables/useLogTable.ts
@@ -87,6 +87,8 @@ export function useLogTable(
   failedNodes?: Ref<string[] | undefined>,
   /** Default check first N nodes (falls back to first+last strategy if not set) */
   selectFirstN?: number,
+  /** Total node count of the current dispatch group (server-side, not just current page) */
+  totalNodeCount?: Ref<number>,
 ) {
   // Log table data
   const loading = ref(false)
@@ -204,10 +206,13 @@ export function useLogTable(
     searchParams.keywords = Array.from(new Set(val.map((s) => s.trim()).filter(Boolean)))
   }
 
-  // Remove nodeNames query param when all selected
+  // Remove nodeNames query param when all selected.
+  // Compare against the full group node count (server-side) rather than the
+  // current page, so selecting a full page of a multi-page group is not
+  // mistaken for "all nodes".
   const applyNodeNamesParam = (rows: NodeRow[], selected: string[]) => {
-    const total = rows.length
-    const isAll = total > 0 && selected.length === total
+    const total = totalNodeCount?.value ?? rows.length
+    const isAll = total > 0 && selected.length >= total
     if (isAll) {
       if ('nodeNames' in searchParams) delete (searchParams as any).nodeNames
     } else {

--- a/Web/apps/safe/src/composables/useWorkloadListQuery.ts
+++ b/Web/apps/safe/src/composables/useWorkloadListQuery.ts
@@ -1,0 +1,81 @@
+import { useRoute, useRouter } from 'vue-router'
+import type { LocationQuery } from 'vue-router'
+import { useUserStore } from '@/stores/user'
+
+export type WorkloadScope = 'All' | 'My Workloads'
+
+interface WorkloadListSearchParams {
+  onlyMyself: string
+  userId: string
+  [key: string]: unknown
+}
+
+interface WorkloadListPagination {
+  page: number
+  pageSize: number
+  [key: string]: unknown
+}
+
+interface WorkloadListQueryConfig {
+  searchParams: WorkloadListSearchParams
+  pagination: WorkloadListPagination
+  /** Scope shown when the URL carries no explicit scope. Defaults to "My Workloads". */
+  defaultScope?: WorkloadScope
+  /** Serialize page-specific filter fields into flat query values. Empty values are omitted. */
+  serializeFilters: () => Record<string, string | undefined>
+  /** Hydrate page-specific filter fields from the URL query. */
+  parseFilters: (query: LocationQuery) => void
+}
+
+/**
+ * Centralizes the URL <-> state handling for workload list pages so that the
+ * URL query is the single source of truth.
+ *
+ * It fixes three recurring problems:
+ * - `userId` is always derived from the scope toggle and never stored in the
+ *   URL, removing the coupled/redundant param that could drift out of sync.
+ * - `writeQuery` builds a fresh query instead of spreading the previous one, so
+ *   cleared filters never linger across navigations.
+ * - the scope default is configurable and applied consistently on read.
+ */
+export function useWorkloadListQuery(config: WorkloadListQueryConfig) {
+  const route = useRoute()
+  const router = useRouter()
+  const userStore = useUserStore()
+  const { searchParams, pagination } = config
+  const defaultScope: WorkloadScope = config.defaultScope ?? 'My Workloads'
+
+  // userId is always derived from the scope toggle; it is never stored in the URL.
+  const syncUserId = () => {
+    searchParams.userId = searchParams.onlyMyself === 'All' ? '' : userStore.userId
+  }
+
+  // The URL query is the single source of truth: hydrate every param from it.
+  const readQuery = () => {
+    const q = route.query
+    searchParams.onlyMyself = (q.onlyMyself as string) || defaultScope
+    config.parseFilters(q)
+    pagination.page = Number(q.page || 1)
+    pagination.pageSize = Number(q.pageSize || pagination.pageSize)
+    syncUserId()
+  }
+
+  // Write a fresh, minimal query (no stale carryover, no redundant userId).
+  const writeQuery = () => {
+    const query: Record<string, string> = {}
+    for (const [key, value] of Object.entries(config.serializeFilters())) {
+      if (value !== undefined && value !== null && value !== '') {
+        query[key] = value
+      }
+    }
+    // Only persist the scope toggle when it differs from the page default.
+    if (searchParams.onlyMyself !== defaultScope) {
+      query.onlyMyself = searchParams.onlyMyself
+    }
+    query.page = String(pagination.page)
+    query.pageSize = String(pagination.pageSize)
+    router.replace({ query })
+  }
+
+  return { readQuery, writeQuery, syncUserId, defaultScope }
+}

--- a/Web/apps/safe/src/pages/Authoring/index.vue
+++ b/Web/apps/safe/src/pages/Authoring/index.vue
@@ -373,8 +373,8 @@ const initialSearchParams = {
   phase: [] as WorkloadPhase[],
   dateRange: '',
   workloadId: '',
-  onlyMyself: 'All',
-  userId: '',
+  onlyMyself: 'My Workloads',
+  userId: userStore.userId,
 }
 const searchParams = reactive({ ...initialSearchParams })
 
@@ -901,7 +901,7 @@ watch(
   // Refresh list data immediately when workspace dropdown changes
   () => store.currentWorkspaceId,
   (id) => {
-    if (id) fetchData()
+    if (id) onSearch({ resetPage: false })
   },
   { immediate: true },
 )

--- a/Web/apps/safe/src/pages/Authoring/index.vue
+++ b/Web/apps/safe/src/pages/Authoring/index.vue
@@ -339,6 +339,7 @@ import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import { useRoute, useRouter } from 'vue-router'
 import { useRouteAction, ROUTE_ACTIONS } from '@/composables/useRouteAction'
+import { useWorkloadListQuery } from '@/composables/useWorkloadListQuery'
 import AddDialog from './Components/AddDialog.vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import {
@@ -385,6 +386,36 @@ const pagination = reactive({
   pageSize: 20,
   total: 0,
 })
+
+const { readQuery, writeQuery, syncUserId } = useWorkloadListQuery({
+  searchParams,
+  pagination,
+  defaultScope: 'My Workloads',
+  serializeFilters: () => {
+    const [start, end] = searchParams.dateRange ?? []
+    return {
+      userName: searchParams.userName || undefined,
+      description: searchParams.description || undefined,
+      phase: searchParams.phase?.length ? searchParams.phase.join(',') : undefined,
+      since: start ? dayjs(start).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      until: end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      workloadId: searchParams.workloadId || undefined,
+    }
+  },
+  parseFilters: (q) => {
+    searchParams.userName = (q.userName as string) || ''
+    searchParams.description = (q.description as string) || ''
+    searchParams.workloadId = (q.workloadId as string) || ''
+    const phaseStr = (q.phase as string) || ''
+    searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
+    const since = q.since as string | undefined
+    const until = q.until as string | undefined
+    searchParams.dateRange = (since || until
+      ? [since ? dayjs(since).toDate() : '', until ? dayjs(until).toDate() : '']
+      : '') as any
+  },
+})
+
 const curWlId = ref()
 const curAction = ref<'Create' | 'Edit' | 'Clone' | 'Resume'>('Create')
 const curLimitedEdit = ref(false)
@@ -624,13 +655,15 @@ const handleFilterChange = (filters: Record<string, string[]>) => {
 }
 
 const filterByMyself = () => {
-  searchParams.userId = searchParams.onlyMyself !== 'All' ? userStore.userId : ''
+  syncUserId()
   onSearch({ resetPage: true })
 }
 
 const onSearch = (options?: { resetPage?: boolean }) => {
   const reset = options?.resetPage ?? true
   if (reset) pagination.page = 1
+
+  writeQuery()
 
   const [start, end] = searchParams.dateRange
   fetchData({
@@ -901,7 +934,10 @@ watch(
   // Refresh list data immediately when workspace dropdown changes
   () => store.currentWorkspaceId,
   (id) => {
-    if (id) onSearch({ resetPage: false })
+    if (id) {
+      readQuery()
+      onSearch({ resetPage: false })
+    }
   },
   { immediate: true },
 )

--- a/Web/apps/safe/src/pages/CICD/index.vue
+++ b/Web/apps/safe/src/pages/CICD/index.vue
@@ -616,6 +616,7 @@ import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import { useRoute, useRouter } from 'vue-router'
 import { useRouteAction, ROUTE_ACTIONS } from '@/composables/useRouteAction'
+import { useWorkloadListQuery } from '@/composables/useWorkloadListQuery'
 import AddDialog from './Components/AddDialog.vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import {
@@ -669,6 +670,36 @@ const pagination = reactive({
   pageSize: 20,
   total: 0,
 })
+
+const { readQuery, writeQuery, syncUserId } = useWorkloadListQuery({
+  searchParams,
+  pagination,
+  defaultScope: 'My Workloads',
+  serializeFilters: () => {
+    const [start, end] = searchParams.dateRange ?? []
+    return {
+      userName: searchParams.userName || undefined,
+      description: searchParams.description || undefined,
+      phase: searchParams.phase?.length ? searchParams.phase.join(',') : undefined,
+      since: start ? dayjs(start).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      until: end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      workloadId: searchParams.workloadId || undefined,
+    }
+  },
+  parseFilters: (q) => {
+    searchParams.userName = (q.userName as string) || ''
+    searchParams.description = (q.description as string) || ''
+    searchParams.workloadId = (q.workloadId as string) || ''
+    const phaseStr = (q.phase as string) || ''
+    searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
+    const since = q.since as string | undefined
+    const until = q.until as string | undefined
+    searchParams.dateRange = (since || until
+      ? [since ? dayjs(since).toDate() : '', until ? dayjs(until).toDate() : '']
+      : '') as any
+  },
+})
+
 const curWlId = ref()
 const curAction = ref<'Create' | 'Edit' | 'Clone' | 'Resume'>('Create')
 
@@ -778,7 +809,7 @@ const handlePageSizeChange = (newSize: number) => {
 }
 
 const filterByMyself = () => {
-  searchParams.userId = searchParams.onlyMyself !== 'All' ? userStore.userId : ''
+  syncUserId()
   onSearch({ resetPage: true })
 }
 
@@ -787,6 +818,9 @@ const onSearch = (options?: { resetPage?: boolean }) => {
   if (reset) pagination.page = 1
 
   const [start, end] = searchParams.dateRange
+
+  writeQuery()
+
   fetchData({
     userName: searchParams.userName,
     description: searchParams.description,
@@ -1355,7 +1389,10 @@ watch(
   // Refresh on workspace dropdown change - update list data immediately
   () => store.currentWorkspaceId,
   (id) => {
-    if (id) onSearch({ resetPage: false })
+    if (id) {
+      readQuery()
+      onSearch({ resetPage: false })
+    }
   },
   { immediate: true },
 )

--- a/Web/apps/safe/src/pages/CICD/index.vue
+++ b/Web/apps/safe/src/pages/CICD/index.vue
@@ -657,8 +657,8 @@ const initialSearchParams = {
   phase: [] as WorkloadPhase[],
   dateRange: '',
   workloadId: '',
-  onlyMyself: 'All',
-  userId: '',
+  onlyMyself: 'My Workloads',
+  userId: userStore.userId,
 }
 const searchParams = reactive({ ...initialSearchParams })
 
@@ -1355,7 +1355,7 @@ watch(
   // Refresh on workspace dropdown change - update list data immediately
   () => store.currentWorkspaceId,
   (id) => {
-    if (id) fetchData()
+    if (id) onSearch({ resetPage: false })
   },
   { immediate: true },
 )

--- a/Web/apps/safe/src/pages/Deploy/index.vue
+++ b/Web/apps/safe/src/pages/Deploy/index.vue
@@ -240,8 +240,30 @@ const passAll = () => {
   return true
 }
 
+// Keep the URL query in sync with the type/status/pagination state so that
+// returning from a deployment detail page restores the same list view.
+const readQuery = () => {
+  const q = router.currentRoute.value.query
+  const type = q.type as string
+  if (type === 'safe' || type === 'lens') currentType.value = type
+  const statusStr = (q.status as string) || ''
+  searchParams.status = statusStr ? (statusStr.split(',') as DeploymentStatus[]) : []
+  pagination.page = Number(q.page || 1)
+  pagination.pageSize = Number(q.pageSize || pagination.pageSize)
+}
+
+const writeQuery = () => {
+  const query: Record<string, string> = {}
+  query.type = currentType.value
+  if (searchParams.status.length) query.status = searchParams.status.join(',')
+  query.page = String(pagination.page)
+  query.pageSize = String(pagination.pageSize)
+  router.replace({ query })
+}
+
 const fetchData = async () => {
   try {
+    writeQuery()
     loading.value = true
     const params: {
       offset: number
@@ -282,15 +304,13 @@ const handleTableFilterChange = (filters: Record<string, DeploymentStatus[]>) =>
 
 const handleTypeChange = () => {
   pagination.page = 1
-  // keep selected type in URL so returning from detail can restore it
-  router.replace({ query: { ...route.query, type: currentType.value } })
+  // writeQuery (called inside fetchData) keeps type + status + pagination in URL
   fetchData()
 }
 
 const handleCreateSuccess = (type?: DeploymentType) => {
   if (type) currentType.value = type
   pagination.page = 1
-  router.replace({ query: { ...route.query, type: currentType.value } })
   fetchData()
 }
 
@@ -399,10 +419,8 @@ const handleRetry = async (row: DeploymentRequest) => {
 onMounted(async () => {
   // Check if there's an approval ID in the query params
   const approvalId = route.query.approvalId
-  const approvalType = route.query.type as DeploymentType | undefined
-  if (approvalType === 'safe' || approvalType === 'lens') {
-    currentType.value = approvalType
-  }
+  // Restore type + status + pagination from URL before the first fetch.
+  readQuery()
 
   await fetchData()
 

--- a/Web/apps/safe/src/pages/Diagnoser/index.vue
+++ b/Web/apps/safe/src/pages/Diagnoser/index.vue
@@ -167,8 +167,37 @@ const onSuccess = () => {
   dateRangeFilterRef.value?.refresh()
 }
 
+// Keep the date range in the URL query so returning from a detail page restores
+// the same filter. DateRangeFilter auto-emits a default range on mount, so on the
+// first emit we prefer any range already present in the URL.
+const firstDateEmit = ref(true)
+
+const readQuery = () => {
+  const q = router.currentRoute.value.query
+  dateFilter.value = {
+    since: (q.since as string) || '',
+    until: (q.until as string) || '',
+  }
+}
+
+const writeQuery = () => {
+  const query: Record<string, string> = {}
+  if (dateFilter.value.since) query.since = dateFilter.value.since
+  if (dateFilter.value.until) query.until = dateFilter.value.until
+  router.replace({ query })
+}
+
 const onDateFilterChange = (val: { since: string; until: string }) => {
-  dateFilter.value = val
+  if (firstDateEmit.value) {
+    firstDateEmit.value = false
+    readQuery()
+    if (!dateFilter.value.since && !dateFilter.value.until) {
+      dateFilter.value = val
+    }
+  } else {
+    dateFilter.value = val
+  }
+  writeQuery()
   fetchData()
 }
 

--- a/Web/apps/safe/src/pages/Diagnoser/index.vue
+++ b/Web/apps/safe/src/pages/Diagnoser/index.vue
@@ -17,7 +17,7 @@
       >
         Create Bench
       </el-button>
-      <DateRangeFilter ref="dateRangeFilterRef" @change="onDateFilterChange" />
+      <DateRangeFilter ref="dateRangeFilterRef" :initial-range="dateFilter" @change="onDateFilterChange" />
     </div>
   </div>
   <el-card class="mt-6 safe-card" shadow="never">
@@ -168,10 +168,8 @@ const onSuccess = () => {
 }
 
 // Keep the date range in the URL query so returning from a detail page restores
-// the same filter. DateRangeFilter auto-emits a default range on mount, so on the
-// first emit we prefer any range already present in the URL.
-const firstDateEmit = ref(true)
-
+// the same filter. We prime dateFilter from the URL before the picker mounts and
+// pass it as :initial-range, so the picker also displays the restored range.
 const readQuery = () => {
   const q = router.currentRoute.value.query
   dateFilter.value = {
@@ -179,6 +177,7 @@ const readQuery = () => {
     until: (q.until as string) || '',
   }
 }
+readQuery()
 
 const writeQuery = () => {
   const query: Record<string, string> = {}
@@ -188,15 +187,7 @@ const writeQuery = () => {
 }
 
 const onDateFilterChange = (val: { since: string; until: string }) => {
-  if (firstDateEmit.value) {
-    firstDateEmit.value = false
-    readQuery()
-    if (!dateFilter.value.since && !dateFilter.value.until) {
-      dateFilter.value = val
-    }
-  } else {
-    dateFilter.value = val
-  }
+  dateFilter.value = val
   writeQuery()
   fetchData()
 }

--- a/Web/apps/safe/src/pages/Dynamo/index.vue
+++ b/Web/apps/safe/src/pages/Dynamo/index.vue
@@ -223,7 +223,6 @@
 
 <script lang="ts" setup>
 import { computed, h, nextTick, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
-import { useRouter } from 'vue-router'
 import { useDark } from '@vueuse/core'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
@@ -241,6 +240,7 @@ import {
 } from '@element-plus/icons-vue'
 import ResetIcon from '@/components/icons/ResetIcon.vue'
 import { useWorkloadWriteGuard } from '@/composables/useWorkloadWriteGuard'
+import { useWorkloadListQuery } from '@/composables/useWorkloadListQuery'
 import { useWorkspaceStore } from '@/stores/workspace'
 import { useUserStore } from '@/stores/user'
 import {
@@ -284,7 +284,6 @@ const workloadConfig = computed(() =>
       },
 )
 
-const router = useRouter()
 const store = useWorkspaceStore()
 const userStore = useUserStore()
 const { canWrite } = useWorkloadWriteGuard()
@@ -323,6 +322,36 @@ interface DynamoRow {
 
 const tableData = ref<DynamoRow[]>([])
 const pagination = reactive({ page: 1, pageSize: 20, total: 0 })
+
+const { readQuery, writeQuery, syncUserId } = useWorkloadListQuery({
+  searchParams,
+  pagination,
+  defaultScope: 'My Workloads',
+  serializeFilters: () => {
+    const [start, end] = searchParams.dateRange ?? []
+    return {
+      userName: searchParams.userName || undefined,
+      description: searchParams.description || undefined,
+      phase: searchParams.phase?.length ? searchParams.phase.join(',') : undefined,
+      since: start ? dayjs(start).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      until: end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      workloadId: searchParams.workloadId || undefined,
+    }
+  },
+  parseFilters: (q) => {
+    searchParams.userName = (q.userName as string) || ''
+    searchParams.description = (q.description as string) || ''
+    searchParams.workloadId = (q.workloadId as string) || ''
+    const phaseStr = (q.phase as string) || ''
+    searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
+    const since = q.since as string | undefined
+    const until = q.until as string | undefined
+    searchParams.dateRange = (since || until
+      ? [since ? dayjs(since).toDate() : '', until ? dayjs(until).toDate() : '']
+      : '') as DateRange
+  },
+})
+
 const addVisible = ref(false)
 const curWlId = ref('')
 const curAction = ref<'Create' | 'Clone'>('Create')
@@ -366,6 +395,8 @@ const onSearch = (options?: { resetPage?: boolean }) => {
   const until = end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : ''
   const phaseStr = searchParams.phase?.length ? searchParams.phase.join(',') : ''
 
+  writeQuery()
+
   fetchData({
     userName: searchParams.userName,
     description: searchParams.description,
@@ -385,7 +416,7 @@ const resetAndSearch = () => {
 }
 
 const filterByMyself = () => {
-  searchParams.userId = searchParams.onlyMyself !== 'All' ? userStore.userId : ''
+  syncUserId()
   onSearch({ resetPage: true })
 }
 
@@ -540,8 +571,8 @@ onMounted(() => {
   window.addEventListener('touchmove', onAnyScroll, { passive: true, capture: true })
   window.addEventListener('pointerdown', onAnyPointerDown, { capture: true })
   userStore.fetchEnvs()
-  router.replace({ query: { ...router.currentRoute.value.query, kind: workloadConfig.value.kind } })
-  onSearch({ resetPage: true })
+  readQuery()
+  onSearch({ resetPage: false })
 })
 
 onBeforeUnmount(() => {

--- a/Web/apps/safe/src/pages/Error/Forbidden.vue
+++ b/Web/apps/safe/src/pages/Error/Forbidden.vue
@@ -1,0 +1,25 @@
+<template>
+  <div class="flex justify-center min-h-[100svh]">
+    <el-result
+      icon="warning"
+      title="403"
+      sub-title="You don't have permission to access this page"
+    >
+      <template #extra>
+        <el-button type="primary" @click="goHome">Back to Home</el-button>
+      </template>
+    </el-result>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+
+const goHome = () => {
+  router.replace('/')
+}
+</script>
+
+<style></style>

--- a/Web/apps/safe/src/pages/Evaluation/index.vue
+++ b/Web/apps/safe/src/pages/Evaluation/index.vue
@@ -261,8 +261,28 @@ const calculateDuration = (startTime?: string, endTime?: string) => {
   return `${hours}h ${minutes}m`
 }
 
+// Keep the URL query in sync with the search/filter/pagination state so that
+// returning from an evaluation detail page restores the same view.
+const readQuery = () => {
+  const q = router.currentRoute.value.query
+  serviceId.value = (q.serviceId as string) || ''
+  const statusStr = (q.status as string) || ''
+  statusSelectedIds.value = statusStr ? (statusStr.split(',') as EvaluationStatus[]) : []
+  currentPage.value = Number(q.page || 1)
+  pageSize.value = Number(q.pageSize || pageSize.value)
+}
+const writeQuery = () => {
+  const query: Record<string, string> = {}
+  if (serviceId.value?.trim()) query.serviceId = serviceId.value.trim()
+  if (statusSelectedIds.value.length) query.status = statusSelectedIds.value.join(',')
+  query.page = String(currentPage.value)
+  query.pageSize = String(pageSize.value)
+  router.replace({ query })
+}
+
 const fetchData = async () => {
   try {
+    writeQuery()
     loading.value = true
     const res = await getEvaluationTasks({
       workspace: workspaceStore.currentWorkspaceId || undefined,
@@ -369,15 +389,15 @@ onMounted(async () => {
   } catch (error) {
     console.error('Failed to load workspace list:', error)
   }
+  // Capture the clone query parameter before readQuery/writeQuery rewrite the URL.
+  const cloneId = route.query.clone as string | undefined
+  readQuery()
   fetchData()
 
-  // Check for clone query parameter
-  const cloneId = route.query.clone as string | undefined
   if (cloneId) {
     cloneTaskId.value = cloneId
     showCreateDialog.value = true
-    // Clear query parameter
-    router.replace({ query: {} })
+    // writeQuery (via fetchData) already dropped the clone param from the URL.
   }
 })
 

--- a/Web/apps/safe/src/pages/Infer/index.vue
+++ b/Web/apps/safe/src/pages/Infer/index.vue
@@ -348,8 +348,9 @@ import ResetIcon from '@/components/icons/ResetIcon.vue'
 import { copyText, formatTimeStr } from '@/utils/index'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
-import { useRoute, useRouter } from 'vue-router'
+import { useRouter } from 'vue-router'
 import { useRouteAction, ROUTE_ACTIONS } from '@/composables/useRouteAction'
+import { useWorkloadListQuery } from '@/composables/useWorkloadListQuery'
 import AddDialog from './Components/AddDialog.vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { Delete, DocumentCopy, Edit, Close, MoreFilled, VideoPlay } from '@element-plus/icons-vue'
@@ -363,7 +364,6 @@ dayjs.extend(utc)
 
 const tableRef = ref()
 const isDark = useDark()
-const route = useRoute()
 const router = useRouter()
 const store = useWorkspaceStore()
 const userStore = useUserStore()
@@ -393,6 +393,36 @@ const pagination = reactive({
   pageSize: 20,
   total: 0,
 })
+
+const { readQuery, writeQuery, syncUserId } = useWorkloadListQuery({
+  searchParams,
+  pagination,
+  defaultScope: 'My Workloads',
+  serializeFilters: () => {
+    const [start, end] = searchParams.dateRange ?? []
+    return {
+      userName: searchParams.userName || undefined,
+      description: searchParams.description || undefined,
+      phase: searchParams.phase?.length ? searchParams.phase.join(',') : undefined,
+      since: start ? dayjs(start).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      until: end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      workloadId: searchParams.workloadId || undefined,
+    }
+  },
+  parseFilters: (q) => {
+    searchParams.userName = (q.userName as string) || ''
+    searchParams.description = (q.description as string) || ''
+    searchParams.workloadId = (q.workloadId as string) || ''
+    const phaseStr = (q.phase as string) || ''
+    searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
+    const since = q.since as string | undefined
+    const until = q.until as string | undefined
+    searchParams.dateRange = (since || until
+      ? [since ? dayjs(since).toDate() : '', until ? dayjs(until).toDate() : '']
+      : '') as any
+  },
+})
+
 const curWlId = ref()
 const curAction = ref<'Create' | 'Edit' | 'Clone' | 'Resume'>('Create')
 
@@ -467,7 +497,7 @@ const handleFilterChange = (filters: Record<string, string[]>) => {
 }
 
 const filterByMyself = () => {
-  searchParams.userId = searchParams.onlyMyself !== 'All' ? userStore.userId : ''
+  syncUserId()
   onSearch({ resetPage: true })
 }
 
@@ -480,21 +510,7 @@ const onSearch = (options?: { resetPage?: boolean }) => {
   const until = end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : ''
   const phaseStr = searchParams.phase?.length ? searchParams.phase.join(',') : ''
 
-  router.replace({
-    query: {
-      ...route.query,
-      userName: searchParams.userName || undefined,
-      description: searchParams.description || undefined,
-      phase: phaseStr || undefined,
-      since: since || undefined,
-      until: until || undefined,
-      workloadId: searchParams.workloadId || undefined,
-      onlyMyself: searchParams.onlyMyself || undefined,
-      userId: searchParams.userId,
-      page: String(pagination.page),
-      pageSize: String(pagination.pageSize),
-    },
-  })
+  writeQuery()
 
   fetchData({
     userName: searchParams.userName,
@@ -731,43 +747,12 @@ onBeforeUnmount(() => {
   window.removeEventListener('pointerdown', onAnyPointerDown, { capture: true } as any)
 })
 
-function applyQueryToParams() {
-  const q = route.query
-
-  searchParams.userName = (q.userName as string) || ''
-  searchParams.description = (q.description as string) || ''
-  searchParams.workloadId = (q.workloadId as string) || ''
-  searchParams.onlyMyself = (q.onlyMyself as string) || 'My Workloads'
-  searchParams.userId = (q.userId as string) || ''
-
-  const phaseStr = (q.phase as string) || ''
-  searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
-
-  const since = q.since as string | undefined
-  const until = q.until as string | undefined
-  if (since || until) {
-    searchParams.dateRange = [
-      since ? dayjs(since).toDate() : '',
-      until ? dayjs(until).toDate() : '',
-    ] as any
-  } else {
-    searchParams.dateRange = ''
-  }
-
-  // Pagination
-  pagination.page = Number(q.page || 1)
-  pagination.pageSize = Number(q.pageSize || pagination.pageSize)
-}
-
 watch(
   // Refresh list data immediately when workspace dropdown changes
   () => store.currentWorkspaceId,
   (id) => {
     if (id) {
-      applyQueryToParams()
-      if (!searchParams.userId && searchParams.onlyMyself === 'My Workloads') {
-        searchParams.userId = userStore.userId
-      }
+      readQuery()
       onSearch({ resetPage: false })
     }
   },

--- a/Web/apps/safe/src/pages/ModelOptimization/index.vue
+++ b/Web/apps/safe/src/pages/ModelOptimization/index.vue
@@ -52,6 +52,7 @@
         column-key="statusFilter"
         :filters="statusFilters"
         :filter-multiple="false"
+        :filtered-value="searchParams.status ? [searchParams.status] : []"
         :filter-method="passAll"
       >
         <template #default="{ row }">
@@ -170,7 +171,26 @@ const handleSearchInput = () => {
   searchTimer = setTimeout(() => onSearch({ resetPage: true }), 500)
 }
 
+// Keep the URL query in sync with the search/filter state so returning from a
+// detail page restores the same results.
+const readQuery = () => {
+  const q = router.currentRoute.value.query
+  searchParams.search = (q.search as string) || ''
+  searchParams.status = (q.status as string) || ''
+  pagination.page = Number(q.page || 1)
+  pagination.pageSize = Number(q.pageSize || pagination.pageSize)
+}
+const writeQuery = () => {
+  const query: Record<string, string> = {}
+  if (searchParams.search?.trim()) query.search = searchParams.search.trim()
+  if (searchParams.status) query.status = searchParams.status
+  query.page = String(pagination.page)
+  query.pageSize = String(pagination.pageSize)
+  router.replace({ query })
+}
+
 const fetchData = async () => {
+  writeQuery()
   loading.value = true
   try {
     const raw = await listOptimizationTasks({
@@ -257,7 +277,10 @@ const handleDelete = async (row: OptimizationTask) => {
   }
 }
 
-onMounted(fetchData)
+onMounted(() => {
+  readQuery()
+  fetchData()
+})
 </script>
 
 <style scoped>

--- a/Web/apps/safe/src/pages/ModelSquare/index.vue
+++ b/Web/apps/safe/src/pages/ModelSquare/index.vue
@@ -286,7 +286,8 @@
         :page-sizes="[12, 24, 48]"
         layout="total, sizes, prev, pager, next"
         background
-        @size-change="currentPage = 1"
+        @size-change="handleSizeChange"
+        @current-change="writeQuery"
       />
     </div>
 
@@ -438,8 +439,34 @@ const paginatedModels = computed(() => {
   return models.value.slice(start, start + pageSize.value)
 })
 
+// Keep the URL query in sync with the filter/pagination state so returning from
+// a model detail page restores the same view (client-side pagination included).
+const readQuery = () => {
+  const q = router.currentRoute.value.query
+  filters.search = (q.search as string) || ''
+  filters.owner = (q.owner as string) || ''
+  filters.origin = (q.origin as string) || ''
+  currentPage.value = Number(q.page || 1)
+  pageSize.value = Number(q.pageSize || pageSize.value)
+}
+const writeQuery = () => {
+  const query: Record<string, string> = {}
+  if (filters.search?.trim()) query.search = filters.search.trim()
+  if (filters.owner) query.owner = filters.owner
+  if (filters.origin) query.origin = filters.origin
+  query.page = String(currentPage.value)
+  query.pageSize = String(pageSize.value)
+  router.replace({ query })
+}
+
+const handleSizeChange = () => {
+  currentPage.value = 1
+  writeQuery()
+}
+
 // Fetch model list
 const fetchModels = async () => {
+  writeQuery()
   loading.value = true
   try {
     const params: ModelsListParams = {}
@@ -720,6 +747,7 @@ const toggleRefreshPause = () => {
 
 // Initialize
 onMounted(() => {
+  readQuery()
   fetchModels()
   startTick()
 })

--- a/Web/apps/safe/src/pages/Monarch/index.vue
+++ b/Web/apps/safe/src/pages/Monarch/index.vue
@@ -357,8 +357,9 @@ import ResetIcon from '@/components/icons/ResetIcon.vue'
 import { copyText, formatTimeStr } from '@/utils/index'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
-import { useRoute, useRouter } from 'vue-router'
+import { useRouter } from 'vue-router'
 import { useRouteAction, ROUTE_ACTIONS } from '@/composables/useRouteAction'
+import { useWorkloadListQuery } from '@/composables/useWorkloadListQuery'
 import AddDialog from './Components/AddDialog.vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { Delete, DocumentCopy, Close, MoreFilled } from '@element-plus/icons-vue'
@@ -371,7 +372,6 @@ dayjs.extend(utc)
 
 const tableRef = ref()
 const isDark = useDark()
-const route = useRoute()
 const router = useRouter()
 const store = useWorkspaceStore()
 const userStore = useUserStore()
@@ -423,6 +423,36 @@ const pagination = reactive({
   pageSize: 20,
   total: 0,
 })
+
+const { readQuery, writeQuery, syncUserId } = useWorkloadListQuery({
+  searchParams,
+  pagination,
+  defaultScope: 'My Workloads',
+  serializeFilters: () => {
+    const [start, end] = searchParams.dateRange ?? []
+    return {
+      userName: searchParams.userName || undefined,
+      description: searchParams.description || undefined,
+      phase: searchParams.phase?.length ? searchParams.phase.join(',') : undefined,
+      since: start ? dayjs(start).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      until: end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      workloadId: searchParams.workloadId || undefined,
+    }
+  },
+  parseFilters: (q) => {
+    searchParams.userName = (q.userName as string) || ''
+    searchParams.description = (q.description as string) || ''
+    searchParams.workloadId = (q.workloadId as string) || ''
+    const phaseStr = (q.phase as string) || ''
+    searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
+    const since = q.since as string | undefined
+    const until = q.until as string | undefined
+    searchParams.dateRange = (since || until
+      ? [since ? dayjs(since).toDate() : '', until ? dayjs(until).toDate() : '']
+      : '') as any
+  },
+})
+
 const curWlId = ref()
 const curAction = ref<'Create' | 'Clone'>('Create')
 
@@ -493,7 +523,7 @@ const handleFilterChange = (filters: Record<string, string[]>) => {
 }
 
 const filterByMyself = () => {
-  searchParams.userId = searchParams.onlyMyself !== 'All' ? userStore.userId : ''
+  syncUserId()
   onSearch({ resetPage: true })
 }
 
@@ -506,21 +536,7 @@ const onSearch = (options?: { resetPage?: boolean }) => {
   const until = end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : ''
   const phaseStr = searchParams.phase?.length ? searchParams.phase.join(',') : ''
 
-  router.replace({
-    query: {
-      ...route.query,
-      userName: searchParams.userName || undefined,
-      description: searchParams.description || undefined,
-      phase: phaseStr || undefined,
-      since: since || undefined,
-      until: until || undefined,
-      workloadId: searchParams.workloadId || undefined,
-      onlyMyself: searchParams.onlyMyself || undefined,
-      userId: searchParams.userId,
-      page: String(pagination.page),
-      pageSize: String(pagination.pageSize),
-    },
-  })
+  writeQuery()
 
   fetchData({
     userName: searchParams.userName,
@@ -730,43 +746,12 @@ onBeforeUnmount(() => {
   } as AddEventListenerOptions)
 })
 
-function applyQueryToParams() {
-  const q = route.query
-
-  searchParams.userName = (q.userName as string) || ''
-  searchParams.description = (q.description as string) || ''
-  searchParams.workloadId = (q.workloadId as string) || ''
-  searchParams.onlyMyself = (q.onlyMyself as string) || 'My Workloads'
-  searchParams.userId = (q.userId as string) || ''
-
-  const phaseStr = (q.phase as string) || ''
-  searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
-
-  const since = q.since as string | undefined
-  const until = q.until as string | undefined
-  if (since || until) {
-    searchParams.dateRange = [
-      since ? dayjs(since).toDate() : '',
-      until ? dayjs(until).toDate() : '',
-    ]
-  } else {
-    searchParams.dateRange = ''
-  }
-
-  // Pagination
-  pagination.page = Number(q.page || 1)
-  pagination.pageSize = Number(q.pageSize || pagination.pageSize)
-}
-
 watch(
   // Refresh list data immediately when workspace dropdown changes
   () => store.currentWorkspaceId,
   (id) => {
     if (id) {
-      applyQueryToParams()
-      if (!searchParams.userId && searchParams.onlyMyself === 'My Workloads') {
-        searchParams.userId = userStore.userId
-      }
+      readQuery()
       onSearch({ resetPage: false })
     }
   },

--- a/Web/apps/safe/src/pages/PostTrain/index.vue
+++ b/Web/apps/safe/src/pages/PostTrain/index.vue
@@ -382,7 +382,43 @@ const handleMenuClick = async (act: Action, row: PostTrainRunItem) => {
   closeMore()
 }
 
+// Keep the URL query in sync with the filter state so returning from a detail
+// page restores the same filters, column selections and page.
+const readQuery = () => {
+  const q = router.currentRoute.value.query
+  filters.trainType = (q.trainType as string) || ''
+  filters.strategy = (q.strategy as string) || ''
+  filters.status = (q.status as string) || ''
+  filters.workspace = (q.workspace as string) || ''
+  filters.baseModel = (q.baseModel as string) || ''
+  filters.owner = (q.owner as string) || ''
+  const since = q.since as string | undefined
+  const until = q.until as string | undefined
+  filters.dateRange = (since || until
+    ? [since ? dayjs(since).toDate() : '', until ? dayjs(until).toDate() : '']
+    : '') as any
+  pagination.page = Number(q.page || 1)
+  pagination.pageSize = Number(q.pageSize || pagination.pageSize)
+}
+
+const writeQuery = () => {
+  const [start, end] = filters.dateRange ?? []
+  const query: Record<string, string> = {}
+  if (filters.trainType) query.trainType = filters.trainType
+  if (filters.strategy) query.strategy = filters.strategy
+  if (filters.status) query.status = filters.status
+  if (filters.workspace) query.workspace = filters.workspace
+  if (filters.baseModel) query.baseModel = filters.baseModel
+  if (filters.owner) query.owner = filters.owner
+  if (start) query.since = dayjs(start).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]')
+  if (end) query.until = dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]')
+  query.page = String(pagination.page)
+  query.pageSize = String(pagination.pageSize)
+  router.replace({ query })
+}
+
 const fetchData = async () => {
+  writeQuery()
   loading.value = true
   try {
     const [start, end] = filters.dateRange ?? []
@@ -468,6 +504,7 @@ const onAnyPointerDown = (e: Event) => {
 }
 
 onMounted(() => {
+  readQuery()
   fetchData()
   window.addEventListener('scroll', onAnyScroll, { passive: true, capture: true })
   window.addEventListener('wheel', onAnyScroll, { passive: true, capture: true })

--- a/Web/apps/safe/src/pages/Preflight/index.vue
+++ b/Web/apps/safe/src/pages/Preflight/index.vue
@@ -36,8 +36,37 @@ const jumpToDetail = (jobId: string) => {
   router.push({ path: '/preflight/ws/detail', query: { id: jobId } })
 }
 
+// Keep the date range in the URL query so returning from a detail page restores
+// the same filter. DateRangeFilter auto-emits a default range on mount, so on the
+// first emit we prefer any range already present in the URL.
+const firstDateEmit = ref(true)
+
+const readQuery = () => {
+  const q = router.currentRoute.value.query
+  dateFilter.value = {
+    since: (q.since as string) || '',
+    until: (q.until as string) || '',
+  }
+}
+
+const writeQuery = () => {
+  const query: Record<string, string> = {}
+  if (dateFilter.value.since) query.since = dateFilter.value.since
+  if (dateFilter.value.until) query.until = dateFilter.value.until
+  router.replace({ query })
+}
+
 const onDateFilterChange = (val: { since: string; until: string }) => {
-  dateFilter.value = val
+  if (firstDateEmit.value) {
+    firstDateEmit.value = false
+    readQuery()
+    if (!dateFilter.value.since && !dateFilter.value.until) {
+      dateFilter.value = val
+    }
+  } else {
+    dateFilter.value = val
+  }
+  writeQuery()
   fetchData()
 }
 

--- a/Web/apps/safe/src/pages/Preflight/index.vue
+++ b/Web/apps/safe/src/pages/Preflight/index.vue
@@ -37,10 +37,8 @@ const jumpToDetail = (jobId: string) => {
 }
 
 // Keep the date range in the URL query so returning from a detail page restores
-// the same filter. DateRangeFilter auto-emits a default range on mount, so on the
-// first emit we prefer any range already present in the URL.
-const firstDateEmit = ref(true)
-
+// the same filter. We prime dateFilter from the URL before the picker mounts and
+// pass it as :initial-range, so the picker also displays the restored range.
 const readQuery = () => {
   const q = router.currentRoute.value.query
   dateFilter.value = {
@@ -48,6 +46,7 @@ const readQuery = () => {
     until: (q.until as string) || '',
   }
 }
+readQuery()
 
 const writeQuery = () => {
   const query: Record<string, string> = {}
@@ -57,15 +56,7 @@ const writeQuery = () => {
 }
 
 const onDateFilterChange = (val: { since: string; until: string }) => {
-  if (firstDateEmit.value) {
-    firstDateEmit.value = false
-    readQuery()
-    if (!dateFilter.value.since && !dateFilter.value.until) {
-      dateFilter.value = val
-    }
-  } else {
-    dateFilter.value = val
-  }
+  dateFilter.value = val
   writeQuery()
   fetchData()
 }
@@ -178,7 +169,7 @@ watch(
       >
         Create Bench
       </el-button>
-      <DateRangeFilter ref="dateRangeFilterRef" @change="onDateFilterChange" />
+      <DateRangeFilter ref="dateRangeFilterRef" :initial-range="dateFilter" @change="onDateFilterChange" />
     </div>
   </div>
   <el-card class="mt-6 safe-card" shadow="never">

--- a/Web/apps/safe/src/pages/RayJob/index.vue
+++ b/Web/apps/safe/src/pages/RayJob/index.vue
@@ -383,8 +383,9 @@ import ResetIcon from '@/components/icons/ResetIcon.vue'
 import { copyText, formatTimeStr, last24hUtcExact } from '@/utils/index'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
-import { useRoute, useRouter } from 'vue-router'
+import { useRouter } from 'vue-router'
 import { useRouteAction, ROUTE_ACTIONS } from '@/composables/useRouteAction'
+import { useWorkloadListQuery } from '@/composables/useWorkloadListQuery'
 import AddDialog from './Components/AddDialog.vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { Delete, DocumentCopy, Edit, Close, MoreFilled, VideoPlay } from '@element-plus/icons-vue'
@@ -398,7 +399,6 @@ dayjs.extend(utc)
 
 const tableRef = ref()
 const isDark = useDark()
-const route = useRoute()
 const router = useRouter()
 const store = useWorkspaceStore()
 const userStore = useUserStore()
@@ -450,6 +450,36 @@ const pagination = reactive({
   pageSize: 20,
   total: 0,
 })
+
+const { readQuery, writeQuery, syncUserId } = useWorkloadListQuery({
+  searchParams,
+  pagination,
+  defaultScope: 'My Workloads',
+  serializeFilters: () => {
+    const [start, end] = searchParams.dateRange ?? []
+    return {
+      userName: searchParams.userName || undefined,
+      description: searchParams.description || undefined,
+      phase: searchParams.phase?.length ? searchParams.phase.join(',') : undefined,
+      since: start ? dayjs(start).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      until: end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      workloadId: searchParams.workloadId || undefined,
+    }
+  },
+  parseFilters: (q) => {
+    searchParams.userName = (q.userName as string) || ''
+    searchParams.description = (q.description as string) || ''
+    searchParams.workloadId = (q.workloadId as string) || ''
+    const phaseStr = (q.phase as string) || ''
+    searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
+    const since = q.since as string | undefined
+    const until = q.until as string | undefined
+    searchParams.dateRange = (since || until
+      ? [since ? dayjs(since).toDate() : '', until ? dayjs(until).toDate() : '']
+      : '') as any
+  },
+})
+
 const curWlId = ref()
 const curAction = ref<'Create' | 'Edit' | 'Clone'>('Create')
 const curLimitedEdit = ref(false)
@@ -577,7 +607,7 @@ const handleFilterChange = (filters: Record<string, string[]>) => {
 }
 
 const filterByMyself = () => {
-  searchParams.userId = searchParams.onlyMyself !== 'All' ? userStore.userId : ''
+  syncUserId()
   onSearch({ resetPage: true })
 }
 
@@ -590,21 +620,7 @@ const onSearch = (options?: { resetPage?: boolean }) => {
   const until = end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : ''
   const phaseStr = searchParams.phase?.length ? searchParams.phase.join(',') : ''
 
-  router.replace({
-    query: {
-      ...route.query,
-      userName: searchParams.userName || undefined,
-      description: searchParams.description || undefined,
-      phase: phaseStr || undefined,
-      since: since || undefined,
-      until: until || undefined,
-      workloadId: searchParams.workloadId || undefined,
-      onlyMyself: searchParams.onlyMyself || undefined,
-      userId: searchParams.userId,
-      page: String(pagination.page),
-      pageSize: String(pagination.pageSize),
-    },
-  })
+  writeQuery()
 
   fetchData({
     userName: searchParams.userName,
@@ -832,43 +848,12 @@ onBeforeUnmount(() => {
   } as AddEventListenerOptions)
 })
 
-function applyQueryToParams() {
-  const q = route.query
-
-  searchParams.userName = (q.userName as string) || ''
-  searchParams.description = (q.description as string) || ''
-  searchParams.workloadId = (q.workloadId as string) || ''
-  searchParams.onlyMyself = (q.onlyMyself as string) || 'My Workloads'
-  searchParams.userId = (q.userId as string) || ''
-
-  const phaseStr = (q.phase as string) || ''
-  searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
-
-  const since = q.since as string | undefined
-  const until = q.until as string | undefined
-  if (since || until) {
-    searchParams.dateRange = [
-      since ? dayjs(since).toDate() : '',
-      until ? dayjs(until).toDate() : '',
-    ]
-  } else {
-    searchParams.dateRange = ''
-  }
-
-  // Pagination
-  pagination.page = Number(q.page || 1)
-  pagination.pageSize = Number(q.pageSize || pagination.pageSize)
-}
-
 watch(
   // Refresh list data immediately when workspace dropdown changes
   () => store.currentWorkspaceId,
   (id) => {
     if (id) {
-      applyQueryToParams()
-      if (!searchParams.userId && searchParams.onlyMyself === 'My Workloads') {
-        searchParams.userId = userStore.userId
-      }
+      readQuery()
       onSearch({ resetPage: false })
     }
   },

--- a/Web/apps/safe/src/pages/SandboxWorkload/index.vue
+++ b/Web/apps/safe/src/pages/SandboxWorkload/index.vue
@@ -313,18 +313,18 @@ import ResetIcon from '@/components/icons/ResetIcon.vue'
 import { copyText, formatTimeStr } from '@/utils/index'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
-import { useRoute, useRouter } from 'vue-router'
+import { useRouter } from 'vue-router'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { type WorkloadParams, type PriorityValue, PRIORITY_LABEL_MAP } from '@/services'
 import { useUserStore } from '@/stores/user'
 import { useDark } from '@vueuse/core'
+import { useWorkloadListQuery } from '@/composables/useWorkloadListQuery'
 import EditDialog from './Components/EditDialog.vue'
 
 dayjs.extend(utc)
 
 const tableRef = ref()
 const isDark = useDark()
-const route = useRoute()
 const router = useRouter()
 const store = useWorkspaceStore()
 const userStore = useUserStore()
@@ -347,6 +347,35 @@ const searchParams = reactive({ ...initialSearchParams })
 const loading = ref(false)
 const tableData = ref([])
 const pagination = reactive({ page: 1, pageSize: 20, total: 0 })
+
+const { readQuery, writeQuery, syncUserId } = useWorkloadListQuery({
+  searchParams,
+  pagination,
+  defaultScope: 'My Workloads',
+  serializeFilters: () => {
+    const [start, end] = searchParams.dateRange ?? []
+    return {
+      userName: searchParams.userName || undefined,
+      description: searchParams.description || undefined,
+      phase: searchParams.phase?.length ? searchParams.phase.join(',') : undefined,
+      since: start ? dayjs(start).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      until: end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      workloadId: searchParams.workloadId || undefined,
+    }
+  },
+  parseFilters: (q) => {
+    searchParams.userName = (q.userName as string) || ''
+    searchParams.description = (q.description as string) || ''
+    searchParams.workloadId = (q.workloadId as string) || ''
+    const phaseStr = (q.phase as string) || ''
+    searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
+    const since = q.since as string | undefined
+    const until = q.until as string | undefined
+    searchParams.dateRange = (since || until
+      ? [since ? dayjs(since).toDate() : '', until ? dayjs(until).toDate() : '']
+      : '') as any
+  },
+})
 
 const SELECTION_BAR_H = 56
 const BASE_OFFSET = 245
@@ -406,7 +435,7 @@ const handleFilterChange = (filters: Record<string, string[]>) => {
 }
 
 const filterByMyself = () => {
-  searchParams.userId = searchParams.onlyMyself !== 'All' ? userStore.userId : ''
+  syncUserId()
   onSearch({ resetPage: true })
 }
 
@@ -419,20 +448,7 @@ const onSearch = (options?: { resetPage?: boolean }) => {
   const until = end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : ''
   const phaseStr = searchParams.phase?.length ? searchParams.phase.join(',') : ''
 
-  router.replace({
-    query: {
-      ...route.query,
-      userName: searchParams.userName || undefined,
-      phase: phaseStr || undefined,
-      since: since || undefined,
-      until: until || undefined,
-      workloadId: searchParams.workloadId || undefined,
-      onlyMyself: searchParams.onlyMyself || undefined,
-      userId: searchParams.userId,
-      page: String(pagination.page),
-      pageSize: String(pagination.pageSize),
-    },
-  })
+  writeQuery()
 
   fetchData({
     userName: searchParams.userName,
@@ -600,40 +616,11 @@ onBeforeUnmount(() => {
   window.removeEventListener('pointerdown', onAnyPointerDown, { capture: true } as any)
 })
 
-function applyQueryToParams() {
-  const q = route.query
-  searchParams.userName = (q.userName as string) || ''
-  searchParams.description = (q.description as string) || ''
-  searchParams.workloadId = (q.workloadId as string) || ''
-  searchParams.onlyMyself = (q.onlyMyself as string) || 'My Workloads'
-  searchParams.userId = (q.userId as string) || ''
-
-  const phaseStr = (q.phase as string) || ''
-  searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
-
-  const since = q.since as string | undefined
-  const until = q.until as string | undefined
-  if (since || until) {
-    searchParams.dateRange = [
-      since ? dayjs(since).toDate() : '',
-      until ? dayjs(until).toDate() : '',
-    ] as any
-  } else {
-    searchParams.dateRange = ''
-  }
-
-  pagination.page = Number(q.page || 1)
-  pagination.pageSize = Number(q.pageSize || pagination.pageSize)
-}
-
 watch(
   () => store.currentWorkspaceId,
   (id) => {
     if (id) {
-      applyQueryToParams()
-      if (!searchParams.userId && searchParams.onlyMyself === 'My Workloads') {
-        searchParams.userId = userStore.userId
-      }
+      readQuery()
       onSearch({ resetPage: false })
     }
   },

--- a/Web/apps/safe/src/pages/TorchFT/index.vue
+++ b/Web/apps/safe/src/pages/TorchFT/index.vue
@@ -365,8 +365,9 @@ import ResetIcon from '@/components/icons/ResetIcon.vue'
 import { copyText, formatTimeStr, last24hUtcExact } from '@/utils/index'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
-import { useRoute, useRouter } from 'vue-router'
+import { useRouter } from 'vue-router'
 import { useRouteAction, ROUTE_ACTIONS } from '@/composables/useRouteAction'
+import { useWorkloadListQuery } from '@/composables/useWorkloadListQuery'
 import AddDialog from './Components/AddDialog.vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import {
@@ -388,7 +389,6 @@ dayjs.extend(utc)
 
 const tableRef = ref()
 const isDark = useDark()
-const route = useRoute()
 const router = useRouter()
 const store = useWorkspaceStore()
 const userStore = useUserStore()
@@ -417,6 +417,36 @@ const pagination = reactive({
   pageSize: 20,
   total: 0,
 })
+
+const { readQuery, writeQuery, syncUserId } = useWorkloadListQuery({
+  searchParams,
+  pagination,
+  defaultScope: 'My Workloads',
+  serializeFilters: () => {
+    const [start, end] = searchParams.dateRange ?? []
+    return {
+      userName: searchParams.userName || undefined,
+      description: searchParams.description || undefined,
+      phase: searchParams.phase?.length ? searchParams.phase.join(',') : undefined,
+      since: start ? dayjs(start).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      until: end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      workloadId: searchParams.workloadId || undefined,
+    }
+  },
+  parseFilters: (q) => {
+    searchParams.userName = (q.userName as string) || ''
+    searchParams.description = (q.description as string) || ''
+    searchParams.workloadId = (q.workloadId as string) || ''
+    const phaseStr = (q.phase as string) || ''
+    searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
+    const since = q.since as string | undefined
+    const until = q.until as string | undefined
+    searchParams.dateRange = (since || until
+      ? [since ? dayjs(since).toDate() : '', until ? dayjs(until).toDate() : '']
+      : '') as any
+  },
+})
+
 const curWlId = ref()
 const curAction = ref<'Create' | 'Edit' | 'Clone'>('Create')
 const curLimitedEdit = ref(false)
@@ -539,7 +569,7 @@ const handleFilterChange = (filters: Record<string, string[]>) => {
 }
 
 const filterByMyself = () => {
-  searchParams.userId = searchParams.onlyMyself !== 'All' ? userStore.userId : ''
+  syncUserId()
   onSearch({ resetPage: true })
 }
 
@@ -552,21 +582,7 @@ const onSearch = (options?: { resetPage?: boolean }) => {
   const until = end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : ''
   const phaseStr = searchParams.phase?.length ? searchParams.phase.join(',') : ''
 
-  router.replace({
-    query: {
-      ...route.query,
-      userName: searchParams.userName || undefined,
-      description: searchParams.description || undefined,
-      phase: phaseStr || undefined,
-      since: since || undefined,
-      until: until || undefined,
-      workloadId: searchParams.workloadId || undefined,
-      onlyMyself: searchParams.onlyMyself || undefined,
-      userId: searchParams.userId,
-      page: String(pagination.page),
-      pageSize: String(pagination.pageSize),
-    },
-  })
+  writeQuery()
 
   fetchData({
     userName: searchParams.userName,
@@ -783,43 +799,12 @@ onBeforeUnmount(() => {
   window.removeEventListener('pointerdown', onAnyPointerDown, { capture: true } as any)
 })
 
-function applyQueryToParams() {
-  const q = route.query
-
-  searchParams.userName = (q.userName as string) || ''
-  searchParams.description = (q.description as string) || ''
-  searchParams.workloadId = (q.workloadId as string) || ''
-  searchParams.onlyMyself = (q.onlyMyself as string) || 'My Workloads'
-  searchParams.userId = (q.userId as string) || ''
-
-  const phaseStr = (q.phase as string) || ''
-  searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
-
-  const since = q.since as string | undefined
-  const until = q.until as string | undefined
-  if (since || until) {
-    searchParams.dateRange = [
-      since ? dayjs(since).toDate() : '',
-      until ? dayjs(until).toDate() : '',
-    ] as any
-  } else {
-    searchParams.dateRange = ''
-  }
-
-  // Pagination
-  pagination.page = Number(q.page || 1)
-  pagination.pageSize = Number(q.pageSize || pagination.pageSize)
-}
-
 watch(
   // Refresh list data immediately when workspace dropdown changes
   () => store.currentWorkspaceId,
   (id) => {
     if (id) {
-      applyQueryToParams()
-      if (!searchParams.userId && searchParams.onlyMyself === 'My Workloads') {
-        searchParams.userId = userStore.userId
-      }
+      readQuery()
       onSearch({ resetPage: false })
     }
   },

--- a/Web/apps/safe/src/pages/Training/index.vue
+++ b/Web/apps/safe/src/pages/Training/index.vue
@@ -388,8 +388,9 @@ import ResetIcon from '@/components/icons/ResetIcon.vue'
 import { copyText, formatTimeStr, last24hUtcExact } from '@/utils/index'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
-import { useRoute, useRouter } from 'vue-router'
+import { useRouter } from 'vue-router'
 import { useRouteAction, ROUTE_ACTIONS } from '@/composables/useRouteAction'
+import { useWorkloadListQuery } from '@/composables/useWorkloadListQuery'
 import AddDialog from './Components/AddDialog.vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { Delete, DocumentCopy, Edit, Close, MoreFilled, VideoPlay } from '@element-plus/icons-vue'
@@ -405,7 +406,6 @@ dayjs.extend(utc)
 
 const tableRef = ref()
 const isDark = useDark()
-const route = useRoute()
 const router = useRouter()
 const store = useWorkspaceStore()
 const { canWrite } = useWorkloadWriteGuard()
@@ -433,6 +433,36 @@ const pagination = reactive({
   pageSize: 20,
   total: 0,
 })
+
+const { readQuery, writeQuery, syncUserId } = useWorkloadListQuery({
+  searchParams,
+  pagination,
+  defaultScope: 'My Workloads',
+  serializeFilters: () => {
+    const [start, end] = searchParams.dateRange ?? []
+    return {
+      userName: searchParams.userName || undefined,
+      description: searchParams.description || undefined,
+      phase: searchParams.phase?.length ? searchParams.phase.join(',') : undefined,
+      since: start ? dayjs(start).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      until: end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      workloadId: searchParams.workloadId || undefined,
+    }
+  },
+  parseFilters: (q) => {
+    searchParams.userName = (q.userName as string) || ''
+    searchParams.description = (q.description as string) || ''
+    searchParams.workloadId = (q.workloadId as string) || ''
+    const phaseStr = (q.phase as string) || ''
+    searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
+    const since = q.since as string | undefined
+    const until = q.until as string | undefined
+    searchParams.dateRange = (since || until
+      ? [since ? dayjs(since).toDate() : '', until ? dayjs(until).toDate() : '']
+      : '') as any
+  },
+})
+
 const curWlId = ref()
 const curAction = ref<'Create' | 'Edit' | 'Clone'>('Create')
 const curLimitedEdit = ref(false)
@@ -685,7 +715,7 @@ const handleFilterChange = (filters: Record<string, string[]>) => {
 }
 
 const filterByMyself = () => {
-  searchParams.userId = searchParams.onlyMyself !== 'All' ? userStore.userId : ''
+  syncUserId()
   onSearch({ resetPage: true })
 }
 
@@ -698,21 +728,7 @@ const onSearch = (options?: { resetPage?: boolean }) => {
   const until = end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : ''
   const phaseStr = searchParams.phase?.length ? searchParams.phase.join(',') : ''
 
-  router.replace({
-    query: {
-      ...route.query,
-      userName: searchParams.userName || undefined,
-      description: searchParams.description || undefined,
-      phase: phaseStr || undefined,
-      since: since || undefined,
-      until: until || undefined,
-      workloadId: searchParams.workloadId || undefined,
-      onlyMyself: searchParams.onlyMyself || undefined,
-      userId: searchParams.userId,
-      page: String(pagination.page),
-      pageSize: String(pagination.pageSize),
-    },
-  })
+  writeQuery()
 
   fetchData({
     userName: searchParams.userName,
@@ -939,43 +955,12 @@ onBeforeUnmount(() => {
   window.removeEventListener('pointerdown', onAnyPointerDown, { capture: true } as any)
 })
 
-function applyQueryToParams() {
-  const q = route.query
-
-  searchParams.userName = (q.userName as string) || ''
-  searchParams.description = (q.description as string) || ''
-  searchParams.workloadId = (q.workloadId as string) || ''
-  searchParams.onlyMyself = (q.onlyMyself as string) || 'My Workloads'
-  searchParams.userId = (q.userId as string) || ''
-
-  const phaseStr = (q.phase as string) || ''
-  searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
-
-  const since = q.since as string | undefined
-  const until = q.until as string | undefined
-  if (since || until) {
-    searchParams.dateRange = [
-      since ? dayjs(since).toDate() : '',
-      until ? dayjs(until).toDate() : '',
-    ] as any
-  } else {
-    searchParams.dateRange = ''
-  }
-
-  // Pagination
-  pagination.page = Number(q.page || 1)
-  pagination.pageSize = Number(q.pageSize || pagination.pageSize)
-}
-
 watch(
   // Refresh list data immediately when workspace dropdown changes
   () => store.currentWorkspaceId,
   (id) => {
     if (id) {
-      applyQueryToParams()
-      if (!searchParams.userId && searchParams.onlyMyself === 'My Workloads') {
-        searchParams.userId = userStore.userId
-      }
+      readQuery()
       onSearch({ resetPage: false })
     }
   },

--- a/Web/apps/safe/src/pages/WorkloadManage/index.vue
+++ b/Web/apps/safe/src/pages/WorkloadManage/index.vue
@@ -447,6 +447,41 @@ const loading = ref(false)
 const tableData = ref<any[]>([])
 const pagination = reactive({ page: 1, pageSize: 20, total: 0 })
 
+// Keep the URL query as the single source of truth for the filter state so that
+// returning from a workload detail page restores the same filters and page.
+const readQuery = () => {
+  const q = router.currentRoute.value.query
+  searchParams.workspaceId = (q.workspaceId as string) || ''
+  searchParams.kind = (q.kind as string) || ''
+  searchParams.workloadId = (q.workloadId as string) || ''
+  const phaseStr = (q.phase as string) || ''
+  searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
+  const since = q.since as string | undefined
+  const until = q.until as string | undefined
+  searchParams.dateRange = (since || until
+    ? [since ? dayjs(since).toDate() : '', until ? dayjs(until).toDate() : '']
+    : '') as any
+  pagination.page = Number(q.page || 1)
+  pagination.pageSize = Number(q.pageSize || pagination.pageSize)
+  // Reflect the restored selections in the column-header filter UI.
+  filterSelectedWs.value = searchParams.workspaceId ? [searchParams.workspaceId] : []
+  filterSelectedKind.value = searchParams.kind ? [searchParams.kind] : []
+}
+
+const writeQuery = () => {
+  const [start, end] = searchParams.dateRange ?? []
+  const query: Record<string, string> = {}
+  if (searchParams.workspaceId) query.workspaceId = searchParams.workspaceId
+  if (searchParams.kind) query.kind = searchParams.kind
+  if (searchParams.workloadId) query.workloadId = searchParams.workloadId
+  if (searchParams.phase?.length) query.phase = searchParams.phase.join(',')
+  if (start) query.since = dayjs(start).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]')
+  if (end) query.until = dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]')
+  query.page = String(pagination.page)
+  query.pageSize = String(pagination.pageSize)
+  router.replace({ query })
+}
+
 // ── Table height & selection bar ──
 const SELECTION_BAR_H = 56
 const BASE_OFFSET = 245
@@ -533,6 +568,8 @@ const onSearch = (options?: { resetPage?: boolean }) => {
   const until = end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : ''
   const phaseStr = searchParams.phase?.length ? searchParams.phase.join(',') : ''
 
+  writeQuery()
+
   fetchData({
     workspaceId: searchParams.workspaceId || undefined,
     kind: searchParams.kind || undefined,
@@ -549,6 +586,7 @@ const onSearch = (options?: { resetPage?: boolean }) => {
 const resetAndSearch = () => {
   Object.assign(searchParams, { ...initialSearchParams })
   filterSelectedWs.value = []
+  filterSelectedKind.value = []
   tableRef.value?.clearFilter()
   pagination.page = 1
   onSearch({ resetPage: true })
@@ -822,7 +860,8 @@ onMounted(() => {
   window.addEventListener('wheel', onAnyScroll, { passive: true, capture: true })
   window.addEventListener('touchmove', onAnyScroll, { passive: true, capture: true })
   window.addEventListener('pointerdown', onAnyPointerDown, { capture: true })
-  fetchData()
+  readQuery()
+  onSearch({ resetPage: false })
 })
 
 onBeforeUnmount(() => {

--- a/Web/apps/safe/src/pages/Workspace/WorkspaceDetail.vue
+++ b/Web/apps/safe/src/pages/Workspace/WorkspaceDetail.vue
@@ -132,6 +132,7 @@
       ref="tblRef"
       :element-loading-text="$loadingText"
       @filter-change="handleFilterChange"
+      @sort-change="handleSortChange"
     >
       <el-table-column type="selection" width="56" />
       <el-table-column prop="nodeId" label="Name/ID" width="200" :fixed="true" align="left">
@@ -228,9 +229,8 @@
       <el-table-column
         prop="amd.com/gpu"
         label="GPU ( available / total )"
-        :sortable="true"
+        sortable="custom"
         :sort-orders="['ascending', 'descending', null]"
-        :sort-method="(a: any, b: any) => avail(a, 'amd.com/gpu') - avail(b, 'amd.com/gpu')"
         width="210"
       >
         <template #default="{ row }">{{
@@ -240,9 +240,8 @@
       <el-table-column
         prop="cpu"
         label="CPU ( available / total )"
-        :sortable="true"
+        sortable="custom"
         :sort-orders="['ascending', 'descending', null]"
-        :sort-method="(a: any, b: any) => avail(a, 'cpu') - avail(b, 'cpu')"
         width="210"
       >
         <template #default="{ row }">
@@ -253,11 +252,8 @@
       <el-table-column
         prop="ephemeral-storage"
         label="ephemeral-storage ( available / total )"
-        :sortable="true"
+        sortable="custom"
         :sort-orders="['ascending', 'descending', null]"
-        :sort-method="
-          (a: any, b: any) => avail(a, 'ephemeral-storage') - avail(b, 'ephemeral-storage')
-        "
         width="300"
       >
         <template #default="{ row }">
@@ -267,10 +263,10 @@
         </template>
       </el-table-column>
       <el-table-column
+        prop="memory"
         label="Memory ( available / total )"
-        :sortable="true"
+        sortable="custom"
         :sort-orders="['ascending', 'descending', null]"
-        :sort-method="(a: any, b: any) => avail(a, 'memory') - avail(b, 'memory')"
         min-width="230"
       >
         <template #default="{ row }">
@@ -281,9 +277,8 @@
       <el-table-column
         prop="rdma/hca"
         label="rdma/hca ( available / total )"
-        :sortable="true"
+        sortable="custom"
         :sort-orders="['ascending', 'descending', null]"
-        :sort-method="(a: any, b: any) => avail(a, 'rdma/hca') - avail(b, 'rdma/hca')"
         width="240"
       >
         <template #default="{ row }">
@@ -530,6 +525,8 @@ const onSearch = (options?: { resetPage?: boolean }) => {
     ...(searchParams.clusterId
       ? { clusterId: searchParams.clusterId === 'UNASSIGNED' ? '' : searchParams.clusterId }
       : {}),
+    ...(sortParams.sortBy ? { sortBy: sortParams.sortBy } : {}),
+    ...(sortParams.order ? { order: sortParams.order } : {}),
   })
 }
 const jumpToDetail = (id: string) => {
@@ -538,8 +535,13 @@ const jumpToDetail = (id: string) => {
 
 // Sorting
 const tblRef = ref()
-const n = (v: unknown) => (Number.isFinite(Number(v)) ? Number(v) : 0)
-const avail = (row: any, key: string) => n(row?.availResources?.[key])
+// Server-side sorting: backend sorts the full node set, then paginates.
+const sortParams = reactive({ sortBy: '', order: '' })
+const handleSortChange = ({ prop, order }: { prop: string; order: string | null }) => {
+  sortParams.sortBy = order ? prop || '' : ''
+  sortParams.order = order === 'ascending' ? 'asc' : order === 'descending' ? 'desc' : ''
+  onSearch({ resetPage: true })
+}
 // Available and addons filter
 const boolFilters = computed(() => [
   { text: 'true', value: 'true' },

--- a/Web/apps/safe/src/router/guards/clusterReady.ts
+++ b/Web/apps/safe/src/router/guards/clusterReady.ts
@@ -6,7 +6,7 @@ import { useUserStore } from '@/stores/user'
 
 const statusOf = (e: unknown) => (axios.isAxiosError(e) ? e.response?.status : undefined)
 
-const SKIP_ROUTES = new Set(['/login', '/register', '/error', '/login-admin', '/sso-error'])
+const SKIP_ROUTES = new Set(['/login', '/register', '/error', '/403', '/login-admin', '/sso-error'])
 
 export default function setupClusterGuard(router: Router) {
   router.beforeEach(async (to, from, next) => {
@@ -55,8 +55,7 @@ export default function setupClusterGuard(router: Router) {
       // Permission check (workspace-admin)
       if (to.meta?.requiresWorkspaceAdmin) {
         if (!wsStore.isCurrentWorkspaceAdmin() && !userStore.hasManagerAccess) {
-          // TODO: redirect to 403 page instead of homepage
-          return next('/')
+          return next('/403')
         }
       }
 

--- a/Web/apps/safe/src/router/index.ts
+++ b/Web/apps/safe/src/router/index.ts
@@ -34,6 +34,12 @@ const router = createRouter({
       component: () => import('../pages/Error/ErrorPage.vue'),
     },
     {
+      path: '/403',
+      name: 'Forbidden',
+      component: () => import('../pages/Error/Forbidden.vue'),
+      meta: { hideMenu: true },
+    },
+    {
       path: '/',
       component: () => import('@/layouts/AppLayout.vue'),
       children: [

--- a/Web/apps/safe/src/services/nodes/type.ts
+++ b/Web/apps/safe/src/services/nodes/type.ts
@@ -133,6 +133,9 @@ export interface NodesParams {
   phase?: string
   search?: string
 
+  sortBy?: string
+  order?: string
+
   offset?: number
   limit?: number
 }

--- a/Web/apps/safe/src/services/sandbox/index.ts
+++ b/Web/apps/safe/src/services/sandbox/index.ts
@@ -6,10 +6,8 @@ import type {
   SandboxSessionListResponse,
 } from './type'
 
-const isOciCluster = window.location.origin === 'https://oci-slc.primus-safe.amd.com'
-
 const sandboxRequest = axios.create({
-  baseURL: isOciCluster ? '/sandbox' : '/x-flannel/sandbox',
+  baseURL: import.meta.env.VITE_SANDBOX_BASE_URL || '/x-flannel/sandbox',
   timeout: 15000,
   withCredentials: true,
 })

--- a/Web/apps/safe/src/services/workload/index.ts
+++ b/Web/apps/safe/src/services/workload/index.ts
@@ -13,8 +13,6 @@ import type {
   PendingCauseAnalysisResult,
   CreatePendingCauseJobRequest,
   CreatePendingCauseJobResponse,
-  DispatchNodesParams,
-  DispatchNodesResponse,
 } from './type'
 
 const LONG_TIMEOUT = 30_000
@@ -34,13 +32,6 @@ export const getWorkloadDetail = (id: string): Promise<any> =>
 
 export const getWorkloadService = (id: string): Promise<any> =>
   request.get(`/workloads/${id}/service`, { timeout: LONG_TIMEOUT })
-
-// Paginated dispatch nodes for a workload (server-side pagination per dispatch group)
-export const getWorkloadDispatchNodes = (
-  wlId: string,
-  params: DispatchNodesParams,
-): Promise<DispatchNodesResponse> =>
-  request.get(`/workloads/${wlId}/dispatch-nodes`, { params, timeout: LONG_TIMEOUT })
 
 // Log download
 export const downloadWlLogs = (data: DownloadParams): Promise<{ jobId: string }> =>

--- a/Web/apps/safe/src/services/workload/index.ts
+++ b/Web/apps/safe/src/services/workload/index.ts
@@ -13,6 +13,8 @@ import type {
   PendingCauseAnalysisResult,
   CreatePendingCauseJobRequest,
   CreatePendingCauseJobResponse,
+  DispatchNodesParams,
+  DispatchNodesResponse,
 } from './type'
 
 const LONG_TIMEOUT = 30_000
@@ -32,6 +34,13 @@ export const getWorkloadDetail = (id: string): Promise<any> =>
 
 export const getWorkloadService = (id: string): Promise<any> =>
   request.get(`/workloads/${id}/service`, { timeout: LONG_TIMEOUT })
+
+// Paginated dispatch nodes for a workload (server-side pagination per dispatch group)
+export const getWorkloadDispatchNodes = (
+  wlId: string,
+  params: DispatchNodesParams,
+): Promise<DispatchNodesResponse> =>
+  request.get(`/workloads/${wlId}/dispatch-nodes`, { params, timeout: LONG_TIMEOUT })
 
 // Log download
 export const downloadWlLogs = (data: DownloadParams): Promise<{ jobId: string }> =>

--- a/Web/apps/safe/src/services/workload/type.ts
+++ b/Web/apps/safe/src/services/workload/type.ts
@@ -352,3 +352,18 @@ export interface CreatePendingCauseJobRequest {
 export interface CreatePendingCauseJobResponse {
   job_id: string
 }
+
+export interface DispatchNodesParams {
+  dispatchIndex: number
+  offset: number
+  limit: number
+}
+
+export interface DispatchNodesResponse {
+  totalCount: number
+  dispatchIndex: number
+  offset: number
+  limit: number
+  nodes: string[]
+  ranks: string[]
+}

--- a/Web/apps/safe/src/services/workload/type.ts
+++ b/Web/apps/safe/src/services/workload/type.ts
@@ -352,18 +352,3 @@ export interface CreatePendingCauseJobRequest {
 export interface CreatePendingCauseJobResponse {
   job_id: string
 }
-
-export interface DispatchNodesParams {
-  dispatchIndex: number
-  offset: number
-  limit: number
-}
-
-export interface DispatchNodesResponse {
-  totalCount: number
-  dispatchIndex: number
-  offset: number
-  limit: number
-  nodes: string[]
-  ranks: string[]
-}


### PR DESCRIPTION
## Summary

Frontend fixes from the audit report, across the `safe` and `lens` web apps.

### Security
- **Remove hardcoded `userId` backdoor header** in lens; authenticate via the session cookie instead (`services/auth.ts`, `services/safe-api.ts`).

### Auth / access control
- Add a `/403` page and route unauthorized workspace access there (`pages/Error/Forbidden.vue`, `router/index.ts`, `router/guards/clusterReady.ts`).

### Error handling & UX (lens)
- Surface fetch errors via `ElMessage`, hide unimplemented Retry / edit actions, and paginate the RunSummary jobs table.

### Workload lists (safe)
- Extract `useWorkloadListQuery` so the URL query is the single source of truth for the Training / Infer lists (drops the coupled `userId` param and stale query carryover).
- Unify the default scope to **My Workloads** across CICD / Authoring.

### Workspace detail (safe)
- Switch the node table from client-side sort to **backend full-dataset sort** (`sortBy` / `order`). Necessary because that list is server-paginated, so sorting must run on the backend to reflect the whole dataset rather than a single page.

### Workload log node list (safe)
- Keep the **client-side** pagination over the full dispatch-node list. A server-side pagination attempt was added and then reverted: the dispatch-node list is small enough to return in full, and paginating it broke the global first/last and failed-node default selection. See the last commit for the rationale.

### Config
- Drive the sandbox `baseURL` from `VITE_SANDBOX_BASE_URL`.

## Test plan
- [x] `pnpm --filter safe run test` — existing unit suite passes (113 tests).
- [x] Workload log node pagination verified with a large node list (55 nodes → 20/20/15 across pages, pager hides below one page, search resets to page 1).
- [ ] 403 redirect on unauthorized workspace access.
- [ ] Training / Infer list filters + pagination reflect the URL query.
- [ ] Workspace node table sort ordering reflects the full dataset across pages.
- [ ] Lens RunSummary jobs table pagination + error toasts.
