### PR TITLE
Add agent skill for automated Primus-SaFE cluster bootstrap

### DIFF
--- a/.cursor/skills/bootstrap-primus-safe-cluster/SKILL.md
+++ b/.cursor/skills/bootstrap-primus-safe-cluster/SKILL.md
@@ -29,6 +29,12 @@ skill executes it non-interactively. The one fragile part -- SaFE's interactive
 - **Never guess a required value.** If a required field is missing (nodes, a required
   password, `cluster_name` when `ingress: higress`), STOP and report BLOCKED naming
   exactly what is absent. A missing prerequisite is BLOCKED, not a failure to paper over.
+- **Check before you run; re-run to resume.** Never assume a fresh cluster. Every step's
+  verification is also its *precondition*: run the check first, and if it already passes,
+  mark the step done and skip it. If it partially passes or a previous run failed midway,
+  re-run that step's script -- **every script here is idempotent and safe to re-run**
+  (see the detection table and idempotency notes in [reference.md](reference.md)). Do not
+  tear things down to "start clean" unless the user asks.
 - **Pause and verify after every long step** (Bootstrap ~20-40 min, install.sh). Run the
   step's verification (see [reference.md](reference.md)) and confirm it passes before
   continuing. Do not chain past a failed check.
@@ -38,6 +44,8 @@ skill executes it non-interactively. The one fragile part -- SaFE's interactive
 
 ## Workflow
 
+Each step is **detect -> (skip if already satisfied) -> run -> verify**. Run the step's
+verification check *first*; only run its script if the check fails or partially passes.
 Copy this checklist and track it:
 
 ```
@@ -51,6 +59,26 @@ Copy this checklist and track it:
 - [ ] 7. install.sh via piped answers                     (verify pods Running)
 - [ ] 8. Access the console                               (root / root)
 ```
+
+### Resuming a partial install
+
+This skill is re-runnable end to end. Before starting at step 0, **probe current state and
+jump to the first incomplete step** rather than blindly re-running everything. Quick sweep:
+
+```bash
+kubectl get nodes 2>/dev/null                              # step 2 done if all Ready
+kubectl get storageclass 2>/dev/null                       # step 3 done if a (default) exists
+kubectl get pods -n higress-system 2>/dev/null             # step 4 (if gateway.higress)
+kubectl get pods -n harbor 2>/dev/null                     # step 5 (if registry.harbor)
+kubectl get secret primus-safe-opensearch-config -n primus-safe 2>/dev/null   # step 6
+helm list -n primus-safe 2>/dev/null                       # step 7 releases present?
+kubectl get pods -n primus-safe 2>/dev/null                # step 7 pods Running?
+```
+
+If `kubectl` cannot reach a cluster at all, start at step 1. If the cluster and storage are
+up but `primus-safe` pods are missing or unhealthy, resume at step 6/7. When in doubt, re-run
+the step's script -- all are idempotent (see [reference.md](reference.md), "Idempotency &
+resuming a partial install"). Report which steps were skipped as already-satisfied.
 
 ### 0. Preconditions
 
@@ -155,7 +183,20 @@ kubectl create secret generic primus-safe-opensearch-config -n primus-safe \
   --from-literal=endpoint=primus-robust-logs.primus-robust.svc.cluster.local:9200
 ```
 
-### 7. Run install.sh non-interactively
+### 7. Install the Primus-SaFE application
+
+`install.sh` is the application installer (everything above only prepared the cluster). It
+is **not** a single black box -- it deploys a stack in order, each as its own Helm release
+in the `primus-safe` namespace (plus a separate observability namespace):
+
+1. Secrets: `primus-safe-image`, `-s3`, `-sso`, `-opensearch-config` (+ higress TLS `default`).
+2. `grafana-operator`.
+3. `primus-pgo` -- the Postgres operator (the script waits for it to be `Running`).
+4. `primus-safe` -- the admin plane: apiserver, job-manager, resource-manager, webhooks, controllers.
+5. `primus-safe-cr` -- the custom resources that drive the platform.
+6. `node-agent` -- the data plane, **only if** `safe.install_node_agent: true`.
+7. `primus-safe-observability` (its own namespace) -- **only if** `safe.install_obs_logs`
+   or `safe.install_obs_metrics` is true.
 
 Build the ordered answer stream from the config (default path is 14 lines; conditional
 blocks insert extra lines) and pipe it. The exact prompt->field mapping, conditional
@@ -167,10 +208,32 @@ cd Primus-SaFE/SaFE/bootstrap
 printf '%s\n' <ordered answers per reference.md> | bash install.sh
 ```
 
-Verify: `kubectl get pods -n primus-safe` -- apiserver, controllers, webhooks, and db
-operator all `Running`. If pods stay `Pending`/`CrashLoopBackOff`, it usually points to
-storage (no bound PVC -> recheck step 3) or the OpenSearch secret (step 6); fix and
-re-run (`install.sh` is idempotent).
+**Idempotent / resumable.** `install.sh` runs with `set -euo pipefail` but every action is
+safe to repeat: it uses `helm upgrade --install`, auto-cleans any Helm release stuck in a
+`failed`/`pending-install` state before reinstalling, `kubectl apply`s all secrets, and
+*keeps* an existing OpenSearch or higress TLS secret. So on a partial or failed app install,
+the supported fix is simply to **re-run `install.sh` with the same piped answers** -- it
+finishes whatever is missing and upgrades the rest in place. Do not uninstall first.
+
+Verify (all should hold):
+
+```bash
+helm list -n primus-safe          # grafana-operator, primus-pgo, primus-safe, primus-safe-cr
+                                  # (+ node-agent if enabled) all STATUS=deployed
+kubectl get pods -n primus-safe   # apiserver, job-manager, resource-manager, webhooks,
+                                  # controllers, primus-pgo + its db pod all Running
+# only when logs/metrics were enabled:
+kubectl get pods -n primus-safe-observability
+```
+
+If pods stay `Pending`/`CrashLoopBackOff`, it usually points to storage (no bound PVC ->
+recheck step 3) or the OpenSearch secret (step 6); fix that, then re-run `install.sh`.
+
+**`install.sh` vs `upgrade.sh`:** use `install.sh` for a first install *and* to resume/repair
+a partial one -- it prompts (piped) and rebuilds every release. `upgrade.sh` is only for a
+later config-preserving upgrade: it reuses `SaFE/bootstrap/.env` (written by `install.sh`),
+prompts for nothing, and expects `cd_require_approval` to already be in `.env` (install does
+not write it). Do not use `upgrade.sh` to resume a broken first install.
 
 ### 8. Access the console
 

--- a/.cursor/skills/bootstrap-primus-safe-cluster/SKILL.md
+++ b/.cursor/skills/bootstrap-primus-safe-cluster/SKILL.md
@@ -67,7 +67,7 @@ jump to the first incomplete step** rather than blindly re-running everything. Q
 
 ```bash
 kubectl get nodes 2>/dev/null                              # step 2 done if all Ready
-kubectl get storageclass 2>/dev/null                       # step 3 done if a (default) exists
+kubectl get storageclass 2>/dev/null                       # step 3 candidate; NOT done until the bind smoke-test passes
 kubectl get pods -n higress-system 2>/dev/null             # step 4 (if gateway.higress)
 kubectl get pods -n harbor 2>/dev/null                     # step 5 (if registry.harbor)
 kubectl get secret primus-safe-opensearch-config -n primus-safe 2>/dev/null   # step 6
@@ -123,11 +123,18 @@ cd Primus-SaFE/Bootstrap
 bash bootstrap.sh
 ```
 
