### PR TITLE
fix(webhook): sync node workspace label with spec.workspace to prevent stuck bind/unbind

### DIFF
--- a/SaFE/webhooks/pkg/node2_test.go
+++ b/SaFE/webhooks/pkg/node2_test.go
@@ -49,6 +49,29 @@ func TestNodeMutateByNodeFlavorNoGpu(t *testing.T) {
 	assert.Assert(t, v1.HasAnnotation(node, v1.NodeDiskAnnotation))
 }
 
+// TestNodeMutateLabelsWorkspaceSync keeps primus-safe.workspace.id aligned with spec.workspace.
+func TestNodeMutateLabelsWorkspaceSync(t *testing.T) {
+	scheme := newScheme(t)
+	m := &NodeMutator{Client: fake.NewClientBuilder().WithScheme(scheme).Build()}
+
+	bind := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+		Spec:       v1.NodeSpec{Workspace: pointer.String("ws1")},
+	}
+	assert.Assert(t, m.mutateLabels(context.Background(), bind))
+	assert.Equal(t, v1.GetWorkspaceId(bind), "ws1")
+
+	unbind := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "n1",
+			Labels: map[string]string{v1.WorkspaceIdLabel: "default-maintenance"},
+		},
+		Spec: v1.NodeSpec{Workspace: pointer.String("")},
+	}
+	assert.Assert(t, m.mutateLabels(context.Background(), unbind))
+	assert.Equal(t, v1.GetWorkspaceId(unbind), "")
+}
+
 // TestNodeMutateLabelsSubnetRemove covers subnet annotation removal branch.
 func TestNodeMutateLabelsSubnetRemove(t *testing.T) {
 	scheme := newScheme(t)

--- a/SaFE/webhooks/pkg/node_webhook.go
+++ b/SaFE/webhooks/pkg/node_webhook.go
@@ -176,7 +176,14 @@ func (m *NodeMutator) mutateLabels(ctx context.Context, node *v1.Node) bool {
 			isChanged = true
 		}
 	}
-	if v1.RemoveEmptyLabel(node, v1.WorkspaceIdLabel) {
+	// Keep the workspace label in sync with spec.workspace so the node's
+	// observed binding never drifts from its desired binding.
+	workspace := node.GetSpecWorkspace()
+	if workspace == "" {
+		if v1.RemoveLabel(node, v1.WorkspaceIdLabel) {
+			isChanged = true
+		}
+	} else if v1.SetLabel(node, v1.WorkspaceIdLabel, workspace) {
 		isChanged = true
 	}
 	if v1.RemoveEmptyLabel(node, v1.ClusterIdLabel) {


### PR DESCRIPTION
## Summary

Fixes a bug where binding or unbinding a node to/from a workspace can get permanently wedged. The UI surfaces this as:

```
Primus.00002: admission webhook "workspace.kb.io" denied the request: ... the node(<name>) belongs to workspace(). it can't be removed
```

The node may show the wrong workspace, or appear unbound even though a bind/unbind action is still pending.

## Root cause

I think currently,  the NodeReconciler reconciles that label onto the core/v1 Node (a copy used for scheduling) but never onto the Node CR itself — so the observed state the state machine actually watches never catches up to desired state, and bind/unbind wedge until you set the label by hand.

Nothing reconciles the **Primus Node's own** `primus-safe.workspace.id` label from `spec.workspace`.

During bind/unbind:
1. The apiserver sets a workspace `nodes.action` annotation.
2. The resource-manager sets `node.spec.workspace`.
3. The node controller syncs only the underlying core k8s Node label.

The node mutating webhook only removed the admin-Node label when its value was already empty and never set it from `spec.workspace`.

Once `spec.workspace` and the label drift apart:

- **Workspace validating webhook rejects retries:** a `remove` action requires `node.spec.workspace == workspace.Name`, but `spec.workspace` may already be empty while the stale label still points at the old workspace.
- **Resource-manager cannot self-heal:** `processWorkspace` is gated on an in-memory expectation that is only cleared when the node label (`GetWorkspaceId`) changes, not when `spec.workspace` changes.

This was observed in production on node `smc300x-ccs-aus-a15-19` when unbinding from the `maintenance` workspace and rebinding to `default`.

## Fix

In `NodeMutator.mutateLabels`, keep `primus-safe.workspace.id` aligned with `spec.workspace` on every node create/update:

- If `spec.workspace` is non-empty, set the label to that value.
- If `spec.workspace` is empty, remove the label.

This makes spec and label change atomically in the same admission request, preventing drift. It is also self-repairing for already-drifted nodes: the controller periodically patches the admin Node, which re-triggers this webhook and corrects the label on the next reconcile.

## Testing

- Added `TestNodeMutateLabelsWorkspaceSync` covering bind (set label) and unbind (remove stale label).
- Existing `TestNodeMutateLabelsRemoveEmpty` still passes.
- `cd SaFE/webhooks && go test ./pkg/...`
- `cd SaFE/webhooks && go build ./...`

## Notes

- Scope is intentionally limited to the workspace label only; cluster-id label behavior is unchanged.
- After deploying, already-drifted nodes should self-heal on the next controller patch without manual kubectl label intervention.
