### PR TITLE
fix(apiserver): return preferredName from verify endpoint

### DIFF
--- a/SaFE/apiserver/pkg/handlers/authority/verify_handler.go
+++ b/SaFE/apiserver/pkg/handlers/authority/verify_handler.go
@@ -43,15 +43,16 @@ type VerifyTokenRequest struct {
 
 // VerifyTokenResponse represents the response body for token verification
 type VerifyTokenResponse struct {
-	Id          string        `json:"id"`
-	Name        string        `json:"name"`
-	Email       string        `json:"email,omitempty"`
-	Exp         int64         `json:"exp"`
-	Type        string        `json:"type"`
-	Roles       []v1.UserRole `json:"roles"`
-	ApiKeyId    int64         `json:"apiKeyId,omitempty"`
-	PlatformKey string        `json:"platformKey,omitempty"`
-	VirtualKey  string        `json:"virtualKey,omitempty"`
+	Id            string        `json:"id"`
+	Name          string        `json:"name"`
+	Email         string        `json:"email,omitempty"`
+	PreferredName string        `json:"preferredName,omitempty"`
+	Exp           int64         `json:"exp"`
+	Type          string        `json:"type"`
+	Roles         []v1.UserRole `json:"roles"`
+	ApiKeyId      int64         `json:"apiKeyId,omitempty"`
+	PlatformKey   string        `json:"platformKey,omitempty"`
+	VirtualKey    string        `json:"virtualKey,omitempty"`
 }
 
 // platformKeyFetcher resolves the platform API key for a user. It is a package
@@ -196,13 +197,24 @@ func VerifyToken(c *gin.Context) {
 	}
 
 	resp := VerifyTokenResponse{
-		Id:       userInfo.Id,
-		Name:     userInfo.Name,
-		Email:    userInfo.Email,
-		Exp:      userInfo.Exp,
-		Type:     userType,
-		ApiKeyId: userInfo.ApiKeyId,
-		Roles:    userInfo.Roles,
+		Id:            userInfo.Id,
+		Name:          userInfo.Name,
+		Email:         userInfo.Email,
+		PreferredName: userInfo.PreferredUsername,
+		Exp:           userInfo.Exp,
+		Type:          userType,
+		ApiKeyId:      userInfo.ApiKeyId,
+		Roles:         userInfo.Roles,
+	}
+
+	// Backfill preferred name from the User CR when the auth path (e.g. API key)
+	// didn't carry it. Mirrors the email backfill below.
+	if resp.PreferredName == "" {
+		if tokenInst := DefaultTokenInstance(); tokenInst != nil {
+			if user, err := getUserById(c.Request.Context(), tokenInst, userInfo.Id); err == nil {
+				resp.PreferredName = v1.GetAnnotation(user, v1.UserPreferredNameAnnotation)
+			}
+		}
 	}
 
 	// Optionally include platform API key (GetOrCreate)


### PR DESCRIPTION
## Summary
- Add `preferredName` to the `/api/v1/auth/verify` `VerifyTokenResponse`, populated from `userInfo.PreferredUsername`.
- When the auth path (e.g. API key) doesn't carry it, backfill from the User CR's preferred-name annotation, mirroring the existing email backfill.

## Why
The verify response previously exposed only `name` (display name). Callers that need the SSO preferred username had no way to obtain it from the API. This adds the missing field so it can be consumed by downstream services.

## Test plan
- [ ] `go build ./apiserver/pkg/handlers/authority/...` passes
- [ ] SSO cookie verify returns `preferredName` from the SSO token
- [ ] API-key verify returns `preferredName` backfilled from the User CR annotation
- [ ] Response omits `preferredName` when the annotation is absent (omitempty)