-~20-40 min. Then **pause** and verify: `kubectl get nodes -o wide` (all `Ready`) and
-`helm list -A` (cert-manager, amd-gpu-operator, network-operator, scheduler-plugins). If
-any node is `NotReady` or the script errored, stop and surface the Kubespray/Ansible
-error (usually SSH reachability or an inventory mistake) -- `bootstrap.sh` has no
-`set -e`, so trust the checks, not the exit code.
+~20-40 min. Then **pause** and verify: `kubectl get nodes -o wide` (every node `Ready`)
+and `helm list -A` (cert-manager, amd-gpu-operator, network-operator, scheduler-plugins).
+Also confirm the add-on pods are actually `READY n/n`, not merely present:
+
+```bash
+kubectl get pods -A | grep -Ev 'Running|Completed' && echo "^ investigate before continuing"
+```
+
+If any node is `NotReady`, an add-on pod is stuck (`Pending` / `CrashLoopBackOff` /
+`ImagePullBackOff`), or the script errored, stop and surface the Kubespray/Ansible error
+(usually SSH reachability or an inventory mistake) -- `bootstrap.sh` has no `set -e`, so
+trust the checks, not the exit code.
 
 ### 3. Storage
 
@@ -146,8 +153,43 @@ cd Primus-SaFE/Bootstrap/storage/ceph
 bash ceph.sh          # the resulting default StorageClass is named `rbd`
 ```
 
-Verify: `kubectl get storageclass` shows a `(default)` class. Its name must match
-`safe.storage_class`.
+For Ceph, a StorageClass can exist while the backing cluster is dead (a very common
+failure: nodes with only an OS disk and no spare **raw** devices produce an `rbd` class
+that never binds). Before trusting it, confirm the cluster is actually healthy:
+
+```bash
+kubectl get pods -n rook-ceph | grep 'rook-ceph-osd-'   # at least one osd pod, Running
+kubectl get cephblockpool -A                            # PHASE must be Ready (not Failure)
+```
+
+If there are no OSD pods or the `CephBlockPool` is `Failure`, STOP and report BLOCKED
+(the nodes likely lack spare raw disks) -- do not proceed on a dead class.
+
+**Verify (functional smoke-test, not just presence).** A `(default)` class that exists but
+cannot provision satisfies a naive presence check yet stalls `install.sh` later. Prove the
+class actually binds a volume, then clean up:
+
+```bash
+kubectl apply -f - <<'EOF'
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: safe-smoke-test
+  namespace: default
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 1Mi
+  storageClassName: <safe.storage_class>   # omit to use the (default) class
+EOF
+kubectl wait --for=jsonpath='{.status.phase}'=Bound pvc/safe-smoke-test --timeout=60s
+kubectl delete pvc safe-smoke-test
+```
+
+Pass only if the PVC reaches `Bound`. If it stays `Pending`, STOP and report BLOCKED,
+quoting `kubectl describe pvc safe-smoke-test -n default` (the provisioner events say why).
+Also confirm the class name matches `safe.storage_class`.
 
 ### 4. Higress gateway (only if `gateway.higress: true`)
 
@@ -156,7 +198,9 @@ cd Primus-SaFE/Bootstrap/higress
 bash higress.sh
 ```
 
-Verify pods in `higress-system`. Required when `safe.ingress: higress`.
+Verify pods in `higress-system` are `READY n/n` (not just present):
+`kubectl get pods -n higress-system | grep -Ev 'Running|Completed'` should print nothing.
+Required when `safe.ingress: higress`.
 
 ### 5. Harbor registry (only if `registry.harbor.enabled: true`)
 
@@ -170,7 +214,9 @@ cd Primus-SaFE/Bootstrap/harbor
 bash harbor.sh '<admin_password>' '<domain>' '<storage_class>' '<ssh_key>'
 ```
 
-Always pass the password as arg 1 so it never prompts. Verify pods in `harbor`.
+Always pass the password as arg 1 so it never prompts. Verify pods in `harbor` are
+`READY n/n`: `kubectl get pods -n harbor | grep -Ev 'Running|Completed'` should print nothing
+(watch for `ImagePullBackOff` on the Harbor images).
 
 ### 6. Pre-create the OpenSearch secret
 
@@ -215,18 +261,27 @@ safe to repeat: it uses `helm upgrade --install`, auto-cleans any Helm release s
 the supported fix is simply to **re-run `install.sh` with the same piped answers** -- it
 finishes whatever is missing and upgrades the rest in place. Do not uninstall first.
 
-Verify (all should hold):
+Verify (all should hold). A release can be `deployed` and a pod can exist while never
+becoming **Ready** -- check `READY n/n`, not just presence:
 
 ```bash
 helm list -n primus-safe          # grafana-operator, primus-pgo, primus-safe, primus-safe-cr
                                   # (+ node-agent if enabled) all STATUS=deployed
