### PR TITLE
fix(web): restore workload list filter URL sync on CICD, Authoring, Dynamo

### DIFF
--- a/Web/apps/safe/src/pages/Authoring/index.vue
+++ b/Web/apps/safe/src/pages/Authoring/index.vue
@@ -627,17 +627,55 @@ const filterByMyself = () => {
   onSearch({ resetPage: true })
 }
 
+const applyQueryToParams = () => {
+  const q = route.query
+  searchParams.userName = (q.userName as string) || ''
+  searchParams.description = (q.description as string) || ''
+  searchParams.workloadId = (q.workloadId as string) || ''
+  searchParams.onlyMyself = (q.onlyMyself as string) || 'All'
+  searchParams.userId = (q.userId as string) || ''
+  const phaseStr = (q.phase as string) || ''
+  searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
+  const since = q.since as string | undefined
+  const until = q.until as string | undefined
+  searchParams.dateRange = (since || until
+    ? [since ? dayjs(since).toDate() : '', until ? dayjs(until).toDate() : '']
+    : '') as any
+  pagination.page = Number(q.page || 1)
+  pagination.pageSize = Number(q.pageSize || pagination.pageSize)
+}
+
 const onSearch = (options?: { resetPage?: boolean }) => {
   const reset = options?.resetPage ?? true
   if (reset) pagination.page = 1
 
   const [start, end] = searchParams.dateRange
+  const since = start ? dayjs(start).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : ''
+  const until = end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : ''
+  const phaseStr = searchParams.phase?.length ? searchParams.phase.join(',') : ''
+
+  router.replace({
+    query: {
+      ...route.query,
+      userName: searchParams.userName || undefined,
+      description: searchParams.description || undefined,
+      phase: phaseStr || undefined,
+      since: since || undefined,
+      until: until || undefined,
+      workloadId: searchParams.workloadId || undefined,
+      onlyMyself: searchParams.onlyMyself || undefined,
+      userId: searchParams.userId,
+      page: String(pagination.page),
+      pageSize: String(pagination.pageSize),
+    },
+  })
+
   fetchData({
     userName: searchParams.userName,
     description: searchParams.description,
-    phase: searchParams.phase && searchParams.phase.length ? searchParams.phase.join(',') : '',
-    since: start ? dayjs(start).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : '',
-    until: end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : '',
+    phase: phaseStr,
+    since,
+    until,
     workloadId: searchParams.workloadId,
     userId: searchParams.userId,
   })
@@ -900,7 +938,10 @@ watch(
   // Refresh list data immediately when workspace dropdown changes
   () => store.currentWorkspaceId,
   (id) => {
-    if (id) fetchData()
+    if (id) {
+      applyQueryToParams()
+      onSearch({ resetPage: false })
+    }
   },
   { immediate: true },
 )

--- a/Web/apps/safe/src/pages/CICD/index.vue
+++ b/Web/apps/safe/src/pages/CICD/index.vue
@@ -781,17 +781,55 @@ const filterByMyself = () => {
   onSearch({ resetPage: true })
 }
 
+const applyQueryToParams = () => {
+  const q = route.query
+  searchParams.userName = (q.userName as string) || ''
+  searchParams.description = (q.description as string) || ''
+  searchParams.workloadId = (q.workloadId as string) || ''
+  searchParams.onlyMyself = (q.onlyMyself as string) || 'All'
+  searchParams.userId = (q.userId as string) || ''
+  const phaseStr = (q.phase as string) || ''
+  searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
+  const since = q.since as string | undefined
+  const until = q.until as string | undefined
+  searchParams.dateRange = (since || until
+    ? [since ? dayjs(since).toDate() : '', until ? dayjs(until).toDate() : '']
+    : '') as any
+  pagination.page = Number(q.page || 1)
+  pagination.pageSize = Number(q.pageSize || pagination.pageSize)
+}
+
 const onSearch = (options?: { resetPage?: boolean }) => {
   const reset = options?.resetPage ?? true
   if (reset) pagination.page = 1
 
   const [start, end] = searchParams.dateRange
+  const since = start ? dayjs(start).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : ''
+  const until = end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : ''
+  const phaseStr = searchParams.phase?.length ? searchParams.phase.join(',') : ''
+
+  router.replace({
+    query: {
+      ...route.query,
+      userName: searchParams.userName || undefined,
+      description: searchParams.description || undefined,
+      phase: phaseStr || undefined,
+      since: since || undefined,
+      until: until || undefined,
+      workloadId: searchParams.workloadId || undefined,
+      onlyMyself: searchParams.onlyMyself || undefined,
+      userId: searchParams.userId,
+      page: String(pagination.page),
+      pageSize: String(pagination.pageSize),
+    },
+  })
+
   fetchData({
     userName: searchParams.userName,
     description: searchParams.description,
-    phase: searchParams.phase && searchParams.phase.length ? searchParams.phase.join(',') : '',
-    since: start ? dayjs(start).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : '',
-    until: end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : '',
+    phase: phaseStr,
+    since,
+    until,
     workloadId: searchParams.workloadId,
     userId: searchParams.userId,
   })
@@ -1354,7 +1392,10 @@ watch(
   // Refresh on workspace dropdown change - update list data immediately
   () => store.currentWorkspaceId,
   (id) => {
-    if (id) fetchData()
+    if (id) {
+      applyQueryToParams()
+      onSearch({ resetPage: false })
+    }
   },
   { immediate: true },
 )

--- a/Web/apps/safe/src/pages/Dynamo/index.vue
+++ b/Web/apps/safe/src/pages/Dynamo/index.vue
@@ -222,7 +222,7 @@
 
 <script lang="ts" setup>
 import { computed, h, nextTick, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { useDark } from '@vueuse/core'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
@@ -284,6 +284,7 @@ const workloadConfig = computed(() =>
 )
 
 const router = useRouter()
+const route = useRoute()
 const store = useWorkspaceStore()
 const userStore = useUserStore()
 const { canWrite } = useWorkloadWriteGuard()
@@ -358,12 +359,46 @@ const fetchData = async (params?: WorkloadParams) => {
   }
 }
 
+const applyQueryToParams = () => {
+  const q = route.query
+  searchParams.userName = (q.userName as string) || ''
+  searchParams.description = (q.description as string) || ''
+  searchParams.workloadId = (q.workloadId as string) || ''
+  searchParams.onlyMyself = (q.onlyMyself as string) || 'My Workloads'
+  searchParams.userId = (q.userId as string) || ''
+  const phaseStr = (q.phase as string) || ''
+  searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
+  const since = q.since as string | undefined
+  const until = q.until as string | undefined
+  searchParams.dateRange = (since || until
+    ? [since ? dayjs(since).toDate() : '', until ? dayjs(until).toDate() : '']
+    : '') as DateRange
+  pagination.page = Number(q.page || 1)
+  pagination.pageSize = Number(q.pageSize || pagination.pageSize)
+}
+
 const onSearch = (options?: { resetPage?: boolean }) => {
   if (options?.resetPage) pagination.page = 1
   const [start, end] = searchParams.dateRange ?? []
   const since = start ? dayjs(start).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : ''
   const until = end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : ''
   const phaseStr = searchParams.phase?.length ? searchParams.phase.join(',') : ''
+
+  router.replace({
+    query: {
+      ...route.query,
+      userName: searchParams.userName || undefined,
+      description: searchParams.description || undefined,
+      phase: phaseStr || undefined,
+      since: since || undefined,
+      until: until || undefined,
+      workloadId: searchParams.workloadId || undefined,
+      onlyMyself: searchParams.onlyMyself || undefined,
+      userId: searchParams.userId,
+      page: String(pagination.page),
+      pageSize: String(pagination.pageSize),
+    },
+  })
 
   fetchData({
     userName: searchParams.userName,
@@ -540,7 +575,8 @@ onMounted(() => {
   window.addEventListener('pointerdown', onAnyPointerDown, { capture: true })
   userStore.fetchEnvs()
   router.replace({ query: { ...router.currentRoute.value.query, kind: workloadConfig.value.kind } })
-  onSearch({ resetPage: true })
+  applyQueryToParams()
+  onSearch({ resetPage: false })
 })
 
 onBeforeUnmount(() => {


### PR DESCRIPTION
## Summary

The 'persist workload list filters in URL' behavior (originally added in commit e70d49dee) was lost for **CICD**, **Authoring** and **Dynamo** list pages after the pulse-alignment merge (#677). On these pages, clicking the filter/search button ran fetchData directly and never wrote query params to the URL, so:

- filter state was not reflected in the URL, and
- returning from a workload detail page did not restore the previous filters/pagination.

The other six workload list pages (Training, Infer, RayJob, Monarch, TorchFT, SandboxWorkload) still had it via their inline router.replace in onSearch.

## Fix

For CICD, Authoring and Dynamo, mirror the surviving pages' inline pattern:
- **onSearch**: write userName/description/phase/since/until/workloadId/onlyMyself/userId/page/pageSize to the URL via router.replace before fetchData.
- **applyQueryToParams()**: restore searchParams + pagination from route.query.
- restore on mount / workspace change (CICD, Authoring watcher; Dynamo onMounted). Dynamo also gains the missing useRoute import.

## Notes
- The orphaned useWorkloadListQuery composable (unused on main) is left as-is; not needed for this fix.

## Test plan
- [ ] On CICD / Authoring / Dynamo list pages, applying a filter updates the URL query.
- [ ] Navigating into a detail page and back restores the same filters + page.
- [ ] vue-tsc passes; vitest 115/115 pass (verified locally).