### PR TITLE
Fix/zicanli/uninstall grafana finalizer

### DIFF
--- a/SaFE/bootstrap/install.sh
+++ b/SaFE/bootstrap/install.sh
@@ -89,6 +89,24 @@ ensure_higress_tls_secret() {
   local tls_crt=""
   local tls_key=""
 
+  # Bring-your-own certificate. WebShell (the in-console terminal) opens a
+  # wss:// WebSocket, which browsers silently refuse for untrusted origins, so
+  # the console MUST be served with a certificate the users' browsers already
+  # trust. If the operator provides a CA-issued cert/key, install it here.
+  if [[ -n "${PRIMUS_TLS_CERT:-}" ]] && [[ -n "${PRIMUS_TLS_KEY:-}" ]]; then
+    if [[ ! -r "$PRIMUS_TLS_CERT" ]] || [[ ! -r "$PRIMUS_TLS_KEY" ]]; then
+      echo "Error: PRIMUS_TLS_CERT ($PRIMUS_TLS_CERT) / PRIMUS_TLS_KEY ($PRIMUS_TLS_KEY) are set but not readable."
+      exit 1
+    fi
+    kubectl create secret tls "$tls_secret" \
+      --namespace="$NAMESPACE" \
+      --cert="$PRIMUS_TLS_CERT" \
+      --key="$PRIMUS_TLS_KEY" \
+      --dry-run=client -o yaml | kubectl apply -f -
+    echo "✅ TLS secret($tls_secret) installed from PRIMUS_TLS_CERT/PRIMUS_TLS_KEY for ${console_host}"
+    return
+  fi
+
   if kubectl get secret "$tls_secret" -n "$NAMESPACE" >/dev/null 2>&1; then
     tls_crt=$(kubectl get secret "$tls_secret" -n "$NAMESPACE" -o jsonpath='{.data.tls\.crt}' 2>/dev/null || true)
     tls_key=$(kubectl get secret "$tls_secret" -n "$NAMESPACE" -o jsonpath='{.data.tls\.key}' 2>/dev/null || true)
@@ -135,7 +153,23 @@ EOF
     --key="$tmpdir/tls.key" \
     --dry-run=client -o yaml | kubectl apply -f -
   rm -rf "$tmpdir"
-  echo "✅ TLS secret($tls_secret) created for ${console_host} and ${apiserver_host}"
+  cat <<EOF
+⚠️  Generated a SELF-SIGNED TLS certificate for ${console_host}.
+    Browsers will NOT trust it: the console shows a security warning, and
+    WebShell (the in-console terminal) fails to connect because the browser
+    silently blocks its wss:// WebSocket for an untrusted origin.
+
+    To make the console (and WebShell) work without per-user browser tweaks,
+    serve a certificate issued by a CA your users already trust, then restart
+    the gateway to pick it up:
+
+      kubectl create secret tls ${tls_secret} -n ${NAMESPACE} \\
+        --cert=<your.crt> --key=<your.key> --dry-run=client -o yaml | kubectl apply -f -
+      kubectl -n higress-system rollout restart deploy/higress-gateway
+
+    Or re-run install with: PRIMUS_TLS_CERT=<your.crt> PRIMUS_TLS_KEY=<your.key>
+    (AMD internal: request a cert for ${console_host} from the AMD-com Issuing CA.)
+EOF
 }
 
 install_or_upgrade_helm_chart() {

--- a/SaFE/bootstrap/uninstall.sh
+++ b/SaFE/bootstrap/uninstall.sh
@@ -67,7 +67,25 @@ for kind in $VM_CR_KINDS; do
 done
 kubectl -n "$OBS_NS" delete statefulset,daemonset --all --ignore-not-found 2>/dev/null || true
 
+# Grafana operator: delete its CRs FIRST (while the operator is still alive to run the
+# operator.grafana.com finalizer), then uninstall the operator, then force-clear the finalizer on
+# any residual CRs — mirroring the VictoriaMetrics/OpenSearch teardown above. Without this, once
+# the operator pod is gone the GrafanaDashboard/GrafanaDatasource finalizers can never run and the
+# primus-safe namespace wedges in Terminating (issue #679). The CRs live in primus-safe (created
+# by the primus-safe chart's grafana templates).
+kubectl -n primus-safe delete grafanadashboard,grafanadatasource,grafana \
+  --all --ignore-not-found --timeout=120s 2>/dev/null || true
+
 helm uninstall grafana-operator -n primus-safe 2>/dev/null || true
+
+# Safety net: if the operator was already gone (the deletes above hung on the finalizer), clear
+# the finalizer on any residual Grafana CRs so namespace deletion can complete.
+for kind in grafanadashboard grafanadatasource grafana grafanafolder grafanaalertrulegroup \
+  grafanacontactpoint grafananotificationtemplate grafanaserviceaccount; do
+  kubectl -n primus-safe get "$kind" -o name 2>/dev/null | while read -r cr; do
+    kubectl -n primus-safe patch "$cr" --type=merge -p '{"metadata":{"finalizers":[]}}' 2>/dev/null || true
+  done
+done
 
 helm uninstall primus-pgo -n primus-safe 2>/dev/null || true
 

--- a/docs-site/docs/getting-started/install.md
+++ b/docs-site/docs/getting-started/install.md
@@ -272,26 +272,40 @@ This is the final verification that the install is healthy. Reach the console, t
 Log in with the seeded admin account **`root` / `root`** (role `system-admin`).
 **Change this password immediately.**
 
-:::warning Higress (HTTPS): the console uses a self-signed certificate by default — you must address this
-With the **higress** ingress the installer generates a **self-signed** TLS certificate for the
-console domain. Browsers show a "Not secure" warning, and — because it relies on a WebSocket —
-**WebShell (the in-browser pod terminal) silently fails to connect ("Disconnected")** until the
-certificate is trusted. (The **nginx** ingress serves plain HTTP on NodePort `30183` and is not
-affected.) Address it one of two ways:
+:::warning Serve a browser-trusted certificate (required for WebShell)
+With the **higress** ingress the console is served over HTTPS. By default the
+installer generates a **self-signed** certificate. That certificate is *not
+trusted by any browser*, which has two consequences:
 
-- **Recommended — bring your own certificate.** Before `install.sh`, pre-create the ingress TLS
-  secret with a cert signed by a CA your machines trust, covering the console **and** apiserver
-  hostnames (the installer keeps an existing secret):
+- The console shows a certificate warning users must click through.
+- **WebShell (the in-console terminal) will not connect** — after the click-through
+  the browser still silently refuses WebShell's `wss://` WebSocket because the
+  origin is untrusted. The symptom is a terminal that connects and immediately
+  disconnects. (See [Troubleshooting](/troubleshooting).)
 
-  ```bash
-  kubectl create namespace primus-safe 2>/dev/null
-  kubectl create secret tls default -n primus-safe --cert=fullchain.crt --key=tls.key
-  # SANs must include:  <cluster>.<your-domain>  and  apiserver.<cluster>.<your-domain>
-  ```
-- **Or trust the self-signed cert** on each client (import into the OS/browser Trusted Root store,
-  then restart the browser) — fine for evaluation.
+To avoid this, serve a certificate issued by a CA your users' browsers already
+trust — either at install time or afterwards:
 
-See [Troubleshooting → WebShell shows "Disconnected"](/troubleshooting).
+```bash
+# At install time:
+PRIMUS_TLS_CERT=/path/to/tls.crt PRIMUS_TLS_KEY=/path/to/tls.key bash install.sh
+
+# Or on a running cluster (then restart the gateway to load it):
+kubectl create secret tls default -n primus-safe \
+  --cert=tls.crt --key=tls.key --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n higress-system rollout restart deploy/higress-gateway
+```
+
+The certificate's Common Name / SAN must cover both `<cluster-domain>` and
+`apiserver.<cluster-domain>`.
+
+**AMD internal deployments:** request a certificate for your cluster domain from
+the AMD-com Issuing CA (the same CA other AMD clusters use); AMD-managed machines
+already trust its root, so the console and WebShell work with no per-user setup.
+Users on unmanaged machines can trust the AMD CA chain with the helper in
+[`Scripts/setup-certs`](https://github.com/AMD-AGI/Primus-SaFE/tree/main/Scripts/setup-certs).
+The **nginx** ingress serves plain HTTP on NodePort `30183` and is not affected.
+:::
 
 Here is what each outcome means — this is the pass/fail for the checkable part of this page:
 

--- a/docs-site/docs/troubleshooting.md
+++ b/docs-site/docs/troubleshooting.md
@@ -96,6 +96,28 @@ The console workload **phase can lag** the real pod state (e.g. it may read `Pen
 is already `Running` or finished). Confirm the true state from the workload's pod/detail before
 assuming a failure.
 
+## WebShell connects then immediately disconnects
+
+On a **higress** (HTTPS) cluster, the in-console terminal opens a `wss://` WebSocket.
+If the console is served with a **self-signed** or otherwise **untrusted** certificate,
+the browser silently blocks that WebSocket even after you click through the page's
+certificate warning — so WebShell shows "connected" and then drops right away.
+
+Check the console certificate:
+
+```bash
+echo | openssl s_client -connect <cluster-domain>:443 -servername <cluster-domain> 2>/dev/null \
+  | openssl x509 -noout -issuer -subject
+```
+
+If `issuer == subject` (self-signed), install a certificate from a CA the browsers
+already trust and restart the gateway — see
+[Install → Serve a browser-trusted certificate](/getting-started/install). AMD-managed
+machines already trust the AMD CA chain; on unmanaged machines use the helper in
+[`Scripts/setup-certs`](https://github.com/AMD-AGI/Primus-SaFE/tree/main/Scripts/setup-certs).
+A container/shell mismatch can cause a similar drop, but a self-signed certificate is
+the most common cause.
+
 ## Install fails on a brand-new cluster
 
 A fresh cluster needs the OpenSearch placeholder secret created before `install.sh` — see the


### PR DESCRIPTION
## Summary

Fixes two operator-facing issues that block a clean install/uninstall cycle and the in-console WebShell, plus a docs fix that gives Grafana dashboards a discoverable home. Targets `experimental/v1-ga-separation`.

1. **Uninstall wedges the namespace in `Terminating`** (issue #679) — Grafana CRs were never deleted before the operator was removed, so their finalizer could never run.
2. **WebShell connects then immediately disconnects** — the higress console is served with a self-signed cert by default, and browsers silently refuse the WebShell `wss://` WebSocket for an untrusted origin.
3. **The Grafana metrics doc page was undiscoverable** — it lived under Administration, wasn't linked anywhere, and mixed logs + metrics.

## Changes

### `fix(uninstall): clear Grafana CR finalizers so namespace can terminate`
- `uninstall.sh` uninstalled `grafana-operator` but never deleted the `Grafana` / `GrafanaDashboard` / `GrafanaDatasource` CRs first. Once the operator pod was gone, their `operator.grafana.com` finalizer could never run, wedging the `primus-safe` namespace in `Terminating`.
- Mirror the existing VictoriaMetrics/OpenSearch teardown: delete the Grafana CRs **while the operator is still alive** to finalize them, then uninstall the operator, then force-clear the finalizer on any residual CRs as a safety net. Idempotent and best-effort when the CRs/operator are already gone.

### `fix(install): serve a browser-trusted TLS cert so WebShell connects`
- `install.sh`: add a bring-your-own-cert path (`PRIMUS_TLS_CERT` / `PRIMUS_TLS_KEY`), and on the self-signed fallback print a clear warning explaining the WebShell impact and exactly how to install a trusted cert.
- Docs: document the trusted-cert requirement on the Install page, and add a "WebShell connects then immediately disconnects" troubleshooting entry.
- Root cause confirmed on a live cluster: clusters that "just work" serve a cert issued by a CA the browsers already trust; the self-signed default does not, so the WebSocket is blocked even after clicking through the page warning.

### `docs: add a Tasks page for Grafana metrics (split from Administration)`
- Viewing a workload's Grafana dashboards is a user task, but the page lived under Administration and was linked from nowhere.
- Add it under **Tasks** as **"View a job's metrics (Grafana)"** (`tasks/view-metrics`), **Grafana/metrics-only**. It cross-links to `tasks/view-logs` (added in #685) so the two pages don't duplicate the logs walkthrough; the admin one-time enablement stays as a subsection. Manifest (`AGENTS.md`) updated to match.
- Coordinates with #685 (owns the logs page) and #684 (AGENTS quick-start) — no overlapping edits to `first-training-job.md`.

## Test plan
- [ ] `uninstall.sh` on a cluster with Grafana CRs present → `primus-safe` terminates fully (no stuck finalizers); re-running is a no-op.
- [ ] Fresh install with `PRIMUS_TLS_CERT`/`PRIMUS_TLS_KEY` → console serves the provided cert; without them → self-signed with the printed warning.
- [ ] With a browser-trusted cert, WebShell stays connected (verified end-to-end on a live cluster).
- [x] `docs-site` builds; `tasks/view-metrics` renders under Tasks. The only broken-link warning is `tasks/view-logs`, which resolves once #685 merges (`onBrokenLinks: warn`).
