### PR TITLE
docs: fix view-logs docs-as-test findings

### DIFF
--- a/docs-site/AGENTS.md
+++ b/docs-site/AGENTS.md
@@ -51,8 +51,10 @@ leave `TARGET = ALL` for a full run. Runtime values come from the gitignored
    note it, don't fail on it. A `kubectl` cross-check is allowed only as a ground-truth *aside*,
    never as the primary assertion.
 6. **Always run cleanup** — the page tells you how (delete/stop the resource you created).
-7. **Report PASS / FAIL / BLOCKED per row**, quoting *page says X, product does Y*, with a
-   screenshot on FAIL.
+7. **Report PASS / FAIL / BLOCKED per row**, quoting *page says X, product does Y*. **Save a
+   screenshot of the result to `/tmp/doc-as-test-<page>-<runid>.png`** — the passing artifact on
+   PASS (e.g. the populated Logs panel) and the failing state on FAIL — and reference it in the
+   report so a human can see the UI, not just the prose verdict.
 
 ## Test-scope exclusions (what the regression run skips, and why)
 
@@ -142,7 +144,9 @@ Execute the docs-as-test suite. The docs-site IS the test spec.
    3× fresh-thread runs). Name created resources doc-as-test-<page>-<runid> and clean them up.
 6. Honor the known-drift notes in the manifest for the pages in the set (documented bugs are not new
    failures).
-7. Output: a summary table (page · level · result) + a findings/ambiguity list.
+7. For each page, save a screenshot of the result to /tmp/doc-as-test-<page>-<runid>.png (the
+   passing artifact on PASS, the failing state on FAIL) and reference it in the report.
+8. Output: a summary table (page · level · result) + a findings/ambiguity list.
 ```
 
 ## Manifest — the only off-page bookkeeping
@@ -169,6 +173,7 @@ negative/permission limit (kept as visible prose) · n/a = reference/overview, n
 | tasks/run-single-node-training | behavior | P0 | member | workspace-with-quota, pullable-image | phase-lag Pending drift (as above) |
 | tasks/run-multi-node-training | behavior | P1 | member | workspace-with-quota, multiple-ready-nodes | phase-lag drift; gang placement slower on first image pull |
 | tasks/interact-with-your-job | behavior | P0 | member | running-cluster, workspace-with-authoring-scope | WebShell needs a trusted cert (see exclusions) and a shell present in the image (pick `sh` on minimal images); SSH:2222 is out of a UI-only run |
+| tasks/view-logs | behavior | P2 | member | running-cluster | console phase can stay **Pending** while the pod is Running and streaming logs (phase-lag) → refresh / check the Pods tab |
 | tasks/speed-up-startup | behavior | P2 | member | workspace-with-quota, harbor-registry | — |
 | tasks/beyond-training | n/a (overview/hub) | — | any | none | — |
 | tasks/run-cicd-runners | behavior | P1 | admin, member | workspace with `CICD` scope (surfaces Workloads → CICD) + ARC add-on + GitHub App | **BLOCKED** unless the CICD scope + ARC add-on are present |

--- a/docs-site/docs/tasks/view-logs.md
+++ b/docs-site/docs/tasks/view-logs.md
@@ -35,8 +35,11 @@ job whose phase is **Running** or that has already run. That job is your target.
 
 **If nothing suitable is available,** create a throwaway smoke job — this is the same recipe as
 [Your first job](/getting-started/first-training-job): select your **workspace**, create a
-**PyTorchJob** with any pullable image (e.g. `docker.io/rocm/pytorch:latest`) and an entrypoint
-that prints something and stays up long enough to read, such as:
+**PyTorchJob** with any pullable image and an entrypoint that prints something and stays up long
+enough to read. Since you're only reading log output here, a **small image like
+`docker.io/library/busybox:latest`** is the best choice — there's no need for a large ML image like
+`docker.io/rocm/pytorch:latest`, which can take several minutes to pull the first time. For
+example:
 
 ```bash
 echo "hello from doc-as-test"; sleep 15
@@ -57,12 +60,17 @@ for the walkthrough:
 
 - **Healthy (pass):** with a node selected, the panel shows **at least one timestamped log line**
   for the pod/host (for the smoke job, you'll see your `hello from doc-as-test` line). You can also
-  narrow the view with the **keyword** filter or the **date range**, and toggle **Wrap** — but a
-  single populated line is enough to pass.
+  **highlight matches** with the **keyword** filter, narrow by **date range**, and toggle **Wrap** —
+  but a single populated line is enough to pass.
 - **If instead you see** an empty panel, a spinner that never resolves, or an error, **that means**
   logs aren't reaching the UI **(fail)** — *unless* the pod genuinely hasn't produced output yet
   (just started / still **Pending**), in which case widen the **date range**, wait a moment, and
   retry before judging.
+
+> **Note:** the workload's overall phase can lag its pod — the job may still read **Pending** at the
+> top of the page even after the pod is **Running** and already writing logs. If the Logs panel is
+> populated, the job is working; just **refresh the page every few minutes** (or check the **Pods**
+> tab) until the phase catches up.
 
 > **Agent:** perform Steps 1–3, fill the table below, show it to the user, and report **PASS** only
 > if at least one real log line rendered in the Logs panel. Then **run cleanup**: if you created
@@ -78,7 +86,7 @@ for the walkthrough:
 | Logs tab present on the detail page | yes | _fill in_ |
 | A node is selected (auto or manual) | yes | _fill in_ |
 | Log panel shows ≥1 timestamped line | yes | _fill in_ |
-| Keyword filter narrows results | yes (optional) | _fill in_ |
+| Keyword filter highlights matching lines | yes (optional) | _fill in_ |
 | Cleanup (smoke job deleted, if created) | done / n/a | _fill in_ |
 
 ## Where to go next


### PR DESCRIPTION
## Summary

Addresses findings from a docs-as-test run of `tasks/view-logs`. Two files changed: the page walkthrough and the run contract.

> **Target branch:** this PR targets `experimental/v1-ga-separation` (not `main`).

- **Manifest (Finding 1):** add the missing `tasks/view-logs` row to `docs-site/AGENTS.md` (`behavior · P2 · member · running-cluster`) with its phase-lag known-drift note. Every other `docs/**` page was listed; this one wasn't, so CI selection and full runs skipped it.
- **Smoke-job image (Finding 3):** the log-viewing walkthrough now recommends a small image (`docker.io/library/busybox:latest`) instead of `docker.io/rocm/pytorch:latest`. You only need log output here, and the large ML image can take several minutes to pull.
- **Phase-lag note (Finding 2):** add a human-facing note that the workload's overall phase can stay **Pending** while the pod is already **Running** and streaming logs — refresh the page or check the **Pods** tab.
- **Keyword-filter wording:** reworded the Step 3 bullet and the "What you should see" row — the keyword filter **highlights matching lines** rather than narrowing the list down.
- **Screenshot rule (agent contract):** added a global instruction in `AGENTS.md` (run steps + trigger prompt) to save a screenshot of the result to `/tmp/doc-as-test-<page>-<runid>.png` so a human can see the UI, not just the prose verdict.

Intentionally left as-is: the persona/`.docs-test.env` observation (running the member walkthrough as admin is fine).

## Test plan

- [ ] `docs-site` builds (Docusaurus) with the edited `view-logs.md`.
- [ ] Manifest table renders with the new `tasks/view-logs` row.
- [ ] Re-run docs-as-test for `TARGET = tasks/view-logs`; confirm PASS and a screenshot saved under `/tmp`.