-kubectl get pods -n primus-safe   # apiserver, job-manager, resource-manager, webhooks,
-                                  # controllers, primus-pgo + its db pod all Running
+kubectl get pods -n primus-safe   # every pod READY n/n; apiserver, job-manager,
+                                  # resource-manager, webhooks, controllers, primus-pgo + db pod
+# flag anything not healthy (empty output = all good):
+kubectl get pods -n primus-safe | grep -Ev 'Running|Completed' && echo "^ investigate"
+kubectl get pods -n primus-safe --field-selector=status.phase=Running \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.containerStatuses[*].ready}{"\n"}{end}' \
+  | grep -i false && echo "^ Running but NOT Ready (e.g. webhooks CrashLoopBackOff)"
+kubectl get pvc -A | grep -v Bound && echo "^ unbound PVC -> recheck step 3"
 # only when logs/metrics were enabled:
 kubectl get pods -n primus-safe-observability
 ```
 
-If pods stay `Pending`/`CrashLoopBackOff`, it usually points to storage (no bound PVC ->
+Pass bar: all releases `deployed`, every pod `READY n/n`, no `CrashLoopBackOff` /
+`ImagePullBackOff` / `Pending`, and all PVCs `Bound`. If pods stay `Pending` /
+`CrashLoopBackOff` / `ImagePullBackOff`, it usually points to storage (no bound PVC ->
 recheck step 3) or the OpenSearch secret (step 6); fix that, then re-run `install.sh`.
 
 **`install.sh` vs `upgrade.sh`:** use `install.sh` for a first install *and* to resume/repair

--- a/.cursor/skills/bootstrap-primus-safe-cluster/SKILL.md
+++ b/.cursor/skills/bootstrap-primus-safe-cluster/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: bootstrap-primus-safe-cluster
+description: >-
+  Bootstrap an entire Primus-SaFE cluster end to end from a single config file:
+  rewrite the Kubespray inventory, provision Kubernetes, set up storage, optional
+  gateway/registry, and drive SaFE's interactive install.sh non-interactively.
+  Use when the user wants to install, bring up, provision, or bootstrap a new
+  Primus-SaFE cluster, or mentions bootstrap.sh / install.sh / hosts.ini automation.
+disable-model-invocation: true
+---
+
+# Bootstrap a Primus-SaFE cluster
+
+Provision a new Primus-SaFE cluster end to end, driven by one filled-in config file.
+The authoritative human runbook is `docs-site/docs/getting-started/install.md`; this
+skill executes it non-interactively. The one fragile part -- SaFE's interactive
+`install.sh` -- is handled by piping config-derived answers in exact prompt order; see
+[reference.md](reference.md).
+
+## Inputs
+
+- A completed config file based on `cluster-config.example.yaml` (ask the user for its
+  path; do not assume). Treat it as the single source of truth.
+- Run from the **deploy host**: has `kubectl` + `helm`, and **passwordless root SSH to
+  every node**. The repo is cloned at `Primus-SaFE/`.
+
+## Hard rules
+
+- **Never guess a required value.** If a required field is missing (nodes, a required
+  password, `cluster_name` when `ingress: higress`), STOP and report BLOCKED naming
+  exactly what is absent. A missing prerequisite is BLOCKED, not a failure to paper over.
+- **Pause and verify after every long step** (Bootstrap ~20-40 min, install.sh). Run the
+  step's verification (see [reference.md](reference.md)) and confirm it passes before
+  continuing. Do not chain past a failed check.
+- **Destructive edits happen** -- the scripts `sed` `hosts.ini`, `harbor/values.yaml`,
+  and `storage/ceph/storageclass.yaml` in place. Expected; do not "fix" them.
+- This is real infrastructure. Show the user each verification result.
+
+## Workflow
+
+Copy this checklist and track it:
+
+```
+- [ ] 0. Preconditions
+- [ ] 1. Rewrite Bootstrap/hosts.ini from nodes
+- [ ] 2. bootstrap.sh -> Kubernetes + base add-ons        (verify nodes Ready)
+- [ ] 3. Storage (local-path | ceph)                      (verify default SC)
+- [ ] 4. (optional) Higress gateway
+- [ ] 5. (optional) Harbor registry
+- [ ] 6. Pre-create primus-safe-opensearch-config secret
+- [ ] 7. install.sh via piped answers                     (verify pods Running)
+- [ ] 8. Access the console                               (root / root)
+```
+
+### 0. Preconditions
+
+- Read the config file. Confirm `kubectl` and `helm` exist on the deploy host.
+- Confirm SSH reachability to each node (`ssh -i <ssh_key> <user>@<ansible_host> true`).
+- If `safe.ingress: higress`, require `safe.cluster_name` and `gateway.higress: true`.
+- If `registry.harbor.enabled`, require `registry.harbor.admin_password`.
+
+### 1. Rewrite `Bootstrap/hosts.ini`
+
+The checked-in file is a broken placeholder -- overwrite it entirely. Standard Ansible
+inventory; control-plane/etcd nodes (odd count) also listed under `[kube_node]` so they
+run workloads:
+
+```ini
+[all]
+node-01 ansible_host=10.0.0.11 ip=10.0.0.11 ansible_user=root ansible_ssh_private_key_file=~/.ssh/id_ed25519
+# ...one line per node from config...
+
+[kube_control_plane]
+node-01
+
+[etcd]
+node-01
+
+[kube_node]
+node-01
+
+[k8s_cluster:children]
+kube_control_plane
+kube_node
+```
+
+If `network.*` overrides are set in the config, edit the matching top-of-file variables
+in `Bootstrap/bootstrap.sh` (KUBE_VERSION, KUBESPRAY_VERSION, KUBE_NETWORK_PLUGIN,
+KUBE_PODS_SUBNET, KUBE_SERVICE_ADDRESSES, NODE_LOCAL_DNS_IP).
+
+### 2. Provision Kubernetes
+
+```bash
+cd Primus-SaFE/Bootstrap
+bash bootstrap.sh
+```
+
+~20-40 min. Then **pause** and verify: `kubectl get nodes -o wide` (all `Ready`) and
+`helm list -A` (cert-manager, amd-gpu-operator, network-operator, scheduler-plugins). If
+any node is `NotReady` or the script errored, stop and surface the Kubespray/Ansible
+error (usually SSH reachability or an inventory mistake) -- `bootstrap.sh` has no
+`set -e`, so trust the checks, not the exit code.
+
+### 3. Storage
+
+`storage.type: local-path`:
+
+```bash
+cd Primus-SaFE/Bootstrap/storage/local-path
+bash local-path.sh    # answer the directory prompt with storage.local_path_dir
+```
+
+`storage.type: ceph` (edit `storage/ceph/cephcluster.yaml` first if not using all
+nodes/devices):
+
+```bash
+cd Primus-SaFE/Bootstrap/storage/ceph
+bash ceph.sh          # the resulting default StorageClass is named `rbd`
+```
+
+Verify: `kubectl get storageclass` shows a `(default)` class. Its name must match
+`safe.storage_class`.
+
+### 4. Higress gateway (only if `gateway.higress: true`)
+
+```bash
+cd Primus-SaFE/Bootstrap/higress
+bash higress.sh
+```
+
+Verify pods in `higress-system`. Required when `safe.ingress: higress`.
+
+### 5. Harbor registry (only if `registry.harbor.enabled: true`)
+
+First generate `Primus-SaFE/Bootstrap/harbor/hosts.yaml` (gitignored) -- an Ansible
+inventory with an `[all]` group listing every node with `ansible_host` +
+`ansible_ssh_user` + key, so Harbor can push its CA to each node. Then:
+
+```bash
+cd Primus-SaFE/Bootstrap/harbor
+# args: <admin_password> <domain> <storage_class> <ssh_key>   (README order is wrong)
+bash harbor.sh '<admin_password>' '<domain>' '<storage_class>' '<ssh_key>'
+```
+
+Always pass the password as arg 1 so it never prompts. Verify pods in `harbor`.
+
+### 6. Pre-create the OpenSearch secret
+
+On a fresh cluster `install.sh`'s pre-install hook expects this to exist:
+
+```bash
+kubectl create namespace primus-safe 2>/dev/null
+kubectl create secret generic primus-safe-opensearch-config -n primus-safe \
+  --from-literal=username=admin --from-literal=password=admin \
+  --from-literal=endpoint=primus-robust-logs.primus-robust.svc.cluster.local:9200
+```
+
+### 7. Run install.sh non-interactively
+
+Build the ordered answer stream from the config (default path is 14 lines; conditional
+blocks insert extra lines) and pipe it. The exact prompt->field mapping, conditional
+insertions, and all-or-nothing behavior are in [reference.md](reference.md) -- read it
+before assembling the stream, and recount the lines against the table.
+
+```bash
+cd Primus-SaFE/SaFE/bootstrap
+printf '%s\n' <ordered answers per reference.md> | bash install.sh
+```
+
+Verify: `kubectl get pods -n primus-safe` -- apiserver, controllers, webhooks, and db
+operator all `Running`. If pods stay `Pending`/`CrashLoopBackOff`, it usually points to
+storage (no bound PVC -> recheck step 3) or the OpenSearch secret (step 6); fix and
+re-run (`install.sh` is idempotent).
+
+### 8. Access the console
+
+- `nginx`: `http://<any-node-ip>:30183`
+- `higress`: `https://<cluster_name>.<your-domain>`
+
+Seeded admin is **`root` / `root`** -- tell the user to change it immediately. With
+`higress` the TLS cert is self-signed (WebShell fails until trusted); note it.
+
+## Report
+
+End with a short status table: each step -> PASS / FAIL / BLOCKED / SKIPPED, plus the
+console URL and the change-the-root-password reminder. On FAIL/BLOCKED, quote the error.

