### PR TITLE
feat(web): restore composable-based workload list URL-query (all pages)

### DIFF
--- a/Web/apps/safe/src/pages/Authoring/index.vue
+++ b/Web/apps/safe/src/pages/Authoring/index.vue
@@ -338,6 +338,7 @@ import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import { useRoute, useRouter } from 'vue-router'
 import { useRouteAction, ROUTE_ACTIONS } from '@/composables/useRouteAction'
+import { useWorkloadListQuery } from '@/composables/useWorkloadListQuery'
 import AddDialog from './Components/AddDialog.vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import {
@@ -384,6 +385,36 @@ const pagination = reactive({
   pageSize: 20,
   total: 0,
 })
+
+const { readQuery, writeQuery, syncUserId } = useWorkloadListQuery({
+  searchParams,
+  pagination,
+  defaultScope: 'My Workloads',
+  serializeFilters: () => {
+    const [start, end] = searchParams.dateRange ?? []
+    return {
+      userName: searchParams.userName || undefined,
+      description: searchParams.description || undefined,
+      phase: searchParams.phase?.length ? searchParams.phase.join(',') : undefined,
+      since: start ? dayjs(start).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      until: end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      workloadId: searchParams.workloadId || undefined,
+    }
+  },
+  parseFilters: (q) => {
+    searchParams.userName = (q.userName as string) || ''
+    searchParams.description = (q.description as string) || ''
+    searchParams.workloadId = (q.workloadId as string) || ''
+    const phaseStr = (q.phase as string) || ''
+    searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
+    const since = q.since as string | undefined
+    const until = q.until as string | undefined
+    searchParams.dateRange = (since || until
+      ? [since ? dayjs(since).toDate() : '', until ? dayjs(until).toDate() : '']
+      : '') as any
+  },
+})
+
 const curWlId = ref()
 const curAction = ref<'Create' | 'Edit' | 'Clone' | 'Resume'>('Create')
 const curLimitedEdit = ref(false)
