### PR TITLE
fix(job-manager): recognize WorkloadStopped phase in IsPodTerminated

### DIFF
--- a/SaFE/apis/pkg/apis/amd/v1/workload_types.go
+++ b/SaFE/apis/pkg/apis/amd/v1/workload_types.go
@@ -402,10 +402,13 @@ func IsPodRunning(p *WorkloadPod) bool {
 		p.AdminNodeName != ""
 }
 
-// IsPodTerminated returns true if the pod is in terminated phase.
+// IsPodTerminated returns true if the pod is in terminated phase. WorkloadStopped
+// is included because pod_handler.go stamps stopped/replaced pods (e.g. CICD
+// ephemeral runners) with that phase instead of a standard corev1.PodPhase value.
 func IsPodTerminated(p *WorkloadPod) bool {
 	return corev1.PodSucceeded == p.Phase ||
-		corev1.PodFailed == p.Phase
+		corev1.PodFailed == p.Phase ||
+		corev1.PodPhase(WorkloadStopped) == p.Phase
 }
 
 // ToSchemaGVK converts the resource template GVK to schema.GroupVersionKind.


### PR DESCRIPTION
## Summary
- `IsPodTerminated()` only matched `corev1.PodSucceeded`/`PodFailed`, so pods that `pod_handler.go` marks with the custom `WorkloadStopped` phase (e.g. completed CICD ephemeral runners) were still counted as active.
- Over time this inflates a workload's/workspace's used-resource accounting in job-manager's scheduler (`common/pkg/workload`, `job-manager/pkg/syncer`), eventually reporting near-zero available CPU and starving new workload dispatch even though real capacity is free.
- `IsWorkloadPhaseEnded()` already treats `WorkloadStopped` as terminal at the workload level; this aligns `IsPodTerminated()` with the same rule at the pod level.

## Test plan
- [x] `go build ./...` passes for `apis`, `common`, `job-manager`, `resource-manager` modules
- [x] Existing unit tests pass: `job-manager/pkg/syncer`, `job-manager/pkg/utils`, `common/pkg/workload`
- [x] Verified in a live cluster: after deploying a build with this fix, job-manager's scheduler log went from reporting near-zero available CPU for the affected workspace to correct non-zero available/used CPU values, matching real usage

Made with [Cursor](https://cursor.com)