--- a/.cursor/skills/bootstrap-primus-safe-cluster/cluster-config.example.yaml
+++ b/.cursor/skills/bootstrap-primus-safe-cluster/cluster-config.example.yaml
@@ -91,6 +91,9 @@ safe:
                                    #  auto-detect at harbor.<cluster_name>.primus-safe.amd.com)
   ethernet_nic: ens51f0            # NCCL_SOCKET_IFNAME; find with: ip -br link
   rdma_nic: bnxt_re0,bnxt_re1,bnxt_re2,bnxt_re3,bnxt_re4,bnxt_re5,bnxt_re6,bnxt_re7  # NCCL_IB_HCA; rdma link
+                                   # NOTE: "" here does NOT blank it -- empty input keeps the
+                                   # rdma0..7 default (see reference.md). Set real devices, or
+                                   # accept it's cosmetic on a no-RDMA/single-node cluster.
   cluster_scale: small             # small | medium | large
   storage_class: local-path        # must match a class that exists (from storage above)
   ingress: higress                 # nginx (NodePort 30183) | higress (domain; needs gateway.higress)

--- a/.cursor/skills/bootstrap-primus-safe-cluster/cluster-config.example.yaml
+++ b/.cursor/skills/bootstrap-primus-safe-cluster/cluster-config.example.yaml
@@ -7,6 +7,12 @@
 # Every field maps 1:1 to a script variable or an install.sh prompt. Anything
 # left blank uses the noted default. The agent must NOT guess values that are
 # required but missing -- it stops and reports what is absent instead.
+#
+# REUSABLE FOR RE-RUNS: this filled-in config is the single source of truth for
+# the whole bring-up. Because every bootstrap/install script is idempotent, you
+# can safely point the skill at the SAME config again to resume or repair a
+# partial installation -- it detects what already exists, skips finished steps,
+# and re-runs the rest (see the skill's "Resuming a partial install" section).
 # =============================================================================
 
 # -----------------------------------------------------------------------------

--- a/.cursor/skills/bootstrap-primus-safe-cluster/cluster-config.example.yaml
+++ b/.cursor/skills/bootstrap-primus-safe-cluster/cluster-config.example.yaml
@@ -1,0 +1,116 @@
+# =============================================================================
+# Primus-SaFE automated cluster bootstrap config
+# =============================================================================
+# Fill this in once, then point the "bootstrap-primus-safe-cluster" skill at it.
+# Copy it to a working file first (e.g. cluster-config.yaml) and edit that.
+#
+# Every field maps 1:1 to a script variable or an install.sh prompt. Anything
+# left blank uses the noted default. The agent must NOT guess values that are
+# required but missing -- it stops and reports what is absent instead.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# nodes -- control-plane / etcd machines only (add GPU workers via the console)
+# -----------------------------------------------------------------------------
+# Use an ODD number (1 or 3) so etcd has a quorum. These drive:
+#   - Bootstrap/hosts.ini            (Kubespray inventory, fully rewritten)
+#   - Bootstrap/harbor/hosts.yaml    (only if harbor.enabled: true)
+# WARNING: Kubespray renames each node's hostname to `name` below -- keep names
+# stable and correct up front (downstream identity/IAM depends on them).
+nodes:
+  - name: node-01
+    ansible_host: 10.0.0.11        # address installer + other nodes use (private net)
+    ip: 10.0.0.11                  # usually same as ansible_host
+    ansible_user: root             # SSH user; needs passwordless sudo/root
+    ssh_key: ~/.ssh/id_ed25519     # private key on the deploy host to reach this node
+  # - name: node-02
+  #   ansible_host: 10.0.0.12
+  #   ip: 10.0.0.12
+  #   ansible_user: root
+  #   ssh_key: ~/.ssh/id_ed25519
+  # - name: node-03
+  #   ansible_host: 10.0.0.13
+  #   ip: 10.0.0.13
+  #   ansible_user: root
+  #   ssh_key: ~/.ssh/id_ed25519
+
+# -----------------------------------------------------------------------------
+# network -- optional overrides for Bootstrap/bootstrap.sh (top-of-file vars)
+# -----------------------------------------------------------------------------
+# Leave commented to keep the script defaults shown here.
+network:
+  # kube_version: 1.32.5
+  # kubespray_version: v2.28.0
+  # network_plugin: flannel               # CNI
+  # pods_subnet: 172.16.0.0/12            # KUBE_PODS_SUBNET
+  # service_addresses: 192.168.0.0/16     # KUBE_SERVICE_ADDRESSES
+  # node_local_dns_ip: 169.254.25.10
+
+# -----------------------------------------------------------------------------
+# storage -- a default StorageClass is REQUIRED before install.sh
+# -----------------------------------------------------------------------------
+storage:
+  type: local-path                 # local-path | ceph
+  local_path_dir: /data            # host dir for local-path (local-path.sh prompt)
+  # ceph has no extra config here; edit Bootstrap/storage/ceph/cephcluster.yaml
+  # first if you are NOT using all nodes / all devices.
+
+# -----------------------------------------------------------------------------
+# gateway + registry -- optional (skip both for a quick start)
+# -----------------------------------------------------------------------------
+gateway:
+  higress: false                   # true installs Bootstrap/higress/higress.sh
+                                   # (required if safe.ingress: higress below)
+
+registry:
+  harbor:
+    enabled: false                 # true installs Bootstrap/harbor/harbor.sh
+    admin_password: ""             # REQUIRED if enabled (passed as arg 1, no prompt)
+    domain: harbor.example.com     # arg 2; e.g. harbor.<your-domain>
+    # storage_class defaults to `rbd` for ceph; set to your class for local-path.
+    storage_class: rbd             # arg 3  (NOTE: README arg order is wrong; this is arg 3)
+    # ssh_key defaults to the first node's ssh_key; Ansible uses it to push the CA.
+
+# -----------------------------------------------------------------------------
+# safe -- answers fed to SaFE/bootstrap/install.sh (interactive; piped in order)
+# -----------------------------------------------------------------------------
+# See reference.md for the exact prompt order these map to.
+safe:
+  cluster_name: ""                 # REQUIRED only if ingress: higress (becomes subdomain)
+  ethernet_nic: eno0               # NCCL_SOCKET_IFNAME; find with: ip -br link
+  rdma_nic: rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7  # NCCL_IB_HCA; rdma link
+  cluster_scale: small             # small | medium | large
+  storage_class: local-path        # must match a class that exists (from storage above)
+  ingress: nginx                   # nginx (NodePort 30183) | higress (domain; needs gateway.higress)
+  csi_volume_handle: ""            # optional; enables workspace PFS
+  install_node_agent: false        # y/n prompt
+  install_obs_logs: false          # OpenSearch + FluentBit
+  install_obs_metrics: false       # VictoriaMetrics + enricher
+
+  # Optional image pull secret (all-or-nothing; blank -> empty placeholder secret)
+  image_pull_secret:
+    enabled: false
+    registry: ""                   # e.g. registry.example.com
+    username: ""
+    password: ""
+
+  # Optional S3 (all-or-nothing; if any field blank after prompts, S3 is disabled)
+  s3:
+    enabled: false
+    endpoint: ""
+    bucket: ""
+    access_key: ""
+    secret_key: ""
+
+  # Optional SSO / OIDC (all-or-nothing)
+  sso:
+    enabled: false
+    endpoint: ""
+    client_id: ""
+    client_secret: ""
+    redirect_uri: ""
+
+  # Optional OpenSearch creds prompt (blank leaves the pre-created placeholder secret)
+  opensearch:
+    username: ""
+    password: ""