@@ -623,13 +654,15 @@ const handleFilterChange = (filters: Record<string, string[]>) => {
 }
 
 const filterByMyself = () => {
-  searchParams.userId = searchParams.onlyMyself !== 'All' ? userStore.userId : ''
+  syncUserId()
   onSearch({ resetPage: true })
 }
 
 const onSearch = (options?: { resetPage?: boolean }) => {
   const reset = options?.resetPage ?? true
   if (reset) pagination.page = 1
+
+  writeQuery()
 
   const [start, end] = searchParams.dateRange
   fetchData({
@@ -900,7 +933,10 @@ watch(
   // Refresh list data immediately when workspace dropdown changes
   () => store.currentWorkspaceId,
   (id) => {
-    if (id) fetchData()
+    if (id) {
+      readQuery()
+      onSearch({ resetPage: false })
+    }
   },
   { immediate: true },
 )

--- a/Web/apps/safe/src/pages/CICD/index.vue
+++ b/Web/apps/safe/src/pages/CICD/index.vue
@@ -615,6 +615,7 @@ import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import { useRoute, useRouter } from 'vue-router'
 import { useRouteAction, ROUTE_ACTIONS } from '@/composables/useRouteAction'
+import { useWorkloadListQuery } from '@/composables/useWorkloadListQuery'
 import AddDialog from './Components/AddDialog.vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import {
@@ -668,6 +669,36 @@ const pagination = reactive({
   pageSize: 20,
   total: 0,
 })
+
+const { readQuery, writeQuery, syncUserId } = useWorkloadListQuery({
+  searchParams,
+  pagination,
+  defaultScope: 'My Workloads',
+  serializeFilters: () => {
+    const [start, end] = searchParams.dateRange ?? []
+    return {
+      userName: searchParams.userName || undefined,
+      description: searchParams.description || undefined,
+      phase: searchParams.phase?.length ? searchParams.phase.join(',') : undefined,
+      since: start ? dayjs(start).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      until: end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      workloadId: searchParams.workloadId || undefined,
+    }
+  },
+  parseFilters: (q) => {
+    searchParams.userName = (q.userName as string) || ''
+    searchParams.description = (q.description as string) || ''
+    searchParams.workloadId = (q.workloadId as string) || ''
+    const phaseStr = (q.phase as string) || ''
+    searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
+    const since = q.since as string | undefined
+    const until = q.until as string | undefined
+    searchParams.dateRange = (since || until
+      ? [since ? dayjs(since).toDate() : '', until ? dayjs(until).toDate() : '']
+      : '') as any
+  },
+})
+
 const curWlId = ref()
 const curAction = ref<'Create' | 'Edit' | 'Clone' | 'Resume'>('Create')
 
@@ -777,7 +808,7 @@ const handlePageSizeChange = (newSize: number) => {
 }
 
 const filterByMyself = () => {
-  searchParams.userId = searchParams.onlyMyself !== 'All' ? userStore.userId : ''
+  syncUserId()
   onSearch({ resetPage: true })
 }
 
@@ -786,6 +817,9 @@ const onSearch = (options?: { resetPage?: boolean }) => {
   if (reset) pagination.page = 1
 
   const [start, end] = searchParams.dateRange
+
+  writeQuery()
+
   fetchData({
     userName: searchParams.userName,
     description: searchParams.description,
@@ -1354,7 +1388,10 @@ watch(
   // Refresh on workspace dropdown change - update list data immediately
   () => store.currentWorkspaceId,
   (id) => {
-    if (id) fetchData()
+    if (id) {
+      readQuery()
+      onSearch({ resetPage: false })
+    }
   },
   { immediate: true },
 )

--- a/Web/apps/safe/src/pages/Deploy/index.vue
+++ b/Web/apps/safe/src/pages/Deploy/index.vue
@@ -234,8 +234,30 @@ const passAll = () => {
   return true
 }
 
+// Keep the URL query in sync with the type/status/pagination state so that
+// returning from a deployment detail page restores the same list view.
+const readQuery = () => {
+  const q = router.currentRoute.value.query
+  const type = q.type as string
+  if (type === 'safe' || type === 'lens') currentType.value = type
+  const statusStr = (q.status as string) || ''
+  searchParams.status = statusStr ? (statusStr.split(',') as DeploymentStatus[]) : []
+  pagination.page = Number(q.page || 1)
+  pagination.pageSize = Number(q.pageSize || pagination.pageSize)
+}
+
+const writeQuery = () => {
+  const query: Record<string, string> = {}
+  query.type = currentType.value
+  if (searchParams.status.length) query.status = searchParams.status.join(',')
+  query.page = String(pagination.page)
+  query.pageSize = String(pagination.pageSize)
+  router.replace({ query })
+}
+
 const fetchData = async () => {
   try {
+    writeQuery()
     loading.value = true
     const params: {
       offset: number
@@ -276,15 +298,13 @@ const handleTableFilterChange = (filters: Record<string, DeploymentStatus[]>) =>
 
 const handleTypeChange = () => {
   pagination.page = 1
-  // keep selected type in URL so returning from detail can restore it
-  router.replace({ query: { ...route.query, type: currentType.value } })
+  // writeQuery (called inside fetchData) keeps type + status + pagination in URL
   fetchData()
 }
 
 const handleCreateSuccess = (type?: DeploymentType) => {
   if (type) currentType.value = type
   pagination.page = 1
-  router.replace({ query: { ...route.query, type: currentType.value } })
   fetchData()
 }
 
@@ -393,10 +413,8 @@ const handleRetry = async (row: DeploymentRequest) => {
 onMounted(async () => {
   // Check if there's an approval ID in the query params
   const approvalId = route.query.approvalId
-  const approvalType = route.query.type as DeploymentType | undefined
-  if (approvalType === 'safe' || approvalType === 'lens') {
-    currentType.value = approvalType
-  }
+  // Restore type + status + pagination from URL before the first fetch.
+  readQuery()
 
   await fetchData()
 

--- a/Web/apps/safe/src/pages/Dynamo/index.vue
+++ b/Web/apps/safe/src/pages/Dynamo/index.vue
@@ -222,7 +222,6 @@
 
 <script lang="ts" setup>
 import { computed, h, nextTick, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
-import { useRouter } from 'vue-router'
 import { useDark } from '@vueuse/core'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
@@ -240,6 +239,7 @@ import {
 } from '@element-plus/icons-vue'
 import ResetIcon from '@/components/icons/ResetIcon.vue'
 import { useWorkloadWriteGuard } from '@/composables/useWorkloadWriteGuard'
+import { useWorkloadListQuery } from '@/composables/useWorkloadListQuery'
 import { useWorkspaceStore } from '@/stores/workspace'
 import { useUserStore } from '@/stores/user'
 import {
@@ -283,7 +283,6 @@ const workloadConfig = computed(() =>
       },
 )
 
-const router = useRouter()
 const store = useWorkspaceStore()
 const userStore = useUserStore()
 const { canWrite } = useWorkloadWriteGuard()
@@ -322,6 +321,36 @@ interface DynamoRow {
 
 const tableData = ref<DynamoRow[]>([])
 const pagination = reactive({ page: 1, pageSize: 20, total: 0 })
+
+const { readQuery, writeQuery, syncUserId } = useWorkloadListQuery({
+  searchParams,
+  pagination,
+  defaultScope: 'My Workloads',
+  serializeFilters: () => {
+    const [start, end] = searchParams.dateRange ?? []
+    return {
+      userName: searchParams.userName || undefined,
+      description: searchParams.description || undefined,
+      phase: searchParams.phase?.length ? searchParams.phase.join(',') : undefined,
+      since: start ? dayjs(start).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      until: end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      workloadId: searchParams.workloadId || undefined,
+    }
+  },
+  parseFilters: (q) => {
+    searchParams.userName = (q.userName as string) || ''
+    searchParams.description = (q.description as string) || ''
+    searchParams.workloadId = (q.workloadId as string) || ''
+    const phaseStr = (q.phase as string) || ''
+    searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
+    const since = q.since as string | undefined
+    const until = q.until as string | undefined
+    searchParams.dateRange = (since || until
+      ? [since ? dayjs(since).toDate() : '', until ? dayjs(until).toDate() : '']
+      : '') as DateRange
+  },
+})
+
 const addVisible = ref(false)
 const curWlId = ref('')
 const curAction = ref<'Create' | 'Clone'>('Create')
@@ -365,6 +394,8 @@ const onSearch = (options?: { resetPage?: boolean }) => {
   const until = end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : ''
   const phaseStr = searchParams.phase?.length ? searchParams.phase.join(',') : ''
 
+  writeQuery()
+
   fetchData({
     userName: searchParams.userName,
     description: searchParams.description,
@@ -384,7 +415,7 @@ const resetAndSearch = () => {
 }
 
 const filterByMyself = () => {
-  searchParams.userId = searchParams.onlyMyself !== 'All' ? userStore.userId : ''
+  syncUserId()
   onSearch({ resetPage: true })
 }
 
@@ -539,8 +570,8 @@ onMounted(() => {
   window.addEventListener('touchmove', onAnyScroll, { passive: true, capture: true })
   window.addEventListener('pointerdown', onAnyPointerDown, { capture: true })
   userStore.fetchEnvs()
-  router.replace({ query: { ...router.currentRoute.value.query, kind: workloadConfig.value.kind } })
-  onSearch({ resetPage: true })
+  readQuery()
+  onSearch({ resetPage: false })
 })
 
 onBeforeUnmount(() => {

--- a/Web/apps/safe/src/pages/Infer/index.vue
+++ b/Web/apps/safe/src/pages/Infer/index.vue
@@ -349,6 +349,7 @@ import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import { useRoute, useRouter } from 'vue-router'
 import { useRouteAction, ROUTE_ACTIONS } from '@/composables/useRouteAction'
+import { useWorkloadListQuery } from '@/composables/useWorkloadListQuery'
 import AddDialog from './Components/AddDialog.vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { Delete, DocumentCopy, Edit, Close, MoreFilled, VideoPlay } from '@element-plus/icons-vue'
@@ -392,6 +393,36 @@ const pagination = reactive({
   pageSize: 20,
   total: 0,
 })
+
+const { readQuery, writeQuery, syncUserId } = useWorkloadListQuery({
+  searchParams,
+  pagination,
+  defaultScope: 'My Workloads',
+  serializeFilters: () => {
+    const [start, end] = searchParams.dateRange ?? []
+    return {
+      userName: searchParams.userName || undefined,
+      description: searchParams.description || undefined,
+      phase: searchParams.phase?.length ? searchParams.phase.join(',') : undefined,
+      since: start ? dayjs(start).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      until: end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      workloadId: searchParams.workloadId || undefined,
+    }
+  },
+  parseFilters: (q) => {
+    searchParams.userName = (q.userName as string) || ''
+    searchParams.description = (q.description as string) || ''
+    searchParams.workloadId = (q.workloadId as string) || ''
+    const phaseStr = (q.phase as string) || ''
+    searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
+    const since = q.since as string | undefined
+    const until = q.until as string | undefined
+    searchParams.dateRange = (since || until
+      ? [since ? dayjs(since).toDate() : '', until ? dayjs(until).toDate() : '']
+      : '') as any
+  },
+})
+
 const curWlId = ref()
 const curAction = ref<'Create' | 'Edit' | 'Clone' | 'Resume'>('Create')
 
@@ -466,7 +497,7 @@ const handleFilterChange = (filters: Record<string, string[]>) => {
 }
 
 const filterByMyself = () => {
-  searchParams.userId = searchParams.onlyMyself !== 'All' ? userStore.userId : ''
+  syncUserId()
   onSearch({ resetPage: true })
 }
 
@@ -479,21 +510,7 @@ const onSearch = (options?: { resetPage?: boolean }) => {
   const until = end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : ''
   const phaseStr = searchParams.phase?.length ? searchParams.phase.join(',') : ''
 
-  router.replace({
-    query: {
-      ...route.query,
-      userName: searchParams.userName || undefined,
-      description: searchParams.description || undefined,
-      phase: phaseStr || undefined,
-      since: since || undefined,
-      until: until || undefined,
-      workloadId: searchParams.workloadId || undefined,
-      onlyMyself: searchParams.onlyMyself || undefined,
-      userId: searchParams.userId,
-      page: String(pagination.page),
-      pageSize: String(pagination.pageSize),
-    },
-  })
+  writeQuery()
 
   fetchData({
     userName: searchParams.userName,
@@ -730,43 +747,12 @@ onBeforeUnmount(() => {
   window.removeEventListener('pointerdown', onAnyPointerDown, { capture: true } as any)
 })
 
-function applyQueryToParams() {
-  const q = route.query
-
-  searchParams.userName = (q.userName as string) || ''
-  searchParams.description = (q.description as string) || ''
-  searchParams.workloadId = (q.workloadId as string) || ''
-  searchParams.onlyMyself = (q.onlyMyself as string) || 'My Workloads'
-  searchParams.userId = (q.userId as string) || ''
-
-  const phaseStr = (q.phase as string) || ''
-  searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
-
-  const since = q.since as string | undefined
-  const until = q.until as string | undefined
-  if (since || until) {
-    searchParams.dateRange = [
-      since ? dayjs(since).toDate() : '',
-      until ? dayjs(until).toDate() : '',
-    ] as any
-  } else {
-    searchParams.dateRange = ''
-  }
-
-  // Pagination
-  pagination.page = Number(q.page || 1)
-  pagination.pageSize = Number(q.pageSize || pagination.pageSize)
-}
-
 watch(
   // Refresh list data immediately when workspace dropdown changes
   () => store.currentWorkspaceId,
   (id) => {
     if (id) {
-      applyQueryToParams()
-      if (!searchParams.userId && searchParams.onlyMyself === 'My Workloads') {
-        searchParams.userId = userStore.userId
-      }
+      readQuery()
       onSearch({ resetPage: false })
     }
   },

--- a/Web/apps/safe/src/pages/Monarch/index.vue
+++ b/Web/apps/safe/src/pages/Monarch/index.vue
@@ -356,8 +356,9 @@ import ResetIcon from '@/components/icons/ResetIcon.vue'
 import { copyText, formatTimeStr } from '@/utils/index'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
-import { useRoute, useRouter } from 'vue-router'
+import { useRouter } from 'vue-router'
 import { useRouteAction, ROUTE_ACTIONS } from '@/composables/useRouteAction'
+import { useWorkloadListQuery } from '@/composables/useWorkloadListQuery'
 import AddDialog from './Components/AddDialog.vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { Delete, DocumentCopy, Close, MoreFilled } from '@element-plus/icons-vue'
@@ -370,7 +371,6 @@ dayjs.extend(utc)
 
 const tableRef = ref()
 const isDark = useDark()
-const route = useRoute()
 const router = useRouter()
 const store = useWorkspaceStore()
 const userStore = useUserStore()
@@ -422,6 +422,36 @@ const pagination = reactive({
   pageSize: 20,
   total: 0,
 })
+
+const { readQuery, writeQuery, syncUserId } = useWorkloadListQuery({
+  searchParams,
+  pagination,
+  defaultScope: 'My Workloads',
+  serializeFilters: () => {
+    const [start, end] = searchParams.dateRange ?? []
+    return {
+      userName: searchParams.userName || undefined,
+      description: searchParams.description || undefined,
+      phase: searchParams.phase?.length ? searchParams.phase.join(',') : undefined,
+      since: start ? dayjs(start).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      until: end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      workloadId: searchParams.workloadId || undefined,
+    }
+  },
+  parseFilters: (q) => {
+    searchParams.userName = (q.userName as string) || ''
+    searchParams.description = (q.description as string) || ''
+    searchParams.workloadId = (q.workloadId as string) || ''
+    const phaseStr = (q.phase as string) || ''
+    searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
+    const since = q.since as string | undefined
+    const until = q.until as string | undefined
+    searchParams.dateRange = (since || until
+      ? [since ? dayjs(since).toDate() : '', until ? dayjs(until).toDate() : '']
+      : '') as any
+  },
+})
+
 const curWlId = ref()
 const curAction = ref<'Create' | 'Clone'>('Create')
 
@@ -492,7 +522,7 @@ const handleFilterChange = (filters: Record<string, string[]>) => {
 }
 
 const filterByMyself = () => {
-  searchParams.userId = searchParams.onlyMyself !== 'All' ? userStore.userId : ''
+  syncUserId()
   onSearch({ resetPage: true })
 }
 
@@ -505,21 +535,7 @@ const onSearch = (options?: { resetPage?: boolean }) => {
   const until = end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : ''
   const phaseStr = searchParams.phase?.length ? searchParams.phase.join(',') : ''
 
-  router.replace({
-    query: {
-      ...route.query,
-      userName: searchParams.userName || undefined,
-      description: searchParams.description || undefined,
-      phase: phaseStr || undefined,
-      since: since || undefined,
-      until: until || undefined,
-      workloadId: searchParams.workloadId || undefined,
-      onlyMyself: searchParams.onlyMyself || undefined,
-      userId: searchParams.userId,
-      page: String(pagination.page),
-      pageSize: String(pagination.pageSize),
-    },
-  })
+  writeQuery()
 
   fetchData({
     userName: searchParams.userName,
@@ -729,43 +745,12 @@ onBeforeUnmount(() => {
   } as AddEventListenerOptions)
 })
 
-function applyQueryToParams() {
-  const q = route.query
-
-  searchParams.userName = (q.userName as string) || ''
-  searchParams.description = (q.description as string) || ''
-  searchParams.workloadId = (q.workloadId as string) || ''
-  searchParams.onlyMyself = (q.onlyMyself as string) || 'My Workloads'
-  searchParams.userId = (q.userId as string) || ''
-
-  const phaseStr = (q.phase as string) || ''
-  searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
-
-  const since = q.since as string | undefined
-  const until = q.until as string | undefined
-  if (since || until) {
-    searchParams.dateRange = [
-      since ? dayjs(since).toDate() : '',
-      until ? dayjs(until).toDate() : '',
-    ]
-  } else {
-    searchParams.dateRange = ''
-  }
-
-  // Pagination
-  pagination.page = Number(q.page || 1)
-  pagination.pageSize = Number(q.pageSize || pagination.pageSize)
-}
-
 watch(
   // Refresh list data immediately when workspace dropdown changes
   () => store.currentWorkspaceId,
   (id) => {
     if (id) {
-      applyQueryToParams()
-      if (!searchParams.userId && searchParams.onlyMyself === 'My Workloads') {
-        searchParams.userId = userStore.userId
-      }
+      readQuery()
       onSearch({ resetPage: false })
     }
   },

--- a/Web/apps/safe/src/pages/RayJob/index.vue
+++ b/Web/apps/safe/src/pages/RayJob/index.vue
@@ -382,8 +382,9 @@ import ResetIcon from '@/components/icons/ResetIcon.vue'
 import { copyText, formatTimeStr, last24hUtcExact } from '@/utils/index'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
-import { useRoute, useRouter } from 'vue-router'
+import { useRouter } from 'vue-router'
 import { useRouteAction, ROUTE_ACTIONS } from '@/composables/useRouteAction'
+import { useWorkloadListQuery } from '@/composables/useWorkloadListQuery'
 import AddDialog from './Components/AddDialog.vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { Delete, DocumentCopy, Edit, Close, MoreFilled, VideoPlay } from '@element-plus/icons-vue'
@@ -397,7 +398,6 @@ dayjs.extend(utc)
 
 const tableRef = ref()
 const isDark = useDark()
-const route = useRoute()
 const router = useRouter()
 const store = useWorkspaceStore()
 const userStore = useUserStore()
@@ -449,6 +449,36 @@ const pagination = reactive({
   pageSize: 20,
   total: 0,
 })
+
+const { readQuery, writeQuery, syncUserId } = useWorkloadListQuery({
+  searchParams,
+  pagination,
+  defaultScope: 'My Workloads',
+  serializeFilters: () => {
+    const [start, end] = searchParams.dateRange ?? []
+    return {
+      userName: searchParams.userName || undefined,
+      description: searchParams.description || undefined,
+      phase: searchParams.phase?.length ? searchParams.phase.join(',') : undefined,
+      since: start ? dayjs(start).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      until: end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      workloadId: searchParams.workloadId || undefined,
+    }
+  },
+  parseFilters: (q) => {
+    searchParams.userName = (q.userName as string) || ''
+    searchParams.description = (q.description as string) || ''
+    searchParams.workloadId = (q.workloadId as string) || ''
+    const phaseStr = (q.phase as string) || ''
+    searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
+    const since = q.since as string | undefined
+    const until = q.until as string | undefined
+    searchParams.dateRange = (since || until
+      ? [since ? dayjs(since).toDate() : '', until ? dayjs(until).toDate() : '']
+      : '') as any
+  },
+})
+
 const curWlId = ref()
 const curAction = ref<'Create' | 'Edit' | 'Clone'>('Create')
 const curLimitedEdit = ref(false)
@@ -576,7 +606,7 @@ const handleFilterChange = (filters: Record<string, string[]>) => {
 }
 
 const filterByMyself = () => {
-  searchParams.userId = searchParams.onlyMyself !== 'All' ? userStore.userId : ''
+  syncUserId()
   onSearch({ resetPage: true })
 }
 
@@ -589,21 +619,7 @@ const onSearch = (options?: { resetPage?: boolean }) => {
   const until = end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : ''
   const phaseStr = searchParams.phase?.length ? searchParams.phase.join(',') : ''
 
-  router.replace({
-    query: {
-      ...route.query,
-      userName: searchParams.userName || undefined,
-      description: searchParams.description || undefined,
-      phase: phaseStr || undefined,
-      since: since || undefined,
-      until: until || undefined,
-      workloadId: searchParams.workloadId || undefined,
-      onlyMyself: searchParams.onlyMyself || undefined,
-      userId: searchParams.userId,
-      page: String(pagination.page),
-      pageSize: String(pagination.pageSize),
-    },
-  })
+  writeQuery()
 
   fetchData({
     userName: searchParams.userName,
@@ -831,43 +847,12 @@ onBeforeUnmount(() => {
   } as AddEventListenerOptions)
 })
 
-function applyQueryToParams() {
-  const q = route.query
-
-  searchParams.userName = (q.userName as string) || ''
-  searchParams.description = (q.description as string) || ''
-  searchParams.workloadId = (q.workloadId as string) || ''
-  searchParams.onlyMyself = (q.onlyMyself as string) || 'My Workloads'
-  searchParams.userId = (q.userId as string) || ''
-
-  const phaseStr = (q.phase as string) || ''
-  searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
-
-  const since = q.since as string | undefined
-  const until = q.until as string | undefined
-  if (since || until) {
-    searchParams.dateRange = [
-      since ? dayjs(since).toDate() : '',
-      until ? dayjs(until).toDate() : '',
-    ]
-  } else {
-    searchParams.dateRange = ''
-  }
-
-  // Pagination
-  pagination.page = Number(q.page || 1)
-  pagination.pageSize = Number(q.pageSize || pagination.pageSize)
-}
-
 watch(
   // Refresh list data immediately when workspace dropdown changes
   () => store.currentWorkspaceId,
   (id) => {
     if (id) {
-      applyQueryToParams()
-      if (!searchParams.userId && searchParams.onlyMyself === 'My Workloads') {
-        searchParams.userId = userStore.userId
-      }
+      readQuery()
       onSearch({ resetPage: false })
     }
   },

--- a/Web/apps/safe/src/pages/SandboxWorkload/index.vue
+++ b/Web/apps/safe/src/pages/SandboxWorkload/index.vue
@@ -312,18 +312,18 @@ import ResetIcon from '@/components/icons/ResetIcon.vue'
 import { copyText, formatTimeStr } from '@/utils/index'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
-import { useRoute, useRouter } from 'vue-router'
+import { useRouter } from 'vue-router'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { type WorkloadParams, type PriorityValue, PRIORITY_LABEL_MAP } from '@/services'
 import { useUserStore } from '@/stores/user'
 import { useDark } from '@vueuse/core'
+import { useWorkloadListQuery } from '@/composables/useWorkloadListQuery'
 import EditDialog from './Components/EditDialog.vue'
 
 dayjs.extend(utc)
 
 const tableRef = ref()
 const isDark = useDark()
-const route = useRoute()
 const router = useRouter()
 const store = useWorkspaceStore()
 const userStore = useUserStore()
@@ -346,6 +346,35 @@ const searchParams = reactive({ ...initialSearchParams })
 const loading = ref(false)
 const tableData = ref([])
 const pagination = reactive({ page: 1, pageSize: 20, total: 0 })
+
+const { readQuery, writeQuery, syncUserId } = useWorkloadListQuery({
+  searchParams,
+  pagination,
+  defaultScope: 'My Workloads',
+  serializeFilters: () => {
+    const [start, end] = searchParams.dateRange ?? []
+    return {
+      userName: searchParams.userName || undefined,
+      description: searchParams.description || undefined,
+      phase: searchParams.phase?.length ? searchParams.phase.join(',') : undefined,
+      since: start ? dayjs(start).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      until: end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      workloadId: searchParams.workloadId || undefined,
+    }
+  },
+  parseFilters: (q) => {
+    searchParams.userName = (q.userName as string) || ''
+    searchParams.description = (q.description as string) || ''
+    searchParams.workloadId = (q.workloadId as string) || ''
+    const phaseStr = (q.phase as string) || ''
+    searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
+    const since = q.since as string | undefined
+    const until = q.until as string | undefined
+    searchParams.dateRange = (since || until
+      ? [since ? dayjs(since).toDate() : '', until ? dayjs(until).toDate() : '']
+      : '') as any
+  },
+})
 
 const SELECTION_BAR_H = 56
 const BASE_OFFSET = 245
@@ -405,7 +434,7 @@ const handleFilterChange = (filters: Record<string, string[]>) => {
 }
 
 const filterByMyself = () => {
-  searchParams.userId = searchParams.onlyMyself !== 'All' ? userStore.userId : ''
+  syncUserId()
   onSearch({ resetPage: true })
 }
 
@@ -418,20 +447,7 @@ const onSearch = (options?: { resetPage?: boolean }) => {
   const until = end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : ''
   const phaseStr = searchParams.phase?.length ? searchParams.phase.join(',') : ''
 
-  router.replace({
-    query: {
-      ...route.query,
-      userName: searchParams.userName || undefined,
-      phase: phaseStr || undefined,
-      since: since || undefined,
-      until: until || undefined,
-      workloadId: searchParams.workloadId || undefined,
-      onlyMyself: searchParams.onlyMyself || undefined,
-      userId: searchParams.userId,
-      page: String(pagination.page),
-      pageSize: String(pagination.pageSize),
-    },
-  })
+  writeQuery()
 
   fetchData({
     userName: searchParams.userName,
@@ -599,40 +615,11 @@ onBeforeUnmount(() => {
   window.removeEventListener('pointerdown', onAnyPointerDown, { capture: true } as any)
 })
 
-function applyQueryToParams() {
-  const q = route.query
-  searchParams.userName = (q.userName as string) || ''
-  searchParams.description = (q.description as string) || ''
-  searchParams.workloadId = (q.workloadId as string) || ''
-  searchParams.onlyMyself = (q.onlyMyself as string) || 'My Workloads'
-  searchParams.userId = (q.userId as string) || ''
-
-  const phaseStr = (q.phase as string) || ''
-  searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
-
-  const since = q.since as string | undefined
-  const until = q.until as string | undefined
-  if (since || until) {
-    searchParams.dateRange = [
-      since ? dayjs(since).toDate() : '',
-      until ? dayjs(until).toDate() : '',
-    ] as any
-  } else {
-    searchParams.dateRange = ''
-  }
-
-  pagination.page = Number(q.page || 1)
-  pagination.pageSize = Number(q.pageSize || pagination.pageSize)
-}
-
 watch(
   () => store.currentWorkspaceId,
   (id) => {
     if (id) {
-      applyQueryToParams()
-      if (!searchParams.userId && searchParams.onlyMyself === 'My Workloads') {
-        searchParams.userId = userStore.userId
-      }
+      readQuery()
       onSearch({ resetPage: false })
     }
   },

--- a/Web/apps/safe/src/pages/TorchFT/index.vue
+++ b/Web/apps/safe/src/pages/TorchFT/index.vue
@@ -364,8 +364,9 @@ import ResetIcon from '@/components/icons/ResetIcon.vue'
 import { copyText, formatTimeStr, last24hUtcExact } from '@/utils/index'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
-import { useRoute, useRouter } from 'vue-router'
+import { useRouter } from 'vue-router'
 import { useRouteAction, ROUTE_ACTIONS } from '@/composables/useRouteAction'
+import { useWorkloadListQuery } from '@/composables/useWorkloadListQuery'
 import AddDialog from './Components/AddDialog.vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import {
@@ -387,7 +388,6 @@ dayjs.extend(utc)
 
 const tableRef = ref()
 const isDark = useDark()
-const route = useRoute()
 const router = useRouter()
 const store = useWorkspaceStore()
 const userStore = useUserStore()
@@ -416,6 +416,36 @@ const pagination = reactive({
   pageSize: 20,
   total: 0,
 })
+
+const { readQuery, writeQuery, syncUserId } = useWorkloadListQuery({
+  searchParams,
+  pagination,
+  defaultScope: 'My Workloads',
+  serializeFilters: () => {
+    const [start, end] = searchParams.dateRange ?? []
+    return {
+      userName: searchParams.userName || undefined,
+      description: searchParams.description || undefined,
+      phase: searchParams.phase?.length ? searchParams.phase.join(',') : undefined,
+      since: start ? dayjs(start).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      until: end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      workloadId: searchParams.workloadId || undefined,
+    }
+  },
+  parseFilters: (q) => {
+    searchParams.userName = (q.userName as string) || ''
+    searchParams.description = (q.description as string) || ''
+    searchParams.workloadId = (q.workloadId as string) || ''
+    const phaseStr = (q.phase as string) || ''
+    searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
+    const since = q.since as string | undefined
+    const until = q.until as string | undefined
+    searchParams.dateRange = (since || until
+      ? [since ? dayjs(since).toDate() : '', until ? dayjs(until).toDate() : '']
+      : '') as any
+  },
+})
+
 const curWlId = ref()
 const curAction = ref<'Create' | 'Edit' | 'Clone'>('Create')
 const curLimitedEdit = ref(false)
@@ -538,7 +568,7 @@ const handleFilterChange = (filters: Record<string, string[]>) => {
 }
 
 const filterByMyself = () => {
-  searchParams.userId = searchParams.onlyMyself !== 'All' ? userStore.userId : ''
+  syncUserId()
   onSearch({ resetPage: true })
 }
 
@@ -551,21 +581,7 @@ const onSearch = (options?: { resetPage?: boolean }) => {
   const until = end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : ''
   const phaseStr = searchParams.phase?.length ? searchParams.phase.join(',') : ''
 
-  router.replace({
-    query: {
-      ...route.query,
-      userName: searchParams.userName || undefined,
-      description: searchParams.description || undefined,
-      phase: phaseStr || undefined,
-      since: since || undefined,
-      until: until || undefined,
-      workloadId: searchParams.workloadId || undefined,
-      onlyMyself: searchParams.onlyMyself || undefined,
-      userId: searchParams.userId,
-      page: String(pagination.page),
-      pageSize: String(pagination.pageSize),
-    },
-  })
+  writeQuery()
 
   fetchData({
     userName: searchParams.userName,
@@ -782,43 +798,12 @@ onBeforeUnmount(() => {
   window.removeEventListener('pointerdown', onAnyPointerDown, { capture: true } as any)
 })
 
-function applyQueryToParams() {
-  const q = route.query
-
-  searchParams.userName = (q.userName as string) || ''
-  searchParams.description = (q.description as string) || ''
-  searchParams.workloadId = (q.workloadId as string) || ''
-  searchParams.onlyMyself = (q.onlyMyself as string) || 'My Workloads'
-  searchParams.userId = (q.userId as string) || ''
-
-  const phaseStr = (q.phase as string) || ''
-  searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
-
-  const since = q.since as string | undefined
-  const until = q.until as string | undefined
-  if (since || until) {
-    searchParams.dateRange = [
-      since ? dayjs(since).toDate() : '',
-      until ? dayjs(until).toDate() : '',
-    ] as any
-  } else {
-    searchParams.dateRange = ''
-  }
-
-  // Pagination
-  pagination.page = Number(q.page || 1)
-  pagination.pageSize = Number(q.pageSize || pagination.pageSize)
-}
-
 watch(
   // Refresh list data immediately when workspace dropdown changes
   () => store.currentWorkspaceId,
   (id) => {
     if (id) {
-      applyQueryToParams()
-      if (!searchParams.userId && searchParams.onlyMyself === 'My Workloads') {
-        searchParams.userId = userStore.userId
-      }
+      readQuery()
       onSearch({ resetPage: false })
     }
   },

--- a/Web/apps/safe/src/pages/Training/index.vue
+++ b/Web/apps/safe/src/pages/Training/index.vue
@@ -389,6 +389,7 @@ import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import { useRoute, useRouter } from 'vue-router'
 import { useRouteAction, ROUTE_ACTIONS } from '@/composables/useRouteAction'
+import { useWorkloadListQuery } from '@/composables/useWorkloadListQuery'
 import AddDialog from './Components/AddDialog.vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { Delete, DocumentCopy, Edit, Close, MoreFilled, VideoPlay } from '@element-plus/icons-vue'
@@ -432,6 +433,36 @@ const pagination = reactive({
   pageSize: 20,
   total: 0,
 })
+
+const { readQuery, writeQuery, syncUserId } = useWorkloadListQuery({
+  searchParams,
+  pagination,
+  defaultScope: 'My Workloads',
+  serializeFilters: () => {
+    const [start, end] = searchParams.dateRange ?? []
+    return {
+      userName: searchParams.userName || undefined,
+      description: searchParams.description || undefined,
+      phase: searchParams.phase?.length ? searchParams.phase.join(',') : undefined,
+      since: start ? dayjs(start).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      until: end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : undefined,
+      workloadId: searchParams.workloadId || undefined,
+    }
+  },
+  parseFilters: (q) => {
+    searchParams.userName = (q.userName as string) || ''
+    searchParams.description = (q.description as string) || ''
+    searchParams.workloadId = (q.workloadId as string) || ''
+    const phaseStr = (q.phase as string) || ''
+    searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
+    const since = q.since as string | undefined
+    const until = q.until as string | undefined
+    searchParams.dateRange = (since || until
+      ? [since ? dayjs(since).toDate() : '', until ? dayjs(until).toDate() : '']
+      : '') as any
+  },
+})
+
 const curWlId = ref()
 const curAction = ref<'Create' | 'Edit' | 'Clone'>('Create')
 const curLimitedEdit = ref(false)
@@ -684,7 +715,7 @@ const handleFilterChange = (filters: Record<string, string[]>) => {
 }
 
 const filterByMyself = () => {
-  searchParams.userId = searchParams.onlyMyself !== 'All' ? userStore.userId : ''
+  syncUserId()
   onSearch({ resetPage: true })
 }
 
@@ -697,21 +728,7 @@ const onSearch = (options?: { resetPage?: boolean }) => {
   const until = end ? dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]') : ''
   const phaseStr = searchParams.phase?.length ? searchParams.phase.join(',') : ''
 
-  router.replace({
-    query: {
-      ...route.query,
-      userName: searchParams.userName || undefined,
-      description: searchParams.description || undefined,
-      phase: phaseStr || undefined,
-      since: since || undefined,
-      until: until || undefined,
-      workloadId: searchParams.workloadId || undefined,
-      onlyMyself: searchParams.onlyMyself || undefined,
-      userId: searchParams.userId,
-      page: String(pagination.page),
-      pageSize: String(pagination.pageSize),
-    },
-  })
+  writeQuery()
 
   fetchData({
     userName: searchParams.userName,
@@ -938,43 +955,12 @@ onBeforeUnmount(() => {
   window.removeEventListener('pointerdown', onAnyPointerDown, { capture: true } as any)
 })
 
-function applyQueryToParams() {
-  const q = route.query
-
-  searchParams.userName = (q.userName as string) || ''
-  searchParams.description = (q.description as string) || ''
-  searchParams.workloadId = (q.workloadId as string) || ''
-  searchParams.onlyMyself = (q.onlyMyself as string) || 'My Workloads'
-  searchParams.userId = (q.userId as string) || ''
-
-  const phaseStr = (q.phase as string) || ''
-  searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
-
-  const since = q.since as string | undefined
-  const until = q.until as string | undefined
-  if (since || until) {
-    searchParams.dateRange = [
-      since ? dayjs(since).toDate() : '',
-      until ? dayjs(until).toDate() : '',
-    ] as any
-  } else {
-    searchParams.dateRange = ''
-  }
-
-  // Pagination
-  pagination.page = Number(q.page || 1)
-  pagination.pageSize = Number(q.pageSize || pagination.pageSize)
-}
-
 watch(
   // Refresh list data immediately when workspace dropdown changes
   () => store.currentWorkspaceId,
   (id) => {
     if (id) {
-      applyQueryToParams()
-      if (!searchParams.userId && searchParams.onlyMyself === 'My Workloads') {
-        searchParams.userId = userStore.userId
-      }
+      readQuery()
       onSearch({ resetPage: false })
     }
   },

--- a/Web/apps/safe/src/pages/WorkloadManage/index.vue
+++ b/Web/apps/safe/src/pages/WorkloadManage/index.vue
@@ -464,8 +464,6 @@ const readQuery = () => {
   searchParams.workspaceId = (q.workspaceId as string) || ''
   searchParams.kind = (q.kind as string) || ''
   searchParams.workloadId = (q.workloadId as string) || ''
-  searchParams.userId = (q.userId as string) || ''
-  searchParams.userName = (q.userName as string) || ''
   const phaseStr = (q.phase as string) || ''
   searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
   const since = q.since as string | undefined
@@ -486,8 +484,6 @@ const writeQuery = () => {
   if (searchParams.workspaceId) query.workspaceId = searchParams.workspaceId
   if (searchParams.kind) query.kind = searchParams.kind
   if (searchParams.workloadId) query.workloadId = searchParams.workloadId
-  if (searchParams.userId) query.userId = searchParams.userId
-  if (searchParams.userName) query.userName = searchParams.userName
   if (searchParams.phase?.length) query.phase = searchParams.phase.join(',')
   if (start) query.since = dayjs(start).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]')
   if (end) query.until = dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]')

--- a/Web/apps/safe/src/pages/WorkloadManage/index.vue
+++ b/Web/apps/safe/src/pages/WorkloadManage/index.vue
@@ -464,6 +464,10 @@ const readQuery = () => {
   searchParams.workspaceId = (q.workspaceId as string) || ''
   searchParams.kind = (q.kind as string) || ''
   searchParams.workloadId = (q.workloadId as string) || ''
+  // userName lands the "View all" (scoped-to-me) entry from the homepage in the
+  // visible User filter; userId keeps an explicit owner filter across navigation.
+  searchParams.userId = (q.userId as string) || ''
+  searchParams.userName = (q.userName as string) || ''
   const phaseStr = (q.phase as string) || ''
   searchParams.phase = phaseStr ? (phaseStr.split(',') as WorkloadPhase[]) : []
   const since = q.since as string | undefined
@@ -484,6 +488,8 @@ const writeQuery = () => {
   if (searchParams.workspaceId) query.workspaceId = searchParams.workspaceId
   if (searchParams.kind) query.kind = searchParams.kind
   if (searchParams.workloadId) query.workloadId = searchParams.workloadId
+  if (searchParams.userId) query.userId = searchParams.userId
+  if (searchParams.userName) query.userName = searchParams.userName
   if (searchParams.phase?.length) query.phase = searchParams.phase.join(',')
   if (start) query.since = dayjs(start).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]')
   if (end) query.until = dayjs(end).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]')


### PR DESCRIPTION
﻿## Why

The complete, considered URL-query solution (composable `useWorkloadListQuery`) authored on `fix/web-issues-report` (e70d49dee / c673a9027 / 04e127397) was **never fully merged to main**. PR #671 landed only a partial/rewritten version: it brought the composable *file* (left orphaned/unused) plus ad-hoc inline `router.replace` on some pages, and missed CICD/Authoring/Dynamo entirely. The #677 style merge only built on that already-partial state.

This PR restores the original composable-based design instead of the inline patchwork.

## Design (from the original composable)

- `userId` is derived from the scope toggle and **never stored in the URL** (removes a redundant param that could drift).
- `writeQuery` builds a **fresh** query (no stale carryover of cleared filters), instead of spreading `...route.query`.
- `onlyMyself` is only written when it differs from the page default (**My Workloads by default**, so "My" adds no param, "All" does).

## Changes

**Composable group (9 pages, now all on `useWorkloadListQuery`):**
Training, Infer, Authoring, CICD, Dynamo, Monarch, RayJob, SandboxWorkload, TorchFT
- cherry-picked e70d49dee for 8 of them (auto-merged cleanly for Dynamo/Monarch/RayJob/SandboxWorkload/TorchFT; resolved trivial watcher conflicts for Authoring/CICD).
- Training/Infer were still on the inline pattern on main; converted them to the composable to match.

**Lightweight group:** only **Deploy** was missing URL sync on main; added `readQuery`/`writeQuery` (type + status + pagination). Evaluation/ModelSquare/PostTrain/Diagnoser/Preflight already have equivalent sync on main (Diagnoser/Preflight already use the newer `:initial-range` date restore), so they are untouched. `DateRangeFilter.vue` (04e127397) is already in main.

## Behavioral note
- **WorkloadManage**: the abandoned design does not persist `userName`/`userId` in the URL (main/style had added `userName`). Following the original design, this PR drops that URL persistence for WorkloadManage. Flag if you want to keep it.

## Test plan
- vue-tsc passes; vitest 115/115 pass (verified locally).
- [ ] On each workload list page: applying a filter updates the URL; back-from-detail restores filters + page.
- [ ] "My Workloads" (default) adds no `onlyMyself`/`userId` params; switching to "All" reflects in the URL.

