### PR TITLE
fix(syncer): guard nil admin workload in getAdminWorkloadAndSyncPod

### DIFF
--- a/SaFE/job-manager/pkg/syncer/pod_handler.go
+++ b/SaFE/job-manager/pkg/syncer/pod_handler.go
@@ -189,7 +189,7 @@ func (r *SyncerReconciler) getAdminWorkloadAndSyncPod(ctx context.Context,
 	} else {
 		adminWorkload, err = r.getAdminWorkload(ctx, message.workloadId)
 	}
-	if err != nil {
+	if err != nil || adminWorkload == nil {
 		return nil, err
 	}
 	v1.SetLabel(adminWorkload, v1.WorkloadDispatchCntLabel, strconv.Itoa(message.dispatchCount))

--- a/SaFE/job-manager/pkg/syncer/pod_handler_test.go
+++ b/SaFE/job-manager/pkg/syncer/pod_handler_test.go
@@ -489,6 +489,21 @@ func TestGetAdminWorkloadAndSyncPodNonMesh(t *testing.T) {
 	assert.Equal(t, v1.GetWorkloadDispatchCnt(got), 2)
 }
 
+// TestGetAdminWorkloadAndSyncPodMissingWorkload reproduces the nil-pointer panic:
+// when the admin workload is deleted (NotFound), getAdminWorkload returns
+// (nil, nil) and the sync must return (nil, nil) instead of dereferencing nil in
+// SetLabel.
+func TestGetAdminWorkloadAndSyncPodMissingWorkload(t *testing.T) {
+	cl := ctrlfake.NewClientBuilder().WithScheme(syncerScheme(t)).Build()
+	r := &SyncerReconciler{Client: cl}
+
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1"}}
+	got, err := r.getAdminWorkloadAndSyncPod(context.Background(), monkeyClientSets(), pod,
+		&resourceMessage{workloadId: "missing", dispatchCount: 1})
+	assert.NilError(t, err)
+	assert.Assert(t, got == nil)
+}
+
 // TestBuildWorkloadPodInfo patches buildPodTerminatedInfo (the only clientSet user) so
 // buildWorkloadPodInfo can assemble pod metadata without a live cluster.
 func TestBuildWorkloadPodInfo(t *testing.T) {


### PR DESCRIPTION
getAdminWorkload returns (nil, nil) when the admin workload was deleted (NotFound) while a pod event is still in flight. getAdminWorkloadAndSyncPod then called v1.SetLabel on the nil *Workload, panicking with a nil-pointer dereference in the syncer controller loop. Return (nil, nil) before SetLabel; the caller already treats nil as a no-op.