--- a/.cursor/skills/bootstrap-primus-safe-cluster/cluster-config.example.yaml
+++ b/.cursor/skills/bootstrap-primus-safe-cluster/cluster-config.example.yaml
@@ -56,19 +56,23 @@ storage:
   # first if you are NOT using all nodes / all devices.
 
 # -----------------------------------------------------------------------------
-# gateway + registry -- optional (skip both for a quick start)
+# gateway + registry
 # -----------------------------------------------------------------------------
 gateway:
-  higress: false                   # true installs Bootstrap/higress/higress.sh
-                                   # (required if safe.ingress: higress below)
+  higress: true                    # installs Bootstrap/higress/higress.sh
+                                   # (required when safe.ingress: higress below)
 
 registry:
   harbor:
-    enabled: false                 # true installs Bootstrap/harbor/harbor.sh
-    admin_password: ""             # REQUIRED if enabled (passed as arg 1, no prompt)
-    domain: harbor.example.com     # arg 2; e.g. harbor.<your-domain>
-    # storage_class defaults to `rbd` for ceph; set to your class for local-path.
-    storage_class: rbd             # arg 3  (NOTE: README arg order is wrong; this is arg 3)
+    enabled: true                  # installs Bootstrap/harbor/harbor.sh (pull-through cache)
+    admin_password: "CHANGE-ME"    # REQUIRED (passed as arg 1, no prompt) -- set a strong password
+    # IMPORTANT: the domain is NOT free-form. install.sh only auto-detects Harbor at
+    #   harbor.<safe.cluster_name>.primus-safe.amd.com
+    # and rewrites helm_registry/proxy_image_registry to that host + /proxy. Keep this
+    # matching that pattern (i.e. keep <cluster_name> in sync with safe.cluster_name).
+    domain: harbor.tas300.primus-safe.amd.com   # arg 2
+    storage_class: local-path      # arg 3  (README arg order is wrong; this is arg 3)
+                                   # use local-path for local-path storage; `rbd` for ceph.
     # ssh_key defaults to the first node's ssh_key; Ansible uses it to push the CA.
 
 # -----------------------------------------------------------------------------
@@ -76,39 +80,33 @@ registry:
 # -----------------------------------------------------------------------------
 # See reference.md for the exact prompt order these map to.
 safe:
-  cluster_name: ""                 # REQUIRED only if ingress: higress (becomes subdomain)
-  ethernet_nic: eno0               # NCCL_SOCKET_IFNAME; find with: ip -br link
-  rdma_nic: rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7  # NCCL_IB_HCA; rdma link
+  cluster_name: tas300             # REQUIRED with ingress: higress; becomes the subdomain
+                                   # (console at <cluster_name>.<your-domain>, and Harbor
+                                   #  auto-detect at harbor.<cluster_name>.primus-safe.amd.com)
+  ethernet_nic: ens51f0            # NCCL_SOCKET_IFNAME; find with: ip -br link
+  rdma_nic: bnxt_re0,bnxt_re1,bnxt_re2,bnxt_re3,bnxt_re4,bnxt_re5,bnxt_re6,bnxt_re7  # NCCL_IB_HCA; rdma link
   cluster_scale: small             # small | medium | large
   storage_class: local-path        # must match a class that exists (from storage above)
-  ingress: nginx                   # nginx (NodePort 30183) | higress (domain; needs gateway.higress)
+  ingress: higress                 # nginx (NodePort 30183) | higress (domain; needs gateway.higress)
   csi_volume_handle: ""            # optional; enables workspace PFS
-  install_node_agent: false        # y/n prompt
+  install_node_agent: true         # y/n prompt
   install_obs_logs: false          # OpenSearch + FluentBit
   install_obs_metrics: false       # VictoriaMetrics + enricher
 
-  # Optional image pull secret (all-or-nothing; blank -> empty placeholder secret)
+  # Optional image pull secret (all-or-nothing; blank -> empty placeholder secret).
+  # Not needed when Harbor above is used as the pull-through cache.
   image_pull_secret:
     enabled: false
     registry: ""                   # e.g. registry.example.com
     username: ""
     password: ""
 
-  # Optional S3 (all-or-nothing; if any field blank after prompts, S3 is disabled)
+  # S3 and SSO are disabled. Set enabled: true and fill every field to turn one on
+  # (all-or-nothing: any blank field silently disables it -- see reference.md).
   s3:
     enabled: false
-    endpoint: ""
-    bucket: ""
-    access_key: ""
-    secret_key: ""
-
-  # Optional SSO / OIDC (all-or-nothing)
   sso:
     enabled: false
-    endpoint: ""
-    client_id: ""
-    client_secret: ""
-    redirect_uri: ""
 
   # Optional OpenSearch creds prompt (blank leaves the pre-created placeholder secret)
   opensearch:

--- a/.cursor/skills/bootstrap-primus-safe-cluster/reference.md
+++ b/.cursor/skills/bootstrap-primus-safe-cluster/reference.md
@@ -98,6 +98,12 @@ later answer.
    (`rbd`), `$4`=ssh key (`~/.ssh/id_ed25519`). Always pass `$1` to skip its prompt.
 4. **`Bootstrap/harbor/hosts.yaml`** is a separate, gitignored Ansible inventory Harbor
    needs to push its CA to every node. Generate it before running `harbor.sh`.
+4b. **Harbor domain is derived, not free-form.** After the prompts, `install.sh` builds
+   `harbor_host="harbor.${sub_domain}.primus-safe.amd.com"` and, if it finds a Harbor
+   endpoint there, sets `helm_registry` / `proxy_image_registry` to `${harbor_host}/proxy`
+   (pull-through cache). So for auto-detection to work, `registry.harbor.domain` must be
+   `harbor.<safe.cluster_name>.primus-safe.amd.com`. A different Harbor domain still
+   installs Harbor, but install.sh won't wire it up as the proxy cache.
 5. **Ceph SC name mismatch** -- `ceph.sh` does `kubectl delete sc storage-rbd`, but the
    StorageClass it creates is named `rbd` (the secret is `storage-rbd`). The delete is a
    no-op; harmless, but the class to reference downstream is `rbd`.

--- a/.cursor/skills/bootstrap-primus-safe-cluster/reference.md
+++ b/.cursor/skills/bootstrap-primus-safe-cluster/reference.md
@@ -86,6 +86,61 @@ Adjust the middle lines (and insert the conditional blocks) to match the config.
 Verify each line count against the table before running -- an off-by-one shifts every
 later answer.
 
