### PR TITLE
fix(common): HA failover dialer + TCP keepalive for data-plane clients

### DIFF
--- a/SaFE/apiserver/pkg/controllers/cluster_controller.go
+++ b/SaFE/apiserver/pkg/controllers/cluster_controller.go
@@ -121,13 +121,13 @@ func (r *ClusterReconciler) addClientFactory(ctx context.Context, cluster *v1.Cl
 	if clientManager.Has(cluster.Name) {
 		return nil
 	}
-	endpoint, err := commoncluster.GetEndpoint(ctx, r.Client, cluster)
+	endpoints, err := commoncluster.GetEndpoints(ctx, r.Client, cluster)
 	if err != nil {
 		return err
 	}
 
 	controlPlane := &cluster.Status.ControlPlaneStatus
-	k8sClientFactory, err := commonclient.NewClientFactory(ctx, cluster.Name, endpoint,
+	k8sClientFactory, err := commonclient.NewClientFactory(ctx, cluster.Name, endpoints,
 		controlPlane.CertData, controlPlane.KeyData, controlPlane.CAData, commonclient.DisableInformer)
 	if err != nil {
 		return err

--- a/SaFE/common/pkg/cluster/cluster.go
+++ b/SaFE/common/pkg/cluster/cluster.go
@@ -16,25 +16,37 @@ import (
 	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/common"
 )
 
-// GetEndpoint retrieve the endpoint address of the given cluster.
+// GetEndpoint retrieve the primary endpoint address of the given cluster.
 // It first tries to get the endpoint from the Kubernetes Service associated with the cluster.
 // If the Service is not found or has no ports, it falls back to using the endpoint from the cluster status.
 // Returns an error if the cluster is nil, not ready, or no valid endpoint can be found.
 func GetEndpoint(ctx context.Context, cli client.Client, cluster *v1.Cluster) (string, error) {
+	endpoints, err := GetEndpoints(ctx, cli, cluster)
+	if err != nil {
+		return "", err
+	}
+	return endpoints[0], nil
+}
+
+// GetEndpoints returns all candidate apiserver endpoints for the cluster, with
+// the primary first. When a per-cluster Service exists its ClusterIP is used (a
+// single, kube-proxy load-balanced address). Otherwise every control-plane
+// endpoint is returned so the client can fail over across the HA members
+// instead of pinning to a single (possibly dead) node.
+func GetEndpoints(ctx context.Context, cli client.Client, cluster *v1.Cluster) ([]string, error) {
 	if cluster == nil || !cluster.IsReady() {
-		return "", fmt.Errorf("cluster is not ready")
+		return nil, fmt.Errorf("cluster is not ready")
 	}
 	service := &corev1.Service{}
 	err := cli.Get(ctx, client.ObjectKey{Name: cluster.Name, Namespace: common.PrimusSafeNamespace}, service)
 	if err == nil {
 		if len(service.Spec.Ports) == 0 {
-			return "", fmt.Errorf("service ports are empty")
+			return nil, fmt.Errorf("service ports are empty")
 		}
-		// return fmt.Sprintf("https://%s.%s.svc", clusterName, common.PrimusSafeNamespace), nil
-		return fmt.Sprintf("%s:%d", service.Spec.ClusterIP, service.Spec.Ports[0].Port), nil
+		return []string{fmt.Sprintf("%s:%d", service.Spec.ClusterIP, service.Spec.Ports[0].Port)}, nil
 	}
 	if len(cluster.Status.ControlPlaneStatus.Endpoints) == 0 {
-		return "", fmt.Errorf("either the Service address or the Endpoint is empty")
+		return nil, fmt.Errorf("either the Service address or the Endpoint is empty")
 	}
-	return cluster.Status.ControlPlaneStatus.Endpoints[0], nil
+	return cluster.Status.ControlPlaneStatus.Endpoints, nil
 }

--- a/SaFE/common/pkg/k8sclient/client.go
+++ b/SaFE/common/pkg/k8sclient/client.go
@@ -6,7 +6,11 @@
 package k8sclient
 
 import (
+	"context"
 	"fmt"
+	"net"
+	"strings"
+	"time"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -14,6 +18,16 @@ import (
 
 	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/common"
 	"github.com/AMD-AIG-AIMA/SAFE/utils/pkg/stringutil"
+)
+
+const (
+	// dialTimeout bounds a single TCP dial so a dead endpoint fails fast and
+	// failover can move on to the next one.
+	dialTimeout = 10 * time.Second
+	// dialKeepAlive makes the kernel probe idle connections, so a half-open
+	// connection (peer rebooted without sending FIN/RST) is detected and torn
+	// down, which unblocks the informer's watch and triggers a reconnect.
+	dialKeepAlive = 30 * time.Second
 )
 
 // NewClientSetInCluster creates and returns a new ClientSetInCluster instance.
@@ -26,10 +40,18 @@ func NewClientSetInCluster() (kubernetes.Interface, *rest.Config, error) {
 	return cli, restConfig, err
 }
 
-// NewClientSet creates and returns a new ClientSet instance.
+// NewClientSet creates and returns a new ClientSet instance for a single endpoint.
 func NewClientSet(endpoint, certData, keyData, caData string,
 	insecure bool) (kubernetes.Interface, *rest.Config, error) {
-	restConfig, err := createRestConfig(endpoint, certData, keyData, caData, insecure)
+	return NewClientSetWithEndpoints([]string{endpoint}, certData, keyData, caData, insecure)
+}
+
+// NewClientSetWithEndpoints creates a ClientSet whose transport dials the given
+// HA apiserver endpoints with keepalive and failover: the first endpoint is the
+// authority (Host), and dials fail over to the others when it is unreachable.
+func NewClientSetWithEndpoints(endpoints []string, certData, keyData, caData string,
+	insecure bool) (kubernetes.Interface, *rest.Config, error) {
+	restConfig, err := createRestConfig(endpoints, certData, keyData, caData, insecure)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -54,14 +76,15 @@ func GetRestConfigInCluster() (*rest.Config, error) {
 }
 
 // createRestConfig creates a REST configuration with provided TLS parameters.
-func createRestConfig(endpoint, certData, keyData, caData string, insecure bool) (*rest.Config, error) {
+// endpoints[0] is the authority; extra endpoints are failover dial targets.
+func createRestConfig(endpoints []string, certData, keyData, caData string, insecure bool) (*rest.Config, error) {
 	cert := stringutil.Base64Decode(certData)
 	key := stringutil.Base64Decode(keyData)
-	if endpoint == "" || cert == "" || key == "" {
+	if len(endpoints) == 0 || endpoints[0] == "" || cert == "" || key == "" {
 		return nil, fmt.Errorf("invalid input")
 	}
 	cfg := &rest.Config{
-		Host: endpoint,
+		Host: endpoints[0],
 		TLSClientConfig: rest.TLSClientConfig{
 			Insecure: insecure,
 			KeyData:  []byte(key),
@@ -69,6 +92,7 @@ func createRestConfig(endpoint, certData, keyData, caData string, insecure bool)
 		},
 		QPS:   common.DefaultQPS,
 		Burst: common.DefaultBurst,
+		Dial:  clusterDialer(endpoints),
 	}
 	if !insecure {
 		ca := stringutil.Base64Decode(caData)
@@ -78,4 +102,46 @@ func createRestConfig(endpoint, certData, keyData, caData string, insecure bool)
 		cfg.TLSClientConfig.CAData = []byte(ca)
 	}
 	return cfg, nil
+}
+
+// clusterDialer returns a DialContext that (1) enables TCP keepalive so a
+// half-open connection to a rebooted apiserver is detected and the watch
+// reconnects, and (2) fails over across all known HA endpoints so a reconnect
+// lands on a healthy apiserver instead of pinning to a single (possibly dead)
+// node. Safe with InsecureSkipVerify clients: dialing any HA member under the
+// same authority needs no per-target SNI/SAN.
+func clusterDialer(endpoints []string) func(context.Context, string, string) (net.Conn, error) {
+	base := &net.Dialer{Timeout: dialTimeout, KeepAlive: dialKeepAlive}
+	hostPorts := make([]string, 0, len(endpoints))
+	for _, ep := range endpoints {
+		if hp := hostPortFromEndpoint(ep); hp != "" {
+			hostPorts = append(hostPorts, hp)
+		}
+	}
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		if len(hostPorts) <= 1 {
+			return base.DialContext(ctx, network, addr)
+		}
+		// Rotate the start so a persistently dead endpoint is not always tried
+		// first (which would waste a dial timeout on every reconnect).
+		start := int(time.Now().UnixNano()%int64(len(hostPorts)) + int64(len(hostPorts))) % len(hostPorts)
+		var lastErr error
+		for i := 0; i < len(hostPorts); i++ {
+			cand := hostPorts[(start+i)%len(hostPorts)]
+			conn, err := base.DialContext(ctx, network, cand)
+			if err == nil {
+				return conn, nil
+			}
+			lastErr = err
+		}
+		return nil, lastErr
+	}
+}
+
+// hostPortFromEndpoint strips the URL scheme/trailing slash from an endpoint,
+// leaving a host:port suitable for dialing.
+func hostPortFromEndpoint(endpoint string) string {
+	endpoint = strings.TrimPrefix(endpoint, "https://")
+	endpoint = strings.TrimPrefix(endpoint, "http://")
+	return strings.TrimSuffix(endpoint, "/")
 }

--- a/SaFE/common/pkg/k8sclient/client_factory.go
+++ b/SaFE/common/pkg/k8sclient/client_factory.go
@@ -53,11 +53,13 @@ type ClientFactory struct {
 	invalidReason string
 }
 
-// NewClientFactory creates a new client factory.
-func NewClientFactory(ctx context.Context, name, endpoint, certData,
+// NewClientFactory creates a new client factory. endpoints[0] is the primary
+// apiserver address; any additional entries are used as keepalive/failover dial
+// targets so the factory's informers survive a single HA member going down.
+func NewClientFactory(ctx context.Context, name string, endpoints []string, certData,
 	keyData, caData string, informerType InformerType,
 ) (*ClientFactory, error) {
-	clientSet, restCfg, err := NewClientSet(endpoint, certData, keyData, caData, true)
+	clientSet, restCfg, err := NewClientSetWithEndpoints(endpoints, certData, keyData, caData, true)
 	if err != nil {
 		return nil, err
 	}

--- a/SaFE/common/pkg/k8sclient/client_test.go
+++ b/SaFE/common/pkg/k8sclient/client_test.go
@@ -7,9 +7,11 @@ package k8sclient
 
 import (
 	"context"
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
 )
@@ -34,4 +36,62 @@ func TestNewClientSetWithRestConfig(t *testing.T) {
 	cs, err := NewClientSetWithRestConfig(&rest.Config{Host: "http://127.0.0.1:60999"})
 	assert.NoError(t, err)
 	assert.NotNil(t, cs)
+}
+
+func TestHostPortFromEndpoint(t *testing.T) {
+	assert.Equal(t, "10.0.0.1:6443", hostPortFromEndpoint("https://10.0.0.1:6443"))
+	assert.Equal(t, "10.0.0.1:6443", hostPortFromEndpoint("http://10.0.0.1:6443/"))
+	assert.Equal(t, "10.0.0.1:6443", hostPortFromEndpoint("10.0.0.1:6443"))
+}
+
+// TestClusterDialerFailsOver verifies the dialer reaches a healthy endpoint even
+// when another endpoint is dead, regardless of the rotated start position.
+func TestClusterDialerFailsOver(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+	go func() {
+		for {
+			c, e := ln.Accept()
+			if e != nil {
+				return
+			}
+			_ = c.Close()
+		}
+	}()
+	healthy := ln.Addr().String()
+
+	// A closed port gives a fast connection-refused, i.e. a "dead" endpoint.
+	tmp, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	dead := tmp.Addr().String()
+	require.NoError(t, tmp.Close())
+
+	dial := clusterDialer([]string{"https://" + dead, "https://" + healthy})
+	for i := 0; i < 8; i++ {
+		conn, err := dial(context.Background(), "tcp", dead)
+		require.NoError(t, err, "dialer should fail over to the healthy endpoint")
+		_ = conn.Close()
+	}
+}
+
+// TestClusterDialerSingleEndpoint verifies a single-endpoint dialer just dials
+// the requested address (keepalive path, no failover).
+func TestClusterDialerSingleEndpoint(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+	go func() {
+		for {
+			c, e := ln.Accept()
+			if e != nil {
+				return
+			}
+			_ = c.Close()
+		}
+	}()
+	dial := clusterDialer([]string{"https://" + ln.Addr().String()})
+	conn, err := dial(context.Background(), "tcp", ln.Addr().String())
+	require.NoError(t, err)
+	_ = conn.Close()
 }

--- a/SaFE/job-manager/pkg/syncer/cluster_client_sets.go
+++ b/SaFE/job-manager/pkg/syncer/cluster_client_sets.go
@@ -82,16 +82,16 @@ func newClusterClientSets(ctx context.Context, cluster *v1.Cluster,
 	if controlPlane == nil {
 		return nil, fmt.Errorf("controlPlane is empty")
 	}
-	endpoint, err := commoncluster.GetEndpoint(ctx, adminClient, cluster)
+	endpoints, err := commoncluster.GetEndpoints(ctx, adminClient, cluster)
 	if err != nil {
 		return nil, err
 	}
-	clientFactory, err := commonclient.NewClientFactory(ctx, cluster.Name, endpoint,
+	clientFactory, err := commonclient.NewClientFactory(ctx, cluster.Name, endpoints,
 		controlPlane.CertData, controlPlane.KeyData, controlPlane.CAData, commonclient.EnableDynamicInformer)
 	if err != nil {
 		return nil, err
 	}
-	klog.Infof("create cluster client sets, cluster: %s, endpoint: %s", cluster.Name, endpoint)
+	klog.Infof("create cluster client sets, cluster: %s, endpoints: %v", cluster.Name, endpoints)
 	return &ClusterClientSets{
 		ctx:               ctx,
 		name:              cluster.Name,

--- a/SaFE/resource-manager/pkg/resource/cluster_controller.go
+++ b/SaFE/resource-manager/pkg/resource/cluster_controller.go
@@ -425,18 +425,18 @@ func (r *ClusterReconciler) guaranteeClientFactory(ctx context.Context, cluster 
 	if !cluster.IsReady() || r.clientManager.Has(cluster.Name) {
 		return nil
 	}
-	endpoint, err := commoncluster.GetEndpoint(ctx, r.Client, cluster)
+	endpoints, err := commoncluster.GetEndpoints(ctx, r.Client, cluster)
 	if err != nil {
 		return err
 	}
 	controlPlane := &cluster.Status.ControlPlaneStatus
-	k8sClients, err := commonclient.NewClientFactory(ctx, cluster.Name, endpoint,
+	k8sClients, err := commonclient.NewClientFactory(ctx, cluster.Name, endpoints,
 		controlPlane.CertData, controlPlane.KeyData, controlPlane.CAData, commonclient.EnableInformer)
 	if err != nil {
 		return err
 	}
 	r.clientManager.AddOrReplace(cluster.Name, k8sClients)
-	klog.Infof("add cluster %s informer, endpoint: %s", cluster.Name, endpoint)
+	klog.Infof("add cluster %s informer, endpoints: %v", cluster.Name, endpoints)
 	return nil
 }
 


### PR DESCRIPTION
Data-plane client factories pinned to a single apiserver (Endpoints[0]), so when that control-plane node was rebooted the informer's watch went half-open and never reconnected nor failed over to the other HA members, freezing workload status sync until job-manager was restarted.

- clusterDialer: TCP keepalive so a half-open connection is detected and the watch reconnects, plus rotation-based failover across all HA endpoints so a reconnect lands on a healthy apiserver. Safe with InsecureSkipVerify clients.
- GetEndpoints returns all control-plane endpoints (Service ClusterIP still preferred when present); GetEndpoint delegates to the first.
- NewClientFactory / NewClientSetWithEndpoints take the endpoint list; syncer, resource-manager and apiserver pass the full HA list.