### PR TITLE
fix(job-manager): retry informer setup and handle tombstone delete ev…

### DIFF
--- a/SaFE/job-manager/pkg/syncer/cluster_client_sets.go
+++ b/SaFE/job-manager/pkg/syncer/cluster_client_sets.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"sync"
 
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -51,6 +52,8 @@ type ClusterClientSets struct {
 	// Key is the GVK, value is the informer instance.
 	// it is controlled by resource template
 	resourceInformers *commonutils.ObjectManager
+	// guards addResourceTemplate / delResourceTemplate against concurrent setup.
+	templateMu sync.Mutex
 }
 
 // resourceInformer wraps a GenericInformer with context management for lifecycle control
@@ -160,6 +163,8 @@ func (r *ClusterClientSets) needsInformerRetry(rtList *v1.ResourceTemplateList) 
 
 // addResourceTemplate adds a resource template and creates corresponding informer.
 func (r *ClusterClientSets) addResourceTemplate(gvk schema.GroupVersionKind) error {
+	r.templateMu.Lock()
+	defer r.templateMu.Unlock()
 	if r.resourceInformers.Has(gvk.String()) {
 		return nil
 	}
@@ -276,6 +281,8 @@ func (r *ClusterClientSets) handleResource(_ context.Context, oldObj, newObj int
 
 // delResourceTemplate removes a resource template and its corresponding informer.
 func (r *ClusterClientSets) delResourceTemplate(gvk schema.GroupVersionKind) {
+	r.templateMu.Lock()
+	defer r.templateMu.Unlock()
 	if err := r.resourceInformers.Delete(gvk.String()); err != nil {
 		klog.ErrorS(err, "failed to delete resource informer", "gvk", gvk)
 	}

--- a/SaFE/job-manager/pkg/syncer/cluster_client_sets.go
+++ b/SaFE/job-manager/pkg/syncer/cluster_client_sets.go
@@ -137,6 +137,27 @@ func (r *ClusterClientSets) getResourceInformer(gvk schema.GroupVersionKind) *re
 	return informer
 }
 
+// informerCount returns the number of running resource informers.
+func (r *ClusterClientSets) informerCount() int {
+	return r.resourceInformers.Len()
+}
+
+// needsInformerRetry reports whether any required resource template informer is still missing.
+// Missing informers are retried periodically so CRDs installed after startup (e.g. Sandbox) can
+// be picked up without restarting job-manager.
+func (r *ClusterClientSets) needsInformerRetry(rtList *v1.ResourceTemplateList) bool {
+	if rtList == nil || len(rtList.Items) == 0 {
+		return false
+	}
+	for i := range rtList.Items {
+		gvk := rtList.Items[i].ToSchemaGVK()
+		if !r.resourceInformers.Has(gvk.String()) {
+			return true
+		}
+	}
+	return false
+}
+
 // addResourceTemplate adds a resource template and creates corresponding informer.
 func (r *ClusterClientSets) addResourceTemplate(gvk schema.GroupVersionKind) error {
 	if r.resourceInformers.Has(gvk.String()) {
@@ -147,8 +168,8 @@ func (r *ClusterClientSets) addResourceTemplate(gvk schema.GroupVersionKind) err
 	mapper, err := r.dataClientFactory.Mapper().RESTMapping(gvk.GroupKind(), gvk.Version)
 	if err != nil {
 		if apimeta.IsNoMatchError(err) {
-			// CRD is not installed on this cluster; skip silently (e.g. Sandbox on mgmt cluster).
-			klog.V(2).InfoS("skip resource template: CRD not installed on cluster",
+			// CRD is not installed yet; retry on the next maintain cycle in case it is added later.
+			klog.V(2).InfoS("resource template pending: CRD not installed on cluster",
 				"cluster", r.name, "gvk", gvk)
 			return nil
 		}
@@ -187,10 +208,27 @@ func (r *ClusterClientSets) addResourceTemplate(gvk schema.GroupVersionKind) err
 	return nil
 }
 
+// toUnstructured extracts an unstructured object from an informer event payload.
+// Relist-driven delete events arrive as cache.DeletedFinalStateUnknown tombstones.
+func toUnstructured(obj interface{}) (*unstructured.Unstructured, bool) {
+	if obj == nil {
+		return nil, false
+	}
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+	u, ok := obj.(*unstructured.Unstructured)
+	return u, ok
+}
+
 // handleResource processes resource events (add, update, delete).
 func (r *ClusterClientSets) handleResource(_ context.Context, oldObj, newObj interface{}, action string) {
-	newUnstructured, ok := newObj.(*unstructured.Unstructured)
+	newUnstructured, ok := toUnstructured(newObj)
 	if !ok {
+		if action == ResourceDel {
+			klog.InfoS("ignored delete event with unsupported object type",
+				"cluster", r.name, "type", fmt.Sprintf("%T", newObj))
+		}
 		return
 	}
 	msg := &resourceMessage{
@@ -225,7 +263,7 @@ func (r *ClusterClientSets) handleResource(_ context.Context, oldObj, newObj int
 			newUnstructured.GetNamespace(), newUnstructured.GetName(), newUnstructured.GetUID(),
 			msg.gvk.Kind, newUnstructured.GetGeneration(), msg.workloadId, msg.dispatchCount)
 	case ResourceDel:
-		if oldUnstructured, ok := oldObj.(*unstructured.Unstructured); ok {
+		if oldUnstructured, ok := toUnstructured(oldObj); ok {
 			klog.Infof("object: %s/%s is deleted, uid: %s, kind: %s, generation: %d, workload: %s, dispatch.cnt: %d",
 				oldUnstructured.GetNamespace(), oldUnstructured.GetName(), oldUnstructured.GetUID(),
 				msg.gvk.Kind, oldUnstructured.GetGeneration(), msg.workloadId, msg.dispatchCount)

--- a/SaFE/job-manager/pkg/syncer/cluster_client_sets_test.go
+++ b/SaFE/job-manager/pkg/syncer/cluster_client_sets_test.go
@@ -13,6 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
 
 	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
 	commonutils "github.com/AMD-AIG-AIMA/SAFE/common/pkg/utils"
@@ -71,6 +72,23 @@ func TestGetClusterClientSets(t *testing.T) {
 	assert.Equal(t, got.name, "c1")
 }
 
+func TestClusterClientSetsNeedsInformerRetry(t *testing.T) {
+	c := newTestClientSets()
+	rtList := &v1.ResourceTemplateList{
+		Items: []v1.ResourceTemplate{
+			{Spec: v1.ResourceTemplateSpec{
+				GroupVersionKind: v1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+			}},
+		},
+	}
+	assert.Equal(t, c.needsInformerRetry(rtList), true)
+}
+
+func TestClusterClientSetsInformerCount(t *testing.T) {
+	c := newTestClientSets()
+	assert.Equal(t, c.informerCount(), 0)
+}
+
 func TestHandleResourceWrongType(t *testing.T) {
 	called := false
 	c := &ClusterClientSets{
@@ -94,6 +112,34 @@ func TestHandleResourceNoWorkloadId(t *testing.T) {
 	// No workload-id label and no mesh label -> not a managed object, ignored.
 	c.handleResource(context.Background(), nil, u, ResourceAdd)
 	assert.Equal(t, called, false)
+}
+
+func TestToUnstructuredTombstone(t *testing.T) {
+	u := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	u.SetKind("Sandbox")
+	u.SetName("sb")
+	got, ok := toUnstructured(cache.DeletedFinalStateUnknown{Obj: u})
+	assert.Assert(t, ok)
+	assert.Equal(t, got.GetName(), "sb")
+}
+
+func TestHandleResourceDeleteTombstone(t *testing.T) {
+	var captured *resourceMessage
+	c := &ClusterClientSets{
+		name:    "cl",
+		handler: ResourceHandler(func(m *resourceMessage) { captured = m }),
+	}
+	u := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	u.SetKind("Sandbox")
+	u.SetName("sb")
+	u.SetNamespace("ws")
+	u.SetLabels(map[string]string{v1.WorkloadIdLabel: "w"})
+	tombstone := cache.DeletedFinalStateUnknown{Obj: u}
+	c.handleResource(context.Background(), tombstone, tombstone, ResourceDel)
+	assert.Assert(t, captured != nil)
+	assert.Equal(t, captured.action, ResourceDel)
+	assert.Equal(t, captured.workloadId, "w")
+	assert.Equal(t, captured.name, "sb")
 }
 
 func TestHandleResourceManaged(t *testing.T) {

--- a/SaFE/job-manager/pkg/syncer/syncer.go
+++ b/SaFE/job-manager/pkg/syncer/syncer.go
@@ -81,6 +81,9 @@ func SetupSyncerController(ctx context.Context, mgr manager.Manager) error {
 	if err := r.start(ctx); err != nil {
 		return err
 	}
+	if err := mgr.Add(&clusterClientSetsMaintainer{r: r}); err != nil {
+		return err
+	}
 
 	err := ctrlruntime.NewControllerManagedBy(mgr).
 		For(&v1.Cluster{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
@@ -179,6 +182,22 @@ func (r *SyncerReconciler) ensureClusterClientSets(ctx context.Context, cluster 
 	return false
 }
 
+// clusterClientSetsMaintainer retries data-plane informer setup on the elected leader only.
+type clusterClientSetsMaintainer struct {
+	r *SyncerReconciler
+}
+
+// Start implements manager.Runnable.
+func (m *clusterClientSetsMaintainer) Start(ctx context.Context) error {
+	m.r.maintainClusterClientSets(ctx)
+	return nil
+}
+
+// NeedLeaderElection implements manager.LeaderElectionRunnable.
+func (m *clusterClientSetsMaintainer) NeedLeaderElection() bool {
+	return true
+}
+
 // maintainClusterClientSets periodically retries informer setup for all clusters.
 func (r *SyncerReconciler) maintainClusterClientSets(ctx context.Context) {
 	ticker := time.NewTicker(clusterClientSetsRetryInterval)
@@ -223,7 +242,6 @@ func (r *SyncerReconciler) start(ctx context.Context) error {
 	for i := 0; i < r.MaxConcurrent; i++ {
 		r.Run(ctx)
 	}
-	go r.maintainClusterClientSets(ctx)
 	return nil
 }
 

--- a/SaFE/job-manager/pkg/syncer/syncer.go
+++ b/SaFE/job-manager/pkg/syncer/syncer.go
@@ -45,6 +45,9 @@ type SyncerReconciler struct {
 // serially while different objects fan out across workers.
 const syncerWorkers = 8
 
+// clusterClientSetsRetryInterval is the backoff for re-attempting data-plane informer setup.
+const clusterClientSetsRetryInterval = 30 * time.Second
+
 // resourceMessageKey identifies the k8s object a message is about. Messages with
 // the same key are serialized and coalesced by the KeyedController.
 func resourceMessageKey(m *resourceMessage) string {
@@ -137,41 +140,74 @@ func (r *SyncerReconciler) Reconcile(ctx context.Context, request ctrlruntime.Re
 		}
 		return ctrlruntime.Result{}, err
 	}
-	if quit := r.observe(c); quit {
-		return ctrlruntime.Result{}, nil
-	}
-	if err := r.handle(ctx, c); err != nil {
+	rtList := &v1.ResourceTemplateList{}
+	if err := r.List(ctx, rtList); err != nil {
+		klog.ErrorS(err, "failed to list ResourceTemplateList")
 		return ctrlruntime.Result{}, err
+	}
+	if retryNeeded := r.ensureClusterClientSets(ctx, c, rtList); retryNeeded {
+		return ctrlruntime.Result{RequeueAfter: clusterClientSetsRetryInterval}, nil
 	}
 	return ctrlruntime.Result{}, nil
 }
 
-// observe checks if a cluster client sets already exists for the given cluster.
-func (r *SyncerReconciler) observe(c *v1.Cluster) bool {
-	_, ok := r.clusterClientSets.Get(c.Name)
-	return ok
-}
-
-// handle processes a cluster by creating a new cluster client sets and initializing resource templates.
-func (r *SyncerReconciler) handle(ctx context.Context, cluster *v1.Cluster) error {
-	clientSets, err := newClusterClientSets(r.ctx, cluster, r.Client, r.Add)
+// ensureClusterClientSets creates or completes data-plane informers for a cluster.
+// Returns true when setup is incomplete and should be retried.
+func (r *SyncerReconciler) ensureClusterClientSets(ctx context.Context, cluster *v1.Cluster,
+	rtList *v1.ResourceTemplateList) bool {
+	clientSets, err := GetClusterClientSets(r.clusterClientSets, cluster.Name)
 	if err != nil {
-		klog.ErrorS(err, "failed to new cluster clientSets", "cluster.name", cluster.Name)
-		return err
+		clientSets, err = newClusterClientSets(r.ctx, cluster, r.Client, r.Add)
+		if err != nil {
+			klog.ErrorS(err, "failed to new cluster clientSets", "cluster", cluster.Name)
+			return true
+		}
+		r.clusterClientSets.AddOrReplace(cluster.Name, clientSets)
+		klog.Infof("create cluster clientSets, name: %s", cluster.Name)
 	}
-	rtList := &v1.ResourceTemplateList{}
-	if err = r.List(ctx, rtList); err != nil {
-		klog.ErrorS(err, "failed to list ResourceTemplateList")
-		return err
-	}
-	for _, rt := range rtList.Items {
-		if err = clientSets.addResourceTemplate(rt.ToSchemaGVK()); err != nil {
-			klog.ErrorS(err, "failed to add resource template", "cluster", cluster.Name, "rt", rt)
+	for i := range rtList.Items {
+		if err := clientSets.addResourceTemplate(rtList.Items[i].ToSchemaGVK()); err != nil {
+			klog.ErrorS(err, "failed to add resource template",
+				"cluster", cluster.Name, "rt", rtList.Items[i].Name)
 		}
 	}
-	r.clusterClientSets.AddOrReplace(cluster.Name, clientSets)
-	klog.Infof("create cluster clientSets, name: %s", cluster.Name)
-	return nil
+	if clientSets.needsInformerRetry(rtList) {
+		klog.InfoS("cluster client sets incomplete, will retry informer setup",
+			"cluster", cluster.Name, "informers", clientSets.informerCount())
+		return true
+	}
+	return false
+}
+
+// maintainClusterClientSets periodically retries informer setup for all clusters.
+func (r *SyncerReconciler) maintainClusterClientSets(ctx context.Context) {
+	ticker := time.NewTicker(clusterClientSetsRetryInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			r.ensureAllClusterClientSets(ctx)
+		}
+	}
+}
+
+// ensureAllClusterClientSets retries informer setup across every registered cluster.
+func (r *SyncerReconciler) ensureAllClusterClientSets(ctx context.Context) {
+	clusterList := &v1.ClusterList{}
+	if err := r.List(ctx, clusterList); err != nil {
+		klog.ErrorS(err, "failed to list clusters for client sets maintenance")
+		return
+	}
+	rtList := &v1.ResourceTemplateList{}
+	if err := r.List(ctx, rtList); err != nil {
+		klog.ErrorS(err, "failed to list ResourceTemplateList during client sets maintenance")
+		return
+	}
+	for i := range clusterList.Items {
+		r.ensureClusterClientSets(ctx, &clusterList.Items[i], rtList)
+	}
 }
 
 // deleteClusterClientSet removes and cleans up a cluster clientSets.
@@ -187,6 +223,7 @@ func (r *SyncerReconciler) start(ctx context.Context) error {
 	for i := 0; i < r.MaxConcurrent; i++ {
 		r.Run(ctx)
 	}
+	go r.maintainClusterClientSets(ctx)
 	return nil
 }
 

--- a/SaFE/job-manager/pkg/syncer/syncer_test.go
+++ b/SaFE/job-manager/pkg/syncer/syncer_test.go
@@ -34,16 +34,10 @@ func TestSyncerReconcileNotFound(t *testing.T) {
 	assert.NilError(t, err)
 }
 
-func TestSyncerObserve(t *testing.T) {
-	mgr := commonutils.NewObjectManager()
-	r := &SyncerReconciler{clusterClientSets: mgr}
-
-	// Not present -> false.
-	assert.Equal(t, r.observe(&v1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c1"}}), false)
-
-	// Present -> true.
-	assert.NilError(t, mgr.Add("c1", newTestClientSets()))
-	assert.Equal(t, r.observe(&v1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c1"}}), true)
+func TestClusterClientSetsNeedsInformerRetryEmpty(t *testing.T) {
+	c := newTestClientSets()
+	assert.Equal(t, c.needsInformerRetry(nil), false)
+	assert.Equal(t, c.needsInformerRetry(&v1.ResourceTemplateList{}), false)
 }
 
 func TestSyncerDeleteClusterClientSet(t *testing.T) {


### PR DESCRIPTION
…ents

Prevent syncer blindness after leader failover by ensuring data-plane informers are retried instead of caching empty client sets, and fix ghost Running workloads caused by silently dropped DeletedFinalStateUnknown events.