+## `install.sh` internal step map
+
+Once the prompts are answered, `install.sh` runs through numbered internal steps, each
+producing a Helm release (or secrets). Use this to locate a mid-run failure to a component
+and to know what a re-run will reconcile:
+
+| install.sh step | What it does | Helm release / namespace |
+|---|---|---|
+| 1 Input Parameters | reads the piped answers; auto-detects Harbor proxy if `sub_domain` set | (none) |
+| 2 Secrets | creates/applies `primus-safe-image`, `-s3`, `-sso`, `-opensearch-config`, higress TLS `default` | secrets in `primus-safe` |
+| 3 grafana-operator | installs the Grafana operator | `grafana-operator` |
+| 4 admin plane | installs `primus-pgo` (Postgres operator, then waits for it Running), then the admin plane (apiserver, job-manager, resource-manager, webhooks, controllers) | `primus-pgo`, `primus-safe` |
+| 5 primus-safe cr | applies the platform custom resources | `primus-safe-cr` |
+| 6 data plane | installs node-agent -- **only if** `install_node_agent=y` | `node-agent` |
+| 6b observability | installs metrics (VictoriaMetrics + exporters + enricher) and/or logs (OpenSearch + FluentBit) -- **only if** logs or metrics enabled; then mirrors the OpenSearch admin secret into `primus-safe` and restarts apiserver + resource-manager | `primus-safe-observability` (own namespace) |
+| 7 done | writes `SaFE/bootstrap/.env` | (file) |
+
+A failure at any step leaves earlier releases installed; re-running resumes from the
+equivalent point because each release is reconciled with `helm upgrade --install`.
+
+## Idempotency & resuming a partial install
+
+Every script in this skill is safe to re-run. On a partial/failed install, detect what is
+already done and re-run only the incomplete steps (or just re-run the step's script -- a
+no-op if it is already satisfied).
+
+### Per-step "already done?" detection
+
+| Step | Detect command | Done when | If not done |
+|---|---|---|---|
+| 2 bootstrap | `kubectl get nodes` | every node `Ready` + base add-ons in `helm list -A` | re-run `bootstrap.sh` (idempotent, but slow -- 20-40 min) |
+| 3 storage | `kubectl get storageclass` | a `(default)` class exists, name matches `safe.storage_class` | re-run `local-path.sh` / `ceph.sh` |
+| 4 higress | `kubectl get pods -n higress-system` | gateway pods `Running` | re-run `higress.sh` |
+| 5 harbor | `kubectl get pods -n harbor` | Harbor pods `Running` | regenerate `harbor/hosts.yaml`, re-run `harbor.sh` (pass `$1`=password) |
+| 6 opensearch secret | `kubectl get secret primus-safe-opensearch-config -n primus-safe` | secret exists | re-create it (SKILL.md step 6) |
+| 7 grafana-operator | `helm status grafana-operator -n primus-safe` | `deployed` | re-run `install.sh` |
+| 7 primus-pgo | `helm status primus-pgo -n primus-safe` | `deployed` + pod Running | re-run `install.sh` |
+| 7 primus-safe | `helm status primus-safe -n primus-safe` | `deployed` + pods Running | re-run `install.sh` |
+| 7 primus-safe-cr | `helm status primus-safe-cr -n primus-safe` | `deployed` | re-run `install.sh` |
+| 7 node-agent | `helm status node-agent -n primus-safe` | `deployed` (only if enabled) | re-run `install.sh` |
+| 7 observability | `kubectl get pods -n primus-safe-observability` | pods Running (only if enabled) | re-run `install.sh` |
+
+### Why each script is safe to re-run
+
+- **`install.sh`** -- `helm upgrade --install` for every chart; `install_or_upgrade_helm_chart`
+  first `helm uninstall --no-hooks` any release stuck in `failed`/`pending-install`, then
+  reinstalls. Secrets go through `kubectl apply` (create-or-update). `ensure_opensearch_secret`
+  and `ensure_higress_tls_secret` **preserve** an existing secret instead of overwriting. So
+  a repeat run reconciles missing pieces and upgrades the rest in place.
+- **`bootstrap.sh`** -- wraps Kubespray (Ansible), which is idempotent: a re-run converges the
+  cluster to the desired state. It is slow, so prefer to skip when `kubectl get nodes` already
+  shows every node `Ready`. Note it has no `set -e`, so trust the checks, not the exit code.
+- **Storage / higress / harbor** -- each applies manifests / Helm charts that tolerate a
+  re-run; the storage scripts `delete` a same-named class before recreating it.
+
 ## Known repo bugs / gotchas to work around
 
 1. **`Bootstrap/hosts.ini` is a broken placeholder** (duplicate `host1`, incomplete
@@ -138,10 +193,23 @@ kubectl get pods -n primus-safe  # apiserver, controllers, webhooks, db operator
 # Seeded login: root / root  (change immediately)
 ```
 
-## `.env` (written by install.sh) and upgrades
+## `install.sh` vs `upgrade.sh` (which to run when)
+
+Both are in `SaFE/bootstrap/`. They are not interchangeable:
+
+| | `install.sh` | `upgrade.sh` |
+|---|---|---|
+| Purpose | first install **and** resume/repair a partial one | later config-preserving upgrade |
+| Input | interactive prompts (pipe answers) | reads `SaFE/bootstrap/.env`; prompts for nothing |
+| Fresh cluster | yes | no -- fails if `.env` is missing |
+| Reconciles | all releases + secrets | admin plane, cr, node-agent, observability |
+| Use to resume a broken first install | **yes** | no |
 
 `install.sh` writes `SaFE/bootstrap/.env` at the end (secrets are NOT stored there --
 they live in K8s secrets `primus-safe-image`, `primus-safe-s3`, `primus-safe-sso`,
 `primus-safe-opensearch-config`). `upgrade.sh` re-reads `.env` and prompts for nothing.
 If you plan to run `upgrade.sh`, add `cd_require_approval=true` (or `false`) to `.env`
-first -- install does not write it and upgrade expects it.
+first -- install does not write it and upgrade expects it. (`upgrade.sh` also honors
+`CALLED_BY_CD=true` to skip the node-agent step when driven by `cd-deploy.sh`.)
+
+To resume a partial *application* install, re-run `install.sh` -- not `upgrade.sh`.

--- a/.cursor/skills/bootstrap-primus-safe-cluster/reference.md
+++ b/.cursor/skills/bootstrap-primus-safe-cluster/reference.md
@@ -19,7 +19,7 @@ send an empty line to accept the default.
 | # | Prompt | Answer from config | Default |
 |---|--------|--------------------|---------|
 | 1 | `Enter ethernet nic(...)` | `safe.ethernet_nic` | `eno0` |
-| 2 | `Enter rdma nic(...)` | `safe.rdma_nic` | `rdma0,...,rdma7` |
+| 2 | `Enter rdma nic(...)` | `safe.rdma_nic` | `rdma0,...,rdma7` (see caveat below) |
 | 3 | `Enter cluster scale, choose 'small/medium/large' (...)` | `safe.cluster_scale` | `small` |
 | 4 | `Enter storage class(...)` | `safe.storage_class` | `local-path` |
 | 5 | `Support S3 ? (y/n)` | `y` if `safe.s3.enabled` else `n` | `n` |
@@ -51,6 +51,17 @@ Maximum path (S3 + image secret + higress + SSO all on) = **26 prompts**.
   empty after the prompts, the script silently sets `s3_enable=false`.
 - **SSO**: same all-or-nothing disable.
 - **Image pull secret**: `y` with any blank field -> an empty placeholder secret.
+
+### `rdma_nic` cannot be blanked from the config (prompt #2)
+
+`get_input_with_default` treats an **empty** line as "accept the default", so piping `""`
+for `safe.rdma_nic` does **not** clear it -- it sets `NCCL_IB_HCA` to the `rdma0,...,rdma7`
+default. On a cluster with no RDMA NICs this silently bakes in a meaningless HCA list
+(the value is a cluster-wide default; single-node jobs are unaffected, but it is
+misleading). There is no piped input that yields an empty `NCCL_IB_HCA`. Options:
+- Set `safe.rdma_nic` to the node's real RDMA devices (`rdma link` / `ibdev2netdev`).
+- Accept the default is cosmetic on a no-RDMA / single-node cluster, or override
+  `NCCL_IB_HCA` per workload later.
 
 ### Not prompted
 
@@ -117,7 +128,7 @@ no-op if it is already satisfied).
 | Step | Detect command | Done when | If not done |
 |---|---|---|---|
 | 2 bootstrap | `kubectl get nodes` | every node `Ready` + base add-ons in `helm list -A` | re-run `bootstrap.sh` (idempotent, but slow -- 20-40 min) |
-| 3 storage | `kubectl get storageclass` | a `(default)` class exists, name matches `safe.storage_class` | re-run `local-path.sh` / `ceph.sh` |
+| 3 storage | 1Mi PVC bind smoke-test (below), not just `kubectl get storageclass` | the smoke-test PVC reaches `Bound` and the class name matches `safe.storage_class` (Ceph: OSD pods Running + `CephBlockPool` Ready) | re-run `local-path.sh` / `ceph.sh`; if a present class won't bind, that's BLOCKED, not a re-run |
 | 4 higress | `kubectl get pods -n higress-system` | gateway pods `Running` | re-run `higress.sh` |
 | 5 harbor | `kubectl get pods -n harbor` | Harbor pods `Running` | regenerate `harbor/hosts.yaml`, re-run `harbor.sh` (pass `$1`=password) |
 | 6 opensearch secret | `kubectl get secret primus-safe-opensearch-config -n primus-safe` | secret exists | re-create it (SKILL.md step 6) |
@@ -170,22 +181,48 @@ no-op if it is already satisfied).
 
 ## Per-stage verification commands
 
+Verify **READY**, not just existence: most install failures are pods that come up but never
+become Ready (webhooks crashloop, OpenSearch `0/1`, a wrong image `ImagePullBackOff`) or
+volumes that never bind. A `Running` phase with `0/1` ready, or a `deployed` helm release
+with a broken pod, is still a failure. The `grep -Ev 'Running|Completed'` lines below print
+nothing when healthy; anything they print needs investigation.
+
 ```bash
 # After bootstrap.sh
 kubectl get nodes -o wide        # every node Ready
 helm list -A                     # cert-manager, amd-gpu-operator, network-operator, scheduler-plugins
+kubectl get pods -A | grep -Ev 'Running|Completed'   # nothing = all add-on pods healthy
 
-# After storage
-kubectl get storageclass         # a (default) class is listed
+# After storage -- prove the class BINDS, don't just check it exists (a dead class,
+# e.g. Ceph rbd with no OSDs, satisfies a presence check but stalls install.sh later)
+kubectl get storageclass         # a (default) class is listed, name == safe.storage_class
+# Ceph only: backing cluster must be healthy
+kubectl get pods -n rook-ceph | grep 'rook-ceph-osd-'   # >=1 osd pod Running
+kubectl get cephblockpool -A                            # PHASE Ready (not Failure)
+# Functional bind smoke-test (all storage types)
+kubectl apply -f - <<'EOF'
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata: {name: safe-smoke-test, namespace: default}
+spec:
+  accessModes: [ReadWriteOnce]
+  resources: {requests: {storage: 1Mi}}
+  storageClassName: <safe.storage_class>   # omit to use the (default) class
+EOF
+kubectl wait --for=jsonpath='{.status.phase}'=Bound pvc/safe-smoke-test --timeout=60s
+kubectl delete pvc safe-smoke-test
+# Pending instead of Bound -> BLOCKED; read `kubectl describe pvc safe-smoke-test`
 
 # After higress (if used)
-kubectl get pods -n higress-system
+kubectl get pods -n higress-system | grep -Ev 'Running|Completed'   # nothing = healthy
 
 # After harbor (if used)
-kubectl get pods -n harbor
+kubectl get pods -n harbor | grep -Ev 'Running|Completed'           # nothing = healthy
 
-# After install.sh
-kubectl get pods -n primus-safe  # apiserver, controllers, webhooks, db operator Running
+# After install.sh -- every pod READY n/n, all PVCs Bound
+kubectl get pods -n primus-safe   # apiserver, controllers, webhooks, db operator -- READY n/n
+kubectl get pods -n primus-safe | grep -Ev 'Running|Completed'      # nothing = healthy
+kubectl get pvc -A | grep -v Bound                                 # nothing = all Bound
 
 # Console
 #   nginx:   http://<any-node-ip>:30183

--- a/.cursor/skills/bootstrap-primus-safe-cluster/reference.md
+++ b/.cursor/skills/bootstrap-primus-safe-cluster/reference.md
@@ -1,0 +1,141 @@
+# Reference: install.sh prompt mapping, repo gotchas, verification
+
+This is the fragile detail behind the skill. If `SaFE/bootstrap/install.sh` changes
+its prompts, **the prompt-order table below is the one thing to re-check.**
+
+## `install.sh` is interactive-only
+
+Every parameter goes through `read` (`get_input_with_default` /
+`get_secret_input_with_default`). There is **no** `--env-file`, no flags, and no
+"skip if variable already set" logic. `install.sh` only *writes* `.env` at the end;
+it never reads one on a fresh install. So the only zero-code-change way to automate it
+is to **pipe answers to stdin in exact prompt order**. Empty input = the shown default.
+
+## Prompt order (default path = 14 prompts)
+
+Feed one answer per line, in this order. `<-` shows the config field; `(Enter)` means
+send an empty line to accept the default.
+
+| # | Prompt | Answer from config | Default |
+|---|--------|--------------------|---------|
+| 1 | `Enter ethernet nic(...)` | `safe.ethernet_nic` | `eno0` |
+| 2 | `Enter rdma nic(...)` | `safe.rdma_nic` | `rdma0,...,rdma7` |
+| 3 | `Enter cluster scale, choose 'small/medium/large' (...)` | `safe.cluster_scale` | `small` |
+| 4 | `Enter storage class(...)` | `safe.storage_class` | `local-path` |
+| 5 | `Support S3 ? (y/n)` | `y` if `safe.s3.enabled` else `n` | `n` |
+| 6 | `Create image pull secret ? (y/n)` | `y` if `safe.image_pull_secret.enabled` else `n` | `n` |
+| 7 | `Enter the ingress name (nginx/higress)` | `safe.ingress` | `nginx` |
+| 8 | `Support SSO ? (y/n)` | `y` if `safe.sso.enabled` else `n` | `n` |
+| 9 | `Enter OpenSearch username (empty if not required)` | `safe.opensearch.username` | `` (empty) |
+| 10 | `Enter OpenSearch password (...)` *(silent)* | `safe.opensearch.password` | `` (empty) |
+| 11 | `Enter csi volume handle? (...)` | `safe.csi_volume_handle` | `` (empty) |
+| 12 | `install node-agent ? (y/n)` | `y`/`n` from `safe.install_node_agent` | `n` |
+| 13 | `install SaFE observability logging stack ... ? (y/n)` | `y`/`n` from `safe.install_obs_logs` | `n` |
+| 14 | `install SaFE observability metrics stack ... ? (y/n)` | `y`/`n` from `safe.install_obs_metrics` | `n` |
+
+### Conditional prompts (inserted right after their trigger)
+
+These extra lines must be inserted **in place** when the trigger answer is `y` /
+`higress`, shifting everything after them down:
+
+- After #5 `Support S3 ? y` -> 4 lines: `s3.endpoint`, `s3.bucket`, `s3.access_key`, `s3.secret_key`
+- After #6 `Create image pull secret ? y` -> 3 lines: `image_pull_secret.registry`, `.username`, `.password`
+- After #7 `ingress = higress` -> 1 line: `safe.cluster_name` (prompt: `Enter cluster name(lowercase with hyphen)`, default `amd`)
+- After #8 `Support SSO ? y` -> 4 lines: `sso.endpoint`, `sso.client_id`, `sso.client_secret`, `sso.redirect_uri`
+
+Maximum path (S3 + image secret + higress + SSO all on) = **26 prompts**.
+
+### All-or-nothing behavior (don't be surprised)
+
+- **S3**: if the user said `y` but any of endpoint/bucket/access_key/secret_key is
+  empty after the prompts, the script silently sets `s3_enable=false`.
+- **SSO**: same all-or-nothing disable.
+- **Image pull secret**: `y` with any blank field -> an empty placeholder secret.
+
+### Not prompted
+
+- No admin-password prompt. The platform seeds **`root` / `root`** (change immediately).
+- `lens_enable` is hardcoded `false`.
+
+## Building the answer stream
+
+Construct the exact ordered list first (with conditional insertions), then pipe it.
+`printf` with one `%s\n` per answer is more reliable than a fragile heredoc:
+
+```bash
+cd Primus-SaFE/SaFE/bootstrap
+printf '%s\n' \
+  "$ETHERNET_NIC" \
+  "$RDMA_NIC" \
+  "$CLUSTER_SCALE" \
+  "$STORAGE_CLASS" \
+  "n" \
+  "n" \
+  "nginx" \
+  "n" \
+  "" \
+  "" \
+  "$CSI_VOLUME_HANDLE" \
+  "$NODE_AGENT_YN" \
+  "$OBS_LOGS_YN" \
+  "$OBS_METRICS_YN" \
+  | bash install.sh
+```
+
+Adjust the middle lines (and insert the conditional blocks) to match the config.
+Verify each line count against the table before running -- an off-by-one shifts every
+later answer.
+
+## Known repo bugs / gotchas to work around
+
+1. **`Bootstrap/hosts.ini` is a broken placeholder** (duplicate `host1`, incomplete
+   IPs). Fully rewrite it from `nodes`.
+2. **`Bootstrap/README.md` says `hosts.yaml`** for the Kubespray inventory -- wrong.
+   `bootstrap.sh` uses `hosts.ini` (`CONFIG_FILE=hosts.ini`). The `docs-site` install
+   page is correct.
+3. **Harbor arg order** -- README shows `harbor.sh <pwd> [domain] [ssh_key]`, but the
+   script is: `$1`=password, `$2`=domain (`primus-safe.amd.com`), `$3`=**storage class**
+   (`rbd`), `$4`=ssh key (`~/.ssh/id_ed25519`). Always pass `$1` to skip its prompt.
+4. **`Bootstrap/harbor/hosts.yaml`** is a separate, gitignored Ansible inventory Harbor
+   needs to push its CA to every node. Generate it before running `harbor.sh`.
+5. **Ceph SC name mismatch** -- `ceph.sh` does `kubectl delete sc storage-rbd`, but the
+   StorageClass it creates is named `rbd` (the secret is `storage-rbd`). The delete is a
+   no-op; harmless, but the class to reference downstream is `rbd`.
+6. **`bootstrap.sh` has no `set -e`** -- partial failures can continue silently. Check
+   each verification step below rather than trusting a zero exit.
+7. **Fresh-cluster pre-install hook** -- `install.sh` expects the
+   `primus-safe-opensearch-config` secret to already exist. Pre-create it (see SKILL.md
+   step 6).
+
+## Per-stage verification commands
+
+```bash
+# After bootstrap.sh
+kubectl get nodes -o wide        # every node Ready
+helm list -A                     # cert-manager, amd-gpu-operator, network-operator, scheduler-plugins
+
+# After storage
+kubectl get storageclass         # a (default) class is listed
+
+# After higress (if used)
+kubectl get pods -n higress-system
+
+# After harbor (if used)
+kubectl get pods -n harbor
+
+# After install.sh
+kubectl get pods -n primus-safe  # apiserver, controllers, webhooks, db operator Running
+
+# Console
+#   nginx:   http://<any-node-ip>:30183
+#   higress: https://<cluster_name>.<your-domain>
+# Seeded login: root / root  (change immediately)
+```
+
+## `.env` (written by install.sh) and upgrades
+
+`install.sh` writes `SaFE/bootstrap/.env` at the end (secrets are NOT stored there --
+they live in K8s secrets `primus-safe-image`, `primus-safe-s3`, `primus-safe-sso`,
+`primus-safe-opensearch-config`). `upgrade.sh` re-reads `.env` and prompts for nothing.
+If you plan to run `upgrade.sh`, add `cd_require_approval=true` (or `false`) to `.env`
+first -- install does not write it and upgrade expects it.


### PR DESCRIPTION
## Summary

Adds a Cursor agent skill that provisions a Primus-SaFE cluster end to end from a single
filled-in config file, turning cluster bring-up into "fill in one YAML, hand it to an
agent" instead of running each script by hand and answering the installer's prompts live.

Lives at `.cursor/skills/bootstrap-primus-safe-cluster/`:

- **`cluster-config.example.yaml`** — the one file an operator fills in (nodes, network,
  storage, gateway/registry, and every `install.sh` answer). Defaults match a real
  deployment: Higress ingress, Harbor pull-through cache, node-agent on, S3/SSO off.
- **`SKILL.md`** — the ordered, detect → skip-if-satisfied → run → verify workflow:
  rewrite the Kubespray inventory → `bootstrap.sh` → storage → optional Higress/Harbor →
  pre-create the OpenSearch secret → drive `install.sh` → verify the console. Idempotent
  and re-runnable: it probes current state and resumes at the first incomplete step.
- **`reference.md`** — the fragile details: the exact `install.sh` prompt→config mapping,
  conditional prompts, S3/SSO all-or-nothing behavior, install.sh idempotency, and the
  known repo gotchas.

## Approach

`SaFE/bootstrap/install.sh` is strictly interactive (every value goes through `read`).
Rather than modify it, the skill generates the answer stream from the config and pipes it
in exact prompt order; everything else in `Bootstrap/` is already scriptable. No existing
scripts are changed — robustness rests on the prompt-order table in `reference.md`, which
is the single thing to update if the prompts ever change.

The docs also capture gotchas found along the way: Harbor's `/proxy` cache is only
auto-wired at `harbor.<cluster_name>.primus-safe.amd.com`; the Kubespray inventory is
`Bootstrap/hosts.ini` (README's `hosts.yaml` is wrong, and the checked-in file is a broken
placeholder); `harbor.sh`'s real arg order is `<pwd> <domain> <storage-class> <ssh-key>`;
and a fresh cluster needs the `primus-safe-opensearch-config` secret pre-created.

## Testing

Ran the skill once against the conductor MI250 nodes: it bootstrapped a fresh cluster end
to end (inventory → Bootstrap → storage → Higress → Harbor → `install.sh`) and the
Primus-SaFE console came up and signed in. More runs across different node/config
combinations still welcome.

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/9065071f-a8c0-40e0-8a77-eb8e390b9ed1" />


## Note for reviewers

The skill lives under `.cursor/`, which is gitignored in this repo, so it was committed
with `git add -f`. Worth deciding whether it should stay here (force-tracked) or move to a
non-ignored location.