### PR TITLE
fix(common,job-manager,resource-manager,apiserver): self-heal wedged …

### DIFF
--- a/SaFE/apiserver/pkg/controllers/cluster_controller.go
+++ b/SaFE/apiserver/pkg/controllers/cluster_controller.go
@@ -8,7 +8,10 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	ctrlruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -23,16 +26,30 @@ import (
 	commonutils "github.com/AMD-AIG-AIMA/SAFE/common/pkg/utils"
 )
 
+// Watchdog tuning for the data-plane direct-call clients. These factories are
+// informer-less (DisableInformer), so the shared ClientFactory does not probe
+// them; this controller probes them itself and rebuilds a factory whose
+// connection is persistently broken (e.g. after an endpoint change or cert
+// rotation), which the Has()-guarded addClientFactory would otherwise never
+// refresh.
+const (
+	clusterHealthInterval = 30 * time.Second
+	clusterProbeTimeout   = 5 * time.Second
+	clusterFailThreshold  = 3
+)
+
 type ClusterReconciler struct {
-	ctx context.Context
+	ctx           context.Context
 	client.Client
+	clientManager *commonutils.ObjectManager
 }
 
 // SetupClusterController sets up the cluster controller with the manager.
 func SetupClusterController(ctx context.Context, mgr manager.Manager) error {
 	r := &ClusterReconciler{
-		Client: mgr.GetClient(),
-		ctx:    ctx,
+		Client:        mgr.GetClient(),
+		ctx:           ctx,
+		clientManager: commonutils.NewObjectManagerSingleton(),
 	}
 	err := ctrlruntime.NewControllerManagedBy(mgr).
 		For(&v1.Cluster{}, builder.WithPredicates(r.relevantChangePredicate())).
@@ -40,6 +57,7 @@ func SetupClusterController(ctx context.Context, mgr manager.Manager) error {
 	if err != nil {
 		return err
 	}
+	r.runFactoryWatchdog(ctx)
 	return nil
 }
 
@@ -96,11 +114,10 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrlruntime.Reque
 // deleteClientFactory removes the Kubernetes client factory for a cluster being deleted.
 // It cleans up the client manager and releases resources associated with the cluster.
 func (r *ClusterReconciler) deleteClientFactory(cluster *v1.Cluster) error {
-	mgr := commonutils.NewObjectManagerSingleton()
-	if mgr == nil {
+	if r.clientManager == nil {
 		return nil
 	}
-	if err := mgr.Delete(cluster.Name); err != nil {
+	if err := r.clientManager.Delete(cluster.Name); err != nil {
 		klog.Errorf("failed to delete cluster clients, err: %v", err)
 		return err
 	}
@@ -114,25 +131,94 @@ func (r *ClusterReconciler) addClientFactory(ctx context.Context, cluster *v1.Cl
 	if !cluster.IsReady() {
 		return nil
 	}
-	clientManager := commonutils.NewObjectManagerSingleton()
-	if clientManager == nil {
+	if r.clientManager == nil {
 		return fmt.Errorf("failed to initialize cluster client manager for cluster %s", cluster.Name)
 	}
-	if clientManager.Has(cluster.Name) {
+	if r.clientManager.Has(cluster.Name) {
 		return nil
 	}
+	return r.createClientFactory(ctx, cluster)
+}
+
+// createClientFactory builds a data-plane direct-call client factory and stores
+// it via AddOrReplace, which atomically releases any existing entry. Shared by
+// addClientFactory (initial setup) and the watchdog (rebuild on a broken
+// connection); on failure the previous factory is left intact for retry.
+func (r *ClusterReconciler) createClientFactory(ctx context.Context, cluster *v1.Cluster) error {
 	endpoint, err := commoncluster.GetEndpoint(ctx, r.Client, cluster)
 	if err != nil {
 		return err
 	}
-
 	controlPlane := &cluster.Status.ControlPlaneStatus
 	k8sClientFactory, err := commonclient.NewClientFactory(ctx, cluster.Name, endpoint,
 		controlPlane.CertData, controlPlane.KeyData, controlPlane.CAData, commonclient.DisableInformer)
 	if err != nil {
 		return err
 	}
-	clientManager.AddOrReplace(cluster.Name, k8sClientFactory)
+	r.clientManager.AddOrReplace(cluster.Name, k8sClientFactory)
 	klog.Infof("add cluster %s clients", cluster.Name)
 	return nil
+}
+
+// runFactoryWatchdog probes each data-plane client on an interval and rebuilds a
+// cluster's factory after sustained probe failures, so a persistently broken
+// direct-call connection (endpoint change, cert rotation) self-heals instead of
+// failing every request until a restart. Probe is activity-independent and any
+// received HTTP status counts as healthy, so idle/limited-RBAC clusters do not
+// trigger needless rebuilds.
+func (r *ClusterReconciler) runFactoryWatchdog(ctx context.Context) {
+	failures := map[string]int{}
+	go wait.UntilWithContext(ctx, func(ctx context.Context) {
+		keys, objs := r.clientManager.GetAll()
+		live := make(map[string]bool, len(keys))
+		for i, name := range keys {
+			factory, ok := objs[i].(*commonclient.ClientFactory)
+			if !ok {
+				continue
+			}
+			live[name] = true
+			probeCtx, cancel := context.WithTimeout(ctx, clusterProbeTimeout)
+			err := factory.Probe(probeCtx)
+			cancel()
+			if err == nil {
+				delete(failures, name)
+				continue
+			}
+			failures[name]++
+			klog.ErrorS(err, "data-plane cluster health probe failed",
+				"cluster", name, "consecutiveFailures", failures[name])
+			if failures[name] < clusterFailThreshold {
+				continue
+			}
+			if rebuildErr := r.rebuildClientFactory(ctx, name); rebuildErr != nil {
+				klog.ErrorS(rebuildErr, "failed to rebuild data-plane cluster client", "cluster", name)
+				continue
+			}
+			klog.InfoS("rebuilt data-plane cluster client after sustained probe failure", "cluster", name)
+			delete(failures, name)
+		}
+		// Drop counters for clusters no longer managed.
+		for name := range failures {
+			if !live[name] {
+				delete(failures, name)
+			}
+		}
+	}, clusterHealthInterval)
+}
+
+// rebuildClientFactory re-fetches the Cluster and recreates its client factory.
+// createClientFactory's AddOrReplace atomically releases the old (broken) one.
+func (r *ClusterReconciler) rebuildClientFactory(ctx context.Context, name string) error {
+	cluster := new(v1.Cluster)
+	if err := r.Get(ctx, client.ObjectKey{Name: name}, cluster); err != nil {
+		if apierrors.IsNotFound(err) {
+			_ = r.clientManager.Delete(name)
+			return nil
+		}
+		return err
+	}
+	if !cluster.IsReady() {
+		return nil
+	}
+	return r.createClientFactory(ctx, cluster)
 }

--- a/SaFE/apiserver/pkg/controllers/cluster_controller.go
+++ b/SaFE/apiserver/pkg/controllers/cluster_controller.go
@@ -8,7 +8,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -22,21 +21,17 @@ import (
 
 	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
 	commoncluster "github.com/AMD-AIG-AIMA/SAFE/common/pkg/cluster"
+	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/common"
 	commonclient "github.com/AMD-AIG-AIMA/SAFE/common/pkg/k8sclient"
 	commonutils "github.com/AMD-AIG-AIMA/SAFE/common/pkg/utils"
 )
 
-// Watchdog tuning for the data-plane direct-call clients. These factories are
-// informer-less (DisableInformer), so the shared ClientFactory does not probe
-// them; this controller probes them itself and rebuilds a factory whose
-// connection is persistently broken (e.g. after an endpoint change or cert
-// rotation), which the Has()-guarded addClientFactory would otherwise never
-// refresh.
-const (
-	clusterHealthInterval = 30 * time.Second
-	clusterProbeTimeout   = 5 * time.Second
-	clusterFailThreshold  = 3
-)
+// The watchdog probes the data-plane direct-call clients on
+// common.DataPlaneHealthProbeInterval and rebuilds a factory whose connection is
+// persistently broken (e.g. after an endpoint change or cert rotation). These
+// factories are informer-less (DisableInformer), so the shared ClientFactory
+// does not probe them and the Has()-guarded addClientFactory would otherwise
+// never refresh a stale one.
 
 type ClusterReconciler struct {
 	ctx           context.Context
@@ -177,7 +172,7 @@ func (r *ClusterReconciler) runFactoryWatchdog(ctx context.Context) {
 				continue
 			}
 			live[name] = true
-			probeCtx, cancel := context.WithTimeout(ctx, clusterProbeTimeout)
+			probeCtx, cancel := context.WithTimeout(ctx, common.DataPlaneHealthProbeTimeout)
 			err := factory.Probe(probeCtx)
 			cancel()
 			if err == nil {
@@ -187,7 +182,7 @@ func (r *ClusterReconciler) runFactoryWatchdog(ctx context.Context) {
 			failures[name]++
 			klog.ErrorS(err, "data-plane cluster health probe failed",
 				"cluster", name, "consecutiveFailures", failures[name])
-			if failures[name] < clusterFailThreshold {
+			if failures[name] < common.DataPlaneHealthFailThreshold {
 				continue
 			}
 			if rebuildErr := r.rebuildClientFactory(ctx, name); rebuildErr != nil {
@@ -203,7 +198,7 @@ func (r *ClusterReconciler) runFactoryWatchdog(ctx context.Context) {
 				delete(failures, name)
 			}
 		}
-	}, clusterHealthInterval)
+	}, common.DataPlaneHealthProbeInterval)
 }
 
 // rebuildClientFactory re-fetches the Cluster and recreates its client factory.

--- a/SaFE/common/pkg/common/constant.go
+++ b/SaFE/common/pkg/common/constant.go
@@ -5,6 +5,23 @@
 
 package common
 
+import "time"
+
+// Data-plane client connection health-watchdog tuning, shared by the common
+// ClientFactory probe and the per-module rebuild watchdogs (job-manager syncer,
+// resource-manager node informer, apiserver direct-call clients).
+const (
+	// DataPlaneHealthProbeInterval is how often a data-plane connection is probed
+	// / a factory's validity is checked.
+	DataPlaneHealthProbeInterval = 30 * time.Second
+	// DataPlaneHealthProbeTimeout bounds a single probe so a wedged connection
+	// fails fast instead of blocking the watchdog.
+	DataPlaneHealthProbeTimeout = 5 * time.Second
+	// DataPlaneHealthFailThreshold is the number of consecutive probe failures
+	// before a connection is treated as broken.
+	DataPlaneHealthFailThreshold = 3
+)
+
 const (
 	PrimusSafeName             = "primus-safe"
 	PrimusSafeNamespace        = "primus-safe"

--- a/SaFE/common/pkg/k8sclient/client_factory.go
+++ b/SaFE/common/pkg/k8sclient/client_factory.go
@@ -7,6 +7,8 @@ package k8sclient
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -29,6 +31,17 @@ const (
 	EnableDynamicInformer InformerType = 2
 )
 
+// Health-probe tuning for the built-in connection watchdog. Informer-enabled
+// factories actively probe the apiserver so a silently wedged watch (which emits
+// no watch error and would otherwise starve callers until a process restart) is
+// detected and the factory flipped invalid, letting callers that gate on
+// IsValid() stop using — and rebuild — the connection.
+const (
+	healthProbeInterval = 30 * time.Second
+	healthProbeTimeout  = 5 * time.Second
+	healthFailThreshold = 3
+)
+
 // ClientFactory kubernetes client factory structure for managing cluster connections and Informers
 type ClientFactory struct {
 	ctx context.Context
@@ -47,6 +60,9 @@ type ClientFactory struct {
 	// Informer type enum definition. 0: disable informer; 1: sharedInformer; 2 dynamicSharedInformer
 	// default 0
 	informerType InformerType
+	// validMu guards valid/invalidReason, which are read/written concurrently by
+	// the health watchdog and by caller goroutines gating on IsValid().
+	validMu sync.RWMutex
 	// Whether the ClientFactory is valid
 	valid bool
 	// If the factory is invalid, explain the reason
@@ -94,6 +110,11 @@ func NewClientFactory(ctx context.Context, name, endpoint, certData,
 		factory.dynamicSharedInformerFactory = dynamicinformer.NewDynamicSharedInformerFactory(dynamicClient, defaultResyncPeriod)
 	default:
 	}
+	// Informer-enabled factories run watches that can silently wedge; start the
+	// connection watchdog so every module gets self-healing by default.
+	if factory.stopCh != nil {
+		factory.runHealthWatchdog()
+	}
 	klog.Infof("new k8s client factory. name: %s, informer type: %d", name, informerType)
 	return factory, nil
 }
@@ -123,11 +144,15 @@ func (f *ClientFactory) Release() error {
 
 // IsValid returns true if factory is valid
 func (f *ClientFactory) IsValid() bool {
+	f.validMu.RLock()
+	defer f.validMu.RUnlock()
 	return f.valid
 }
 
 // SetValid set factory validity status and reason.
 func (f *ClientFactory) SetValid(valid bool, msg string) {
+	f.validMu.Lock()
+	defer f.validMu.Unlock()
 	f.valid = valid
 	f.invalidReason = msg
 }
@@ -170,7 +195,71 @@ func (f *ClientFactory) DynamicSharedInformerFactory() dynamicinformer.DynamicSh
 
 // GetInvalidReason get reason for factory invalidity.
 func (f *ClientFactory) GetInvalidReason() string {
+	f.validMu.RLock()
+	defer f.validMu.RUnlock()
 	return f.invalidReason
+}
+
+// Probe performs an activity-independent liveness check against the apiserver
+// using the factory's client (hence the same cached transport the informers
+// use), so a wedged watch connection surfaces as a probe failure. An idle
+// cluster still answers, so this never false-positives on "no events".
+//
+// Any received HTTP status (even 4xx/5xx, e.g. an RBAC 403 on /livez) counts as
+// a live connection; only a transport-level failure (timeout, refused, EOF,
+// TLS) — where no status code is ever set — is reported as an error.
+func (f *ClientFactory) Probe(ctx context.Context) error {
+	if f.clientSet == nil {
+		return fmt.Errorf("client factory %s has no client", f.name)
+	}
+	res := f.clientSet.Discovery().RESTClient().Get().AbsPath("/livez").Do(ctx)
+	var code int
+	res.StatusCode(&code)
+	if code != 0 {
+		return nil
+	}
+	return res.Error()
+}
+
+// runHealthWatchdog periodically probes the apiserver and flips the factory's
+// validity, so callers gating on IsValid() stop using — and rebuild — a wedged
+// connection. This covers the silent half-open case that per-informer watch
+// error handlers never observe. It exits when the factory context is cancelled
+// or the informer stop channel is closed (see Release/StopInformer).
+func (f *ClientFactory) runHealthWatchdog() {
+	go func() {
+		ticker := time.NewTicker(healthProbeInterval)
+		defer ticker.Stop()
+		failures := 0
+		for {
+			select {
+			case <-f.ctx.Done():
+				return
+			case <-f.stopCh:
+				return
+			case <-ticker.C:
+			}
+			probeCtx, cancel := context.WithTimeout(f.ctx, healthProbeTimeout)
+			err := f.Probe(probeCtx)
+			cancel()
+			if err == nil {
+				failures = 0
+				if !f.IsValid() {
+					klog.Infof("client factory %s health probe recovered, marking valid", f.name)
+					f.SetValid(true, "")
+				}
+				continue
+			}
+			failures++
+			klog.ErrorS(err, "client factory health probe failed",
+				"cluster", f.name, "consecutiveFailures", failures)
+			if failures >= healthFailThreshold && f.IsValid() {
+				klog.Warningf("client factory %s marked invalid after %d consecutive probe failures: %v",
+					f.name, failures, err)
+				f.SetValid(false, fmt.Sprintf("health probe failed: %v", err))
+			}
+		}
+	}()
 }
 
 // StartInformer Start Informer factory (start corresponding Informer based on type).

--- a/SaFE/common/pkg/k8sclient/client_factory.go
+++ b/SaFE/common/pkg/k8sclient/client_factory.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
+	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/common"
 	"github.com/AMD-AIG-AIMA/SAFE/utils/pkg/channel"
 )
 
@@ -29,17 +30,6 @@ const (
 	DisableInformer       InformerType = 0
 	EnableInformer        InformerType = 1
 	EnableDynamicInformer InformerType = 2
-)
-
-// Health-probe tuning for the built-in connection watchdog. Informer-enabled
-// factories actively probe the apiserver so a silently wedged watch (which emits
-// no watch error and would otherwise starve callers until a process restart) is
-// detected and the factory flipped invalid, letting callers that gate on
-// IsValid() stop using — and rebuild — the connection.
-const (
-	healthProbeInterval = 30 * time.Second
-	healthProbeTimeout  = 5 * time.Second
-	healthFailThreshold = 3
 )
 
 // ClientFactory kubernetes client factory structure for managing cluster connections and Informers
@@ -228,7 +218,7 @@ func (f *ClientFactory) Probe(ctx context.Context) error {
 // or the informer stop channel is closed (see Release/StopInformer).
 func (f *ClientFactory) runHealthWatchdog() {
 	go func() {
-		ticker := time.NewTicker(healthProbeInterval)
+		ticker := time.NewTicker(common.DataPlaneHealthProbeInterval)
 		defer ticker.Stop()
 		failures := 0
 		for {
@@ -239,7 +229,7 @@ func (f *ClientFactory) runHealthWatchdog() {
 				return
 			case <-ticker.C:
 			}
-			probeCtx, cancel := context.WithTimeout(f.ctx, healthProbeTimeout)
+			probeCtx, cancel := context.WithTimeout(f.ctx, common.DataPlaneHealthProbeTimeout)
 			err := f.Probe(probeCtx)
 			cancel()
 			if err == nil {
@@ -253,7 +243,7 @@ func (f *ClientFactory) runHealthWatchdog() {
 			failures++
 			klog.ErrorS(err, "client factory health probe failed",
 				"cluster", f.name, "consecutiveFailures", failures)
-			if failures >= healthFailThreshold && f.IsValid() {
+			if failures >= common.DataPlaneHealthFailThreshold && f.IsValid() {
 				klog.Warningf("client factory %s marked invalid after %d consecutive probe failures: %v",
 					f.name, failures, err)
 				f.SetValid(false, fmt.Sprintf("health probe failed: %v", err))

--- a/SaFE/common/pkg/k8sclient/client_factory_test.go
+++ b/SaFE/common/pkg/k8sclient/client_factory_test.go
@@ -61,3 +61,22 @@ func TestProbeNoClient(t *testing.T) {
 	f := &ClientFactory{name: "test"}
 	assert.Error(t, f.Probe(context.Background()))
 }
+
+// TestReleaseInformerFactoryIdempotent verifies Release closes the informer stop
+// channel (which stops the health watchdog) and is safe to call twice, since the
+// factory may be released both via ObjectManager.AddOrReplace and explicitly.
+func TestReleaseInformerFactoryIdempotent(t *testing.T) {
+	f := &ClientFactory{
+		name:         "c1",
+		informerType: EnableInformer,
+		stopCh:       make(chan struct{}),
+	}
+	assert.NoError(t, f.Release())
+	select {
+	case <-f.stopCh:
+	default:
+		t.Fatal("expected stopCh to be closed after Release")
+	}
+	// Second Release must not panic on a double-close.
+	assert.NoError(t, f.Release())
+}

--- a/SaFE/common/pkg/k8sclient/client_factory_test.go
+++ b/SaFE/common/pkg/k8sclient/client_factory_test.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+package k8sclient
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// newFactoryForServer builds a client factory whose clientSet targets the given
+// base URL, so Probe exercises a real HTTP round-trip.
+func newFactoryForServer(t *testing.T, host string) *ClientFactory {
+	t.Helper()
+	cs, err := kubernetes.NewForConfig(&rest.Config{Host: host})
+	require.NoError(t, err)
+	return &ClientFactory{name: "test", clientSet: cs}
+}
+
+func TestProbeTreatsAnyHTTPStatusAsAlive(t *testing.T) {
+	// A 500 still means the connection is alive; Probe must not report an error.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	f := newFactoryForServer(t, srv.URL)
+	assert.NoError(t, f.Probe(context.Background()))
+}
+
+func TestProbeHealthyOn200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	f := newFactoryForServer(t, srv.URL)
+	assert.NoError(t, f.Probe(context.Background()))
+}
+
+func TestProbeFailsOnTransportError(t *testing.T) {
+	// Point at a closed server so no HTTP status is ever received.
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+
+	f := newFactoryForServer(t, url)
+	assert.Error(t, f.Probe(context.Background()))
+}
+
+func TestProbeNoClient(t *testing.T) {
+	f := &ClientFactory{name: "test"}
+	assert.Error(t, f.Probe(context.Background()))
+}

--- a/SaFE/job-manager/pkg/syncer/cluster_client_sets.go
+++ b/SaFE/job-manager/pkg/syncer/cluster_client_sets.go
@@ -7,9 +7,12 @@ package syncer
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"strconv"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -179,12 +182,45 @@ func (r *ClusterClientSets) addResourceTemplate(gvk schema.GroupVersionKind) err
 		return err
 	}
 
+	// Surface reflector watch failures with cluster+gvk context. Data-plane
+	// informers run outside the manager cache and are otherwise unmonitored, so a
+	// watch that keeps failing (e.g. after an apiserver/node restart) would starve
+	// the syncer silently. Must be set before the informer is started.
+	if err = informer.Informer().SetWatchErrorHandler(r.watchErrorHandler(gvk)); err != nil {
+		klog.ErrorS(err, "failed to set watch error handler for resource informer",
+			"cluster", r.name, "gvk", gvk)
+		return err
+	}
+
 	if r.resourceInformers.Add(gvk.String(), informer) == nil {
 		informer.start()
 		klog.Infof("start resource syncer, cluster: %s, gvr: %s, kind: %s",
 			r.name, mapper.Resource.String(), gvk.Kind)
 	}
 	return nil
+}
+
+// watchErrorHandler returns a reflector watch-error callback that classifies the
+// failure to keep logs actionable: an expired resourceVersion is a routine
+// relist, a normal EOF is a routine watch close, and everything else is a real
+// watch failure worth an error line (tagged with cluster+gvk to pinpoint which
+// data-plane informer is unhealthy).
+func (r *ClusterClientSets) watchErrorHandler(gvk schema.GroupVersionKind) cache.WatchErrorHandler {
+	return func(_ *cache.Reflector, err error) {
+		switch {
+		case err == nil, errors.Is(err, io.EOF):
+			return
+		case apierrors.IsResourceExpired(err):
+			klog.V(4).InfoS("resource informer watch expired, relisting",
+				"cluster", r.name, "gvk", gvk.String())
+		case errors.Is(err, io.ErrUnexpectedEOF):
+			klog.V(1).InfoS("resource informer watch closed with unexpected EOF",
+				"cluster", r.name, "gvk", gvk.String())
+		default:
+			klog.ErrorS(err, "resource informer watch failed",
+				"cluster", r.name, "gvk", gvk.String())
+		}
+	}
 }
 
 // handleResource processes resource events (add, update, delete).

--- a/SaFE/job-manager/pkg/syncer/cluster_client_sets.go
+++ b/SaFE/job-manager/pkg/syncer/cluster_client_sets.go
@@ -284,6 +284,11 @@ func (r *ClusterClientSets) delResourceTemplate(gvk schema.GroupVersionKind) {
 // it implements the interface of commonutils.Object.
 func (r *ClusterClientSets) Release() error {
 	r.resourceInformers.Clear()
+	// Release the underlying factory too, otherwise its built-in health watchdog
+	// goroutine (started in NewClientFactory) leaks on every rebuild/delete.
+	if r.dataClientFactory != nil {
+		return r.dataClientFactory.Release()
+	}
 	return nil
 }
 

--- a/SaFE/job-manager/pkg/syncer/cluster_client_sets_test.go
+++ b/SaFE/job-manager/pkg/syncer/cluster_client_sets_test.go
@@ -14,7 +14,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
 	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
+	commonclient "github.com/AMD-AIG-AIMA/SAFE/common/pkg/k8sclient"
 	commonutils "github.com/AMD-AIG-AIMA/SAFE/common/pkg/utils"
 )
 
@@ -23,6 +26,20 @@ func newTestClientSets() *ClusterClientSets {
 		name:              "c1",
 		resourceInformers: commonutils.NewObjectManager(),
 	}
+}
+
+// TestClusterClientSetsReleaseReleasesFactory ensures Release delegates to the
+// underlying factory (so its health watchdog goroutine is stopped) and tolerates
+// a nil factory.
+func TestClusterClientSetsReleaseReleasesFactory(t *testing.T) {
+	// Nil factory: must not panic and returns nil.
+	assert.NilError(t, newTestClientSets().Release())
+
+	// With a factory present, Release delegates without error.
+	c := newTestClientSets()
+	c.dataClientFactory = commonclient.NewClientFactoryWithOnlyClient(
+		context.Background(), "c1", k8sfake.NewSimpleClientset())
+	assert.NilError(t, c.Release())
 }
 
 func TestClusterClientSetsGettersSetters(t *testing.T) {

--- a/SaFE/job-manager/pkg/syncer/syncer.go
+++ b/SaFE/job-manager/pkg/syncer/syncer.go
@@ -46,13 +46,12 @@ type SyncerReconciler struct {
 // serially while different objects fan out across workers.
 const syncerWorkers = 8
 
-// syncerHealthInterval is how often the watchdog checks each data-plane
-// cluster's client-factory validity. The connection health probing itself lives
-// in the shared ClientFactory (which flips validity on a wedged watch); this
-// loop only reacts to an invalid factory by rebuilding that cluster's informers,
-// since the syncer — unlike other modules — has no reconcile path that recreates
-// an existing-but-wedged cluster.
-const syncerHealthInterval = 30 * time.Second
+// The watchdog checks each data-plane cluster's client-factory validity on
+// common.DataPlaneHealthProbeInterval. The connection health probing itself
+// lives in the shared ClientFactory (which flips validity on a wedged watch);
+// this loop only reacts to an invalid factory by rebuilding that cluster's
+// informers, since the syncer — unlike other modules — has no reconcile path
+// that recreates an existing-but-wedged cluster.
 
 // resourceMessageKey identifies the k8s object a message is about. Messages with
 // the same key are serialized and coalesced by the KeyedController.
@@ -207,7 +206,7 @@ func (r *SyncerReconciler) start(ctx context.Context) error {
 // the affected cluster; a genuinely-down remote just keeps failing the rebuild
 // cheaply until it recovers, so there is no restart thrash.
 func (r *SyncerReconciler) runInformerWatchdog(ctx context.Context) {
-	go wait.UntilWithContext(ctx, r.checkClusterHealth, syncerHealthInterval)
+	go wait.UntilWithContext(ctx, r.checkClusterHealth, common.DataPlaneHealthProbeInterval)
 }
 
 // checkClusterHealth rebuilds any managed cluster whose client factory is

--- a/SaFE/job-manager/pkg/syncer/syncer.go
+++ b/SaFE/job-manager/pkg/syncer/syncer.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	ctrlruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -45,6 +46,14 @@ type SyncerReconciler struct {
 // serially while different objects fan out across workers.
 const syncerWorkers = 8
 
+// syncerHealthInterval is how often the watchdog checks each data-plane
+// cluster's client-factory validity. The connection health probing itself lives
+// in the shared ClientFactory (which flips validity on a wedged watch); this
+// loop only reacts to an invalid factory by rebuilding that cluster's informers,
+// since the syncer — unlike other modules — has no reconcile path that recreates
+// an existing-but-wedged cluster.
+const syncerHealthInterval = 30 * time.Second
+
 // resourceMessageKey identifies the k8s object a message is about. Messages with
 // the same key are serialized and coalesced by the KeyedController.
 func resourceMessageKey(m *resourceMessage) string {
@@ -78,6 +87,7 @@ func SetupSyncerController(ctx context.Context, mgr manager.Manager) error {
 	if err := r.start(ctx); err != nil {
 		return err
 	}
+	r.runInformerWatchdog(ctx)
 
 	err := ctrlruntime.NewControllerManagedBy(mgr).
 		For(&v1.Cluster{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
@@ -188,6 +198,60 @@ func (r *SyncerReconciler) start(ctx context.Context) error {
 		r.Run(ctx)
 	}
 	return nil
+}
+
+// runInformerWatchdog starts a background loop that rebuilds a cluster's
+// informers once the shared ClientFactory has flipped itself invalid (its
+// built-in health probe detects a wedged watch). This lets a silently starved
+// syncer self-heal without restarting the whole process. Rebuild targets only
+// the affected cluster; a genuinely-down remote just keeps failing the rebuild
+// cheaply until it recovers, so there is no restart thrash.
+func (r *SyncerReconciler) runInformerWatchdog(ctx context.Context) {
+	go wait.UntilWithContext(ctx, r.checkClusterHealth, syncerHealthInterval)
+}
+
+// checkClusterHealth rebuilds any managed cluster whose client factory is
+// invalid. Validity is driven by ClientFactory's own connection probe, so this
+// loop stays purely reactive.
+func (r *SyncerReconciler) checkClusterHealth(ctx context.Context) {
+	keys, objs := r.clusterClientSets.GetAll()
+	for i, name := range keys {
+		clientSets, ok := objs[i].(*ClusterClientSets)
+		if !ok {
+			continue
+		}
+		// Validity is not probed here: the shared ClientFactory runs its own
+		// background watchdog (runHealthWatchdog -> Probe) that flips validity on a
+		// wedged connection. This loop only consumes that result and reacts by
+		// rebuilding the affected cluster's informers.
+		factory := clientSets.ClientFactory()
+		if factory == nil || factory.IsValid() {
+			continue
+		}
+		klog.InfoS("rebuilding data-plane cluster informers: factory marked invalid",
+			"cluster", name, "reason", factory.GetInvalidReason())
+		if err := r.rebuildCluster(ctx, name); err != nil {
+			// The old (wedged) clientSets stay in place until a new one is built;
+			// the next tick retries.
+			klog.ErrorS(err, "failed to rebuild data-plane cluster informers", "cluster", name)
+			continue
+		}
+		klog.InfoS("rebuilt data-plane cluster informers", "cluster", name)
+	}
+}
+
+// rebuildCluster re-fetches the Cluster and rebuilds its client sets/informers.
+// handle() replaces the entry via AddOrReplace, which releases the old informers.
+func (r *SyncerReconciler) rebuildCluster(ctx context.Context, name string) error {
+	c := new(v1.Cluster)
+	if err := r.Get(ctx, client.ObjectKey{Name: name}, c); err != nil {
+		if apierrors.IsNotFound(err) {
+			r.deleteClusterClientSet(name)
+			return nil
+		}
+		return err
+	}
+	return r.handle(ctx, c)
 }
 
 // Do process resource messages from cluster clientSets.

--- a/SaFE/job-manager/pkg/syncer/syncer.go
+++ b/SaFE/job-manager/pkg/syncer/syncer.go
@@ -7,6 +7,7 @@ package syncer
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -39,6 +40,11 @@ type SyncerReconciler struct {
 	clusterClientSets *commonutils.ObjectManager
 	dbClient          dbclient.Interface
 	*controller.KeyedController[*resourceMessage]
+
+	// rebuilding tracks clusters whose informers are being rebuilt so overlapping
+	// watchdog ticks do not launch duplicate concurrent rebuilds. Key: cluster
+	// name, value: struct{}.
+	rebuilding sync.Map
 }
 
 // syncerWorkers is the number of concurrent workers for the event queue. The
@@ -227,15 +233,24 @@ func (r *SyncerReconciler) checkClusterHealth(ctx context.Context) {
 		if factory == nil || factory.IsValid() {
 			continue
 		}
-		klog.InfoS("rebuilding data-plane cluster informers: factory marked invalid",
-			"cluster", name, "reason", factory.GetInvalidReason())
-		if err := r.rebuildCluster(ctx, name); err != nil {
-			// The old (wedged) clientSets stay in place until a new one is built;
-			// the next tick retries.
-			klog.ErrorS(err, "failed to rebuild data-plane cluster informers", "cluster", name)
+		// Skip clusters already being rebuilt so overlapping ticks don't stack; the
+		// rebuild runs off this loop because handle() does network I/O and informer
+		// setup that could otherwise stall checks for other clusters.
+		if _, inFlight := r.rebuilding.LoadOrStore(name, struct{}{}); inFlight {
 			continue
 		}
-		klog.InfoS("rebuilt data-plane cluster informers", "cluster", name)
+		klog.InfoS("rebuilding data-plane cluster informers: factory marked invalid",
+			"cluster", name, "reason", factory.GetInvalidReason())
+		go func(name string) {
+			defer r.rebuilding.Delete(name)
+			if err := r.rebuildCluster(ctx, name); err != nil {
+				// The old (wedged) clientSets stay in place until a new one is built;
+				// the next tick retries.
+				klog.ErrorS(err, "failed to rebuild data-plane cluster informers", "cluster", name)
+				return
+			}
+			klog.InfoS("rebuilt data-plane cluster informers", "cluster", name)
+		}(name)
 	}
 }
 

--- a/SaFE/resource-manager/pkg/resource/cluster_controller.go
+++ b/SaFE/resource-manager/pkg/resource/cluster_controller.go
@@ -425,7 +425,17 @@ func (r *ClusterReconciler) guaranteeClientFactory(ctx context.Context, cluster 
 	if !cluster.IsReady() || r.clientManager.Has(cluster.Name) {
 		return nil
 	}
-	endpoint, err := commoncluster.GetEndpoint(ctx, r.Client, cluster)
+	return createClientFactory(ctx, r.Client, r.clientManager, cluster)
+}
+
+// createClientFactory builds a data-plane client factory (informer-enabled) for
+// the cluster and stores it via AddOrReplace, which atomically releases any
+// existing entry. Shared by guaranteeClientFactory (initial setup) and the node
+// informer watchdog (rebuild on a wedged connection); on failure the previous
+// factory is left intact so the caller can retry.
+func createClientFactory(ctx context.Context, cli client.Client,
+	clientManager *commonutils.ObjectManager, cluster *v1.Cluster) error {
+	endpoint, err := commoncluster.GetEndpoint(ctx, cli, cluster)
 	if err != nil {
 		return err
 	}
@@ -435,7 +445,7 @@ func (r *ClusterReconciler) guaranteeClientFactory(ctx context.Context, cluster 
 	if err != nil {
 		return err
 	}
-	r.clientManager.AddOrReplace(cluster.Name, k8sClients)
+	clientManager.AddOrReplace(cluster.Name, k8sClients)
 	klog.Infof("add cluster %s informer, endpoint: %s", cluster.Name, endpoint)
 	return nil
 }

--- a/SaFE/resource-manager/pkg/resource/node_k8s_controller.go
+++ b/SaFE/resource-manager/pkg/resource/node_k8s_controller.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -72,6 +73,15 @@ type NodeK8sReconciler struct {
 	clientManager *commonutils.ObjectManager
 	queue         NodeQueue
 	*commonctrl.Controller[*nodeQueueMessage]
+
+	// rebuildInFlight guards against overlapping rebuilds of the same cluster
+	// (startNodeInformer can block on cache sync for minutes). Key: cluster name.
+	rebuildInFlight sync.Map
+	// startFailed marks clusters whose node informer failed to (re)start, so the
+	// watchdog retries even though the factory connection itself is healthy
+	// (validity is driven by the /livez probe and cannot see a start failure).
+	// Key: cluster name.
+	startFailed sync.Map
 }
 
 // SetupNodeK8sController initializes and registers the NodeK8sReconciler with the controller manager.
@@ -116,31 +126,54 @@ func (r *NodeK8sReconciler) runFactoryWatchdog(ctx context.Context) {
 }
 
 // checkFactoryHealth rebuilds every managed cluster whose client factory is
-// invalid. The rebuild recreates the factory (new connection) and re-registers
-// the node informer on it.
+// invalid (connection wedged) or whose node informer previously failed to start.
+// The rebuild recreates the factory (new connection) and re-registers the node
+// informer on it, and runs off this loop so a slow rebuild does not stall checks
+// for other clusters.
 func (r *NodeK8sReconciler) checkFactoryHealth(ctx context.Context) {
 	keys, objs := r.clientManager.GetAll()
 	for i, name := range keys {
 		factory, ok := objs[i].(*commonclient.ClientFactory)
-		if !ok || factory.IsValid() {
+		if !ok {
 			continue
 		}
-		klog.InfoS("rebuilding data-plane node informer: factory marked invalid",
-			"cluster", name, "reason", factory.GetInvalidReason())
-		if err := r.rebuildNodeInformer(ctx, name); err != nil {
-			klog.ErrorS(err, "failed to rebuild data-plane node informer", "cluster", name)
+		_, retryStart := r.startFailed.Load(name)
+		if factory.IsValid() && !retryStart {
+			continue
 		}
+		// Skip clusters already being rebuilt so overlapping ticks don't stack;
+		// startNodeInformer can block on cache sync for minutes.
+		if _, inFlight := r.rebuildInFlight.LoadOrStore(name, struct{}{}); inFlight {
+			continue
+		}
+		klog.InfoS("rebuilding data-plane node informer",
+			"cluster", name, "valid", factory.IsValid(), "reason", factory.GetInvalidReason())
+		go func(name string) {
+			defer r.rebuildInFlight.Delete(name)
+			if err := r.rebuildNodeInformer(ctx, name); err != nil {
+				// Remember the failure so the next tick retries even if the factory
+				// connection probes healthy (a start failure is invisible to /livez).
+				r.startFailed.Store(name, struct{}{})
+				klog.ErrorS(err, "failed to rebuild data-plane node informer", "cluster", name)
+				return
+			}
+			r.startFailed.Delete(name)
+			klog.InfoS("rebuilt data-plane node informer", "cluster", name)
+		}(name)
 	}
 }
 
 // rebuildNodeInformer recreates the client factory for the cluster and restarts
 // its node informer. createClientFactory's AddOrReplace atomically releases the
-// old (wedged) factory; on failure the old one is kept so the next tick retries.
+// old factory; recreating on every attempt also yields a fresh informer, so a
+// retry never double-registers the event handler. Runs synchronously inside the
+// watchdog's per-cluster goroutine, so its cache-sync wait is acceptable.
 func (r *NodeK8sReconciler) rebuildNodeInformer(ctx context.Context, name string) error {
 	cluster := new(v1.Cluster)
 	if err := r.Get(ctx, client.ObjectKey{Name: name}, cluster); err != nil {
 		if apierrors.IsNotFound(err) {
 			_ = r.clientManager.Delete(name)
+			r.startFailed.Delete(name)
 			return nil
 		}
 		return err
@@ -151,15 +184,7 @@ func (r *NodeK8sReconciler) rebuildNodeInformer(ctx context.Context, name string
 	if err := createClientFactory(ctx, r.Client, r.clientManager, cluster); err != nil {
 		return err
 	}
-	// startNodeInformer waits for cache sync (up to minutes); run it off the
-	// watchdog goroutine so one cluster does not stall the others. The freshly
-	// created factory is already valid, so the next tick will not re-enter here.
-	go func() {
-		if err := r.startNodeInformer(cluster); err != nil {
-			klog.ErrorS(err, "failed to start node informer during rebuild", "cluster", name)
-		}
-	}()
-	return nil
+	return r.startNodeInformer(cluster)
 }
 
 // relevantChangePredicate defines which Cluster changes should trigger node informer initialization.

--- a/SaFE/resource-manager/pkg/resource/node_k8s_controller.go
+++ b/SaFE/resource-manager/pkg/resource/node_k8s_controller.go
@@ -12,8 +12,10 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
@@ -92,6 +94,7 @@ func SetupNodeK8sController(ctx context.Context, mgr manager.Manager) error {
 	if err = r.start(ctx); err != nil {
 		return err
 	}
+	r.runFactoryWatchdog(ctx)
 	err = ctrlruntime.NewControllerManagedBy(mgr).
 		For(&v1.Cluster{}, builder.WithPredicates(r.relevantChangePredicate())).
 		Complete(r)
@@ -99,6 +102,66 @@ func SetupNodeK8sController(ctx context.Context, mgr manager.Manager) error {
 		return err
 	}
 	klog.Infof("Setup K8sNode Controller successfully")
+	return nil
+}
+
+// nodeInformerHealthInterval is how often the watchdog checks each data-plane
+// factory's validity and rebuilds a wedged node informer.
+const nodeInformerHealthInterval = 30 * time.Second
+
+// runFactoryWatchdog starts a loop that rebuilds a cluster's client factory and
+// node informer once the shared ClientFactory's built-in probe has flipped it
+// invalid. This lets a silently wedged node watch (which emits no watch error)
+// self-heal without a process restart. Validity is set by ClientFactory itself;
+// this loop only reacts to it.
+func (r *NodeK8sReconciler) runFactoryWatchdog(ctx context.Context) {
+	go wait.UntilWithContext(ctx, r.checkFactoryHealth, nodeInformerHealthInterval)
+}
+
+// checkFactoryHealth rebuilds every managed cluster whose client factory is
+// invalid. The rebuild recreates the factory (new connection) and re-registers
+// the node informer on it.
+func (r *NodeK8sReconciler) checkFactoryHealth(ctx context.Context) {
+	keys, objs := r.clientManager.GetAll()
+	for i, name := range keys {
+		factory, ok := objs[i].(*commonclient.ClientFactory)
+		if !ok || factory.IsValid() {
+			continue
+		}
+		klog.InfoS("rebuilding data-plane node informer: factory marked invalid",
+			"cluster", name, "reason", factory.GetInvalidReason())
+		if err := r.rebuildNodeInformer(ctx, name); err != nil {
+			klog.ErrorS(err, "failed to rebuild data-plane node informer", "cluster", name)
+		}
+	}
+}
+
+// rebuildNodeInformer recreates the client factory for the cluster and restarts
+// its node informer. createClientFactory's AddOrReplace atomically releases the
+// old (wedged) factory; on failure the old one is kept so the next tick retries.
+func (r *NodeK8sReconciler) rebuildNodeInformer(ctx context.Context, name string) error {
+	cluster := new(v1.Cluster)
+	if err := r.Get(ctx, client.ObjectKey{Name: name}, cluster); err != nil {
+		if apierrors.IsNotFound(err) {
+			_ = r.clientManager.Delete(name)
+			return nil
+		}
+		return err
+	}
+	if !cluster.IsReady() {
+		return nil
+	}
+	if err := createClientFactory(ctx, r.Client, r.clientManager, cluster); err != nil {
+		return err
+	}
+	// startNodeInformer waits for cache sync (up to minutes); run it off the
+	// watchdog goroutine so one cluster does not stall the others. The freshly
+	// created factory is already valid, so the next tick will not re-enter here.
+	go func() {
+		if err := r.startNodeInformer(cluster); err != nil {
+			klog.ErrorS(err, "failed to start node informer during rebuild", "cluster", name)
+		}
+	}()
 	return nil
 }
 

--- a/SaFE/resource-manager/pkg/resource/node_k8s_controller.go
+++ b/SaFE/resource-manager/pkg/resource/node_k8s_controller.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
+	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/common"
 	commonctrl "github.com/AMD-AIG-AIMA/SAFE/common/pkg/controller"
 	commonerrors "github.com/AMD-AIG-AIMA/SAFE/common/pkg/errors"
 	commonfaults "github.com/AMD-AIG-AIMA/SAFE/common/pkg/faults"
@@ -105,17 +106,13 @@ func SetupNodeK8sController(ctx context.Context, mgr manager.Manager) error {
 	return nil
 }
 
-// nodeInformerHealthInterval is how often the watchdog checks each data-plane
-// factory's validity and rebuilds a wedged node informer.
-const nodeInformerHealthInterval = 30 * time.Second
-
 // runFactoryWatchdog starts a loop that rebuilds a cluster's client factory and
 // node informer once the shared ClientFactory's built-in probe has flipped it
 // invalid. This lets a silently wedged node watch (which emits no watch error)
 // self-heal without a process restart. Validity is set by ClientFactory itself;
 // this loop only reacts to it.
 func (r *NodeK8sReconciler) runFactoryWatchdog(ctx context.Context) {
-	go wait.UntilWithContext(ctx, r.checkFactoryHealth, nodeInformerHealthInterval)
+	go wait.UntilWithContext(ctx, r.checkFactoryHealth, common.DataPlaneHealthProbeInterval)
 }
 
 // checkFactoryHealth rebuilds every managed cluster whose client factory is


### PR DESCRIPTION
…data-plane client connections

Data-plane informers/clients could silently wedge (e.g. half-open watch after an apiserver/node restart) with no watch error emitted, starving the syncer/controllers until a manual process restart.

- common/ClientFactory: add activity-independent Probe (/livez, any HTTP status = alive) and a built-in health watchdog that flips validity on a wedged connection; guard valid/invalidReason with a mutex.
- job-manager syncer: watchdog rebuilds a cluster's informers when its factory is marked invalid; add SetWatchErrorHandler for visibility.
- resource-manager: rebuild node informer + factory on invalid; share createClientFactory helper.
- apiserver: informer-less direct-call factories self-probe and rebuild on a persistently broken connection (endpoint change / cert rotation).