### PR TITLE
feat(observability): add Okta and PostgreSQL access metrics

### DIFF
--- a/.github/workflows/block-sensitive-secrets.yml
+++ b/.github/workflows/block-sensitive-secrets.yml
@@ -81,6 +81,9 @@ jobs:
             # DB client config: the pass-phrase struct field is populated from a
             # config getter (GetDBPassword), not a literal credential value.
             [[ "$path" == SaFE/common/pkg/database/client/client.go ]] && return 0
+            # DSN builder: "password=%s" is a format placeholder filled from the
+            # DBConfig at runtime, not a literal credential value.
+            [[ "$path" == SaFE/common/pkg/database/utils/db.go ]] && return 0
             # applyconfiguration-gen output: schema / field names may match generic secret patterns
             [[ "$path" == SaFE/apis/pkg/client/applyconfiguration/* ]] && return 0
             # Frontend form field names and TypeScript type definitions, not credential values

--- a/SaFE/apiserver/go.mod
+++ b/SaFE/apiserver/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/AMD-AIG-AIMA/SAFE/apis v0.0.0
 	github.com/AMD-AIG-AIMA/SAFE/common v0.0.0
 	github.com/AMD-AIG-AIMA/SAFE/utils v0.0.0
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/agiledragon/gomonkey/v2 v2.14.0
 	github.com/alexflint/go-restructure v0.3.0
@@ -20,6 +21,8 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
+	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/sashabaranov/go-openai v1.41.2
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.11.1
@@ -138,6 +141,7 @@ require (
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
 	github.com/klauspost/pgzip v1.2.6 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
@@ -158,8 +162,6 @@ require (
 	github.com/opencontainers/selinux v1.14.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.3.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect

--- a/SaFE/apiserver/go.sum
+++ b/SaFE/apiserver/go.sum
@@ -9,6 +9,8 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg6
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=
@@ -287,6 +289,7 @@ github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHm
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
 github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=

--- a/SaFE/apiserver/pkg/handlers/authority/sso_token.go
+++ b/SaFE/apiserver/pkg/handlers/authority/sso_token.go
@@ -194,9 +194,8 @@ func (c *ssoToken) Validate(ctx context.Context, rawToken string) (*UserInfo, er
 // validate verifies ID token and extracts user information
 // Implements TokenInterface.Validate method for OAuth2 tokens
 func (c *ssoToken) validate(ctx context.Context, rawToken string) (*UserInfo, error) {
-	verifyStart := time.Now()
 	idToken, err := c.verifier.Verify(ctx, rawToken)
-	metrics.ObserveIdPRequest(metrics.OpTokenVerify, verifyStart, err)
+	metrics.ObserveTokenVerify(err)
 	if err != nil {
 		return nil, fmt.Errorf("failed to verify ID token: %v", err)
 	}

--- a/SaFE/apiserver/pkg/handlers/authority/sso_token.go
+++ b/SaFE/apiserver/pkg/handlers/authority/sso_token.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
+	"github.com/AMD-AIG-AIMA/SAFE/apiserver/pkg/metrics"
 	commonconfig "github.com/AMD-AIG-AIMA/SAFE/common/pkg/config"
 	dbclient "github.com/AMD-AIG-AIMA/SAFE/common/pkg/database/client"
 	commonerrors "github.com/AMD-AIG-AIMA/SAFE/common/pkg/errors"
@@ -96,7 +97,9 @@ func initializeSSOToken(cli client.Client) (*ssoToken, error) {
 
 	ctx := oidc.ClientContext(context.Background(), ssoTokenInstance.httpClient.GetBaseClient())
 	var err error
+	discoveryStart := time.Now()
 	ssoTokenInstance.provider, err = oidc.NewProvider(ctx, ssoTokenInstance.endpoint)
+	metrics.ObserveIdPRequest(metrics.OpProviderDiscovery, discoveryStart, err)
 	if err != nil {
 		return nil, fmt.Errorf("failed to new provider %q: %v", ssoTokenInstance.endpoint, err)
 	}
@@ -110,9 +113,11 @@ func initializeSSOToken(cli client.Client) (*ssoToken, error) {
 // Implements TokenInterface.Login method for OAuth2 flow
 func (c *ssoToken) Login(ctx context.Context, input TokenInput) (*v1.User, *TokenResponse, error) {
 	if input.Code == "" {
+		metrics.ObserveLoginFailure(metrics.StageBadRequest)
 		return nil, nil, commonerrors.NewBadRequest("no code in request")
 	}
 	if c.httpClient == nil {
+		metrics.ObserveLoginFailure(metrics.StageBadRequest)
 		return nil, nil, commonerrors.NewInternalError("http client is nil")
 	}
 	var (
@@ -121,35 +126,43 @@ func (c *ssoToken) Login(ctx context.Context, input TokenInput) (*v1.User, *Toke
 	)
 	ctx = oidc.ClientContext(ctx, c.httpClient.GetBaseClient())
 	config := c.oauth2Config()
+	exchangeStart := time.Now()
 	token, err = config.Exchange(ctx, input.Code)
+	metrics.ObserveIdPRequest(metrics.OpTokenExchange, exchangeStart, err)
 	if err != nil {
+		metrics.ObserveLoginFailure(metrics.StageTokenExchange)
 		return nil, nil, commonerrors.NewInternalError(fmt.Sprintf("failed to get token: %v", err))
 	}
 
 	rawIDToken, ok := token.Extra("id_token").(string)
 	if !ok {
+		metrics.ObserveLoginFailure(metrics.StageTokenExchange)
 		return nil, nil, commonerrors.NewInternalError("no id_token in token response")
 	}
 
 	// Validate ID token and extract user info
 	userInfo, err := c.validate(ctx, rawIDToken)
 	if err != nil {
+		metrics.ObserveLoginFailure(metrics.StageTokenVerify)
 		return nil, nil, err
 	}
 
 	// Synchronize user with system
 	user, err := c.synchronizeUser(ctx, userInfo)
 	if err != nil {
+		metrics.ObserveLoginFailure(metrics.StageUserSync)
 		return nil, nil, err
 	}
 	userToken := ""
 	if commonconfig.IsDBEnable() {
 		if userToken, err = c.updateUserInfoInDB(ctx, rawIDToken, userInfo); err != nil {
+			metrics.ObserveLoginFailure(metrics.StageDBSession)
 			return nil, nil, err
 		}
 	} else {
 		userToken = rawIDToken
 	}
+	metrics.ObserveLoginSuccess()
 	response := &TokenResponse{
 		Expire: userInfo.Exp,
 		Token:  userToken,
@@ -181,7 +194,9 @@ func (c *ssoToken) Validate(ctx context.Context, rawToken string) (*UserInfo, er
 // validate verifies ID token and extracts user information
 // Implements TokenInterface.Validate method for OAuth2 tokens
 func (c *ssoToken) validate(ctx context.Context, rawToken string) (*UserInfo, error) {
+	verifyStart := time.Now()
 	idToken, err := c.verifier.Verify(ctx, rawToken)
+	metrics.ObserveIdPRequest(metrics.OpTokenVerify, verifyStart, err)
 	if err != nil {
 		return nil, fmt.Errorf("failed to verify ID token: %v", err)
 	}

--- a/SaFE/apiserver/pkg/metrics/sso.go
+++ b/SaFE/apiserver/pkg/metrics/sso.go
@@ -98,6 +98,14 @@ var (
 		Name: "safe_apiserver_sso_login_total",
 		Help: "SSO login attempts, by outcome and the stage that decided it.",
 	}, []string{"result", "stage"})
+
+	ssoTokenVerify = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "safe_apiserver_sso_token_verify_total",
+		Help: "ID token verifications, by outcome. Verification runs on every " +
+			"authenticated request and is offline while the signing keys are cached, " +
+			"so a failure here is normally an expired or malformed token rather than " +
+			"a provider fault.",
+	}, []string{"result"})
 )
 
 func init() {
@@ -105,6 +113,7 @@ func init() {
 		ssoIdPRequestDuration,
 		ssoIdPErrors,
 		ssoLogins,
+		ssoTokenVerify,
 	)
 }
 
@@ -117,6 +126,38 @@ func ObserveIdPRequest(operation string, start time.Time, err error) {
 		ssoIdPErrors.WithLabelValues(operation, ClassifyIdPError(err)).Inc()
 	}
 	ssoIdPRequestDuration.WithLabelValues(operation, status).Observe(time.Since(start).Seconds())
+}
+
+// ObserveTokenVerify records an ID token verification.
+//
+// Verification is deliberately kept out of the identity provider latency
+// histogram and, in the common case, out of its error counter too: it runs on
+// every authenticated request and resolves locally while the signing keys are
+// cached, so an expired or forged token would otherwise light up a provider
+// alert. Only a network class failure means the key fetch actually left the
+// process, and only that is attributed to the provider.
+func ObserveTokenVerify(err error) {
+	if err == nil {
+		ssoTokenVerify.WithLabelValues(resultSuccess).Inc()
+		return
+	}
+	ssoTokenVerify.WithLabelValues(resultFailure).Inc()
+	if kind := ClassifyIdPError(err); isNetworkKind(kind) {
+		ssoIdPErrors.WithLabelValues(OpTokenVerify, kind).Inc()
+	}
+}
+
+// isNetworkKind reports whether an error kind means the call reached the
+// network, as opposed to being decided locally or by the provider's own
+// response. A canceled context is excluded: it means the caller went away.
+func isNetworkKind(kind string) bool {
+	switch kind {
+	case IdPErrTimeout, IdPErrConnectionReset, IdPErrConnectionRefused,
+		IdPErrDNS, IdPErrTLS, IdPErrNetwork:
+		return true
+	default:
+		return false
+	}
 }
 
 // ObserveLoginSuccess records a login that completed end to end.

--- a/SaFE/apiserver/pkg/metrics/sso.go
+++ b/SaFE/apiserver/pkg/metrics/sso.go
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+// Package metrics defines apiserver business metrics (SSO login, identity
+// provider access). They are registered on the controller-runtime registry so
+// they are exposed on the existing /metrics endpoint and collected via pull.
+package metrics
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"net"
+	"syscall"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/oauth2"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// Operations performed against the identity provider.
+const (
+	// OpTokenExchange is the authorization-code-for-token call made on login.
+	OpTokenExchange = "token_exchange"
+	// OpTokenVerify is ID token verification, which reaches the provider when
+	// the signing keys are not cached.
+	OpTokenVerify = "token_verify"
+	// OpProviderDiscovery is the OIDC discovery call made at startup.
+	OpProviderDiscovery = "provider_discovery"
+)
+
+// Stages of a login attempt, reported on safe_apiserver_sso_login_total so that
+// an identity provider outage can be told apart from a database outage.
+const (
+	StageOK            = "ok"
+	StageTokenExchange = "token_exchange"
+	StageTokenVerify   = "token_verify"
+	StageUserSync      = "user_sync"
+	StageDBSession     = "db_session"
+	StageBadRequest    = "bad_request"
+)
+
+// Error kinds reported for identity provider calls.
+const (
+	// IdPErrTimeout is a deadline exceeded while talking to the provider.
+	IdPErrTimeout = "timeout"
+	// IdPErrCanceled means the caller went away before the provider answered.
+	// This is what the browser aborting a slow login looks like server side.
+	IdPErrCanceled = "canceled"
+	// IdPErrConnectionReset is a TCP reset from the provider or a middlebox,
+	// which is how a stalled connection eventually fails.
+	IdPErrConnectionReset = "connection_reset"
+	// IdPErrConnectionRefused is a refused connection.
+	IdPErrConnectionRefused = "connection_refused"
+	// IdPErrDNS is a name resolution failure.
+	IdPErrDNS = "dns"
+	// IdPErrTLS is a TLS handshake or certificate failure.
+	IdPErrTLS = "tls"
+	// IdPErrNetwork is any other transport level failure.
+	IdPErrNetwork = "network"
+	// IdPErrInvalidGrant means the provider rejected the authorization code,
+	// typically because it was already used or has expired. It is a client
+	// problem rather than an outage.
+	IdPErrInvalidGrant = "invalid_grant"
+	// IdPErrOAuth is any other structured OAuth2 error response.
+	IdPErrOAuth = "oauth"
+	// IdPErrOther is anything not recognised above.
+	IdPErrOther = "other"
+)
+
+const (
+	statusSuccess = "success"
+	statusError   = "error"
+
+	resultSuccess = "success"
+	resultFailure = "failure"
+)
+
+var (
+	ssoIdPRequestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "safe_apiserver_sso_idp_request_duration_seconds",
+		Help: "Latency of outbound calls to the SSO identity provider.",
+		// The outbound HTTP client allows 30s per attempt and the OAuth2
+		// library may probe a second auth style, so a stalled call can reach
+		// 60s. The buckets deliberately span that whole range.
+		Buckets: []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30, 45, 60},
+	}, []string{"operation", "status"})
+
+	ssoIdPErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "safe_apiserver_sso_idp_errors_total",
+		Help: "Failed outbound calls to the SSO identity provider, by error kind.",
+	}, []string{"operation", "kind"})
+
+	ssoLogins = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "safe_apiserver_sso_login_total",
+		Help: "SSO login attempts, by outcome and the stage that decided it.",
+	}, []string{"result", "stage"})
+)
+
+func init() {
+	ctrlmetrics.Registry.MustRegister(
+		ssoIdPRequestDuration,
+		ssoIdPErrors,
+		ssoLogins,
+	)
+}
+
+// ObserveIdPRequest records the latency and outcome of one call to the
+// identity provider.
+func ObserveIdPRequest(operation string, start time.Time, err error) {
+	status := statusSuccess
+	if err != nil {
+		status = statusError
+		ssoIdPErrors.WithLabelValues(operation, ClassifyIdPError(err)).Inc()
+	}
+	ssoIdPRequestDuration.WithLabelValues(operation, status).Observe(time.Since(start).Seconds())
+}
+
+// ObserveLoginSuccess records a login that completed end to end.
+func ObserveLoginSuccess() {
+	ssoLogins.WithLabelValues(resultSuccess, StageOK).Inc()
+}
+
+// ObserveLoginFailure records a login that failed, tagged with the stage it
+// failed at so that alerts can point at the responsible dependency.
+func ObserveLoginFailure(stage string) {
+	ssoLogins.WithLabelValues(resultFailure, stage).Inc()
+}
+
+// ClassifyIdPError maps an error from an identity provider call onto one of the
+// IdPErr constants. It returns an empty string for a nil error.
+func ClassifyIdPError(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	var retrieveErr *oauth2.RetrieveError
+	if errors.As(err, &retrieveErr) {
+		if retrieveErr.ErrorCode == "invalid_grant" {
+			return IdPErrInvalidGrant
+		}
+		return IdPErrOAuth
+	}
+
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		return IdPErrTimeout
+	case errors.Is(err, context.Canceled):
+		return IdPErrCanceled
+	case errors.Is(err, syscall.ECONNRESET):
+		return IdPErrConnectionReset
+	case errors.Is(err, syscall.ECONNREFUSED):
+		return IdPErrConnectionRefused
+	}
+
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return IdPErrDNS
+	}
+
+	var certErr *tls.CertificateVerificationError
+	if errors.As(err, &certErr) {
+		return IdPErrTLS
+	}
+	var recordErr tls.RecordHeaderError
+	if errors.As(err, &recordErr) {
+		return IdPErrTLS
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		if netErr.Timeout() {
+			return IdPErrTimeout
+		}
+		return IdPErrNetwork
+	}
+
+	return IdPErrOther
+}

--- a/SaFE/apiserver/pkg/metrics/sso_test.go
+++ b/SaFE/apiserver/pkg/metrics/sso_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 const tokenURL = "https://example.okta.com/oauth2/default/v1/token"
@@ -121,6 +122,75 @@ func TestObserveIdPRequest(t *testing.T) {
 	ObserveIdPRequest(operation, time.Now(), urlErr(context.Canceled))
 	assert.Equal(t, uint64(1), idpRequestCount(t, operation, statusError))
 	assert.Equal(t, 1.0, testutil.ToFloat64(ssoIdPErrors.WithLabelValues(operation, IdPErrCanceled)))
+}
+
+// Verification runs on every authenticated request, so an expired or forged
+// token must not be attributed to the identity provider. This is the case that
+// would otherwise page someone for ordinary client behaviour.
+func TestObserveTokenVerifyDoesNotBlameProvider(t *testing.T) {
+	before := testutil.ToFloat64(ssoTokenVerify.WithLabelValues(resultFailure))
+	idpBefore := idpErrorTotal(t, OpTokenVerify)
+
+	// The shape go-oidc returns for a token that is simply no longer valid.
+	ObserveTokenVerify(errors.New("oidc: token is expired (Token Expiry: 2026-08-03 09:00:00 +0000 UTC)"))
+
+	assert.Equal(t, before+1, testutil.ToFloat64(ssoTokenVerify.WithLabelValues(resultFailure)))
+	assert.Equal(t, idpBefore, idpErrorTotal(t, OpTokenVerify), "a bad token is not a provider fault")
+}
+
+// A key-set fetch that fails on the network did leave the process, so it is a
+// genuine provider signal and must still be counted.
+func TestObserveTokenVerifyReportsNetworkFailure(t *testing.T) {
+	before := testutil.ToFloat64(ssoIdPErrors.WithLabelValues(OpTokenVerify, IdPErrConnectionReset))
+
+	ObserveTokenVerify(urlErr(&net.OpError{Op: "read", Err: os.NewSyscallError("read", syscall.ECONNRESET)}))
+
+	assert.Equal(t, before+1, testutil.ToFloat64(ssoIdPErrors.WithLabelValues(OpTokenVerify, IdPErrConnectionReset)))
+}
+
+// A canceled context means the caller went away, not that the provider failed.
+func TestObserveTokenVerifyIgnoresCancellation(t *testing.T) {
+	before := idpErrorTotal(t, OpTokenVerify)
+	ObserveTokenVerify(urlErr(context.Canceled))
+	assert.Equal(t, before, idpErrorTotal(t, OpTokenVerify))
+}
+
+func TestObserveTokenVerifySuccess(t *testing.T) {
+	before := testutil.ToFloat64(ssoTokenVerify.WithLabelValues(resultSuccess))
+	ObserveTokenVerify(nil)
+	assert.Equal(t, before+1, testutil.ToFloat64(ssoTokenVerify.WithLabelValues(resultSuccess)))
+}
+
+// Verification is excluded from the outbound latency histogram: it is offline
+// on the hot path, and its sub-millisecond samples would all pile into the
+// first bucket of a histogram whose lower bound is 100ms.
+func TestObserveTokenVerifyStaysOutOfLatencyHistogram(t *testing.T) {
+	before := testutil.CollectAndCount(ssoIdPRequestDuration, "safe_apiserver_sso_idp_request_duration_seconds")
+	ObserveTokenVerify(nil)
+	ObserveTokenVerify(errors.New("oidc: malformed jwt"))
+	assert.Equal(t, before, testutil.CollectAndCount(ssoIdPRequestDuration, "safe_apiserver_sso_idp_request_duration_seconds"))
+}
+
+// idpErrorTotal sums every error kind recorded for one identity provider
+// operation.
+func idpErrorTotal(t *testing.T, operation string) float64 {
+	t.Helper()
+	families, err := ctrlmetrics.Registry.Gather()
+	require.NoError(t, err)
+	total := 0.0
+	for _, family := range families {
+		if family.GetName() != "safe_apiserver_sso_idp_errors_total" {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			for _, label := range metric.GetLabel() {
+				if label.GetName() == "operation" && label.GetValue() == operation {
+					total += metric.GetCounter().GetValue()
+				}
+			}
+		}
+	}
+	return total
 }
 
 func TestObserveLogin(t *testing.T) {

--- a/SaFE/apiserver/pkg/metrics/sso_test.go
+++ b/SaFE/apiserver/pkg/metrics/sso_test.go
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+package metrics
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+const tokenURL = "https://example.okta.com/oauth2/default/v1/token"
+
+// urlErr reproduces the shape of an error returned by net/http, which always
+// wraps the underlying failure in a *url.Error.
+func urlErr(err error) error {
+	return &url.Error{Op: "Post", URL: tokenURL, Err: err}
+}
+
+func TestClassifyIdPError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"nil is not an error", nil, ""},
+		{
+			"reused authorization code",
+			&oauth2.RetrieveError{ErrorCode: "invalid_grant"},
+			IdPErrInvalidGrant,
+		},
+		{
+			"other oauth error",
+			&oauth2.RetrieveError{ErrorCode: "invalid_client"},
+			IdPErrOAuth,
+		},
+		{
+			"wrapped oauth error",
+			fmt.Errorf("exchange: %w", &oauth2.RetrieveError{ErrorCode: "invalid_grant"}),
+			IdPErrInvalidGrant,
+		},
+		// The browser aborts the request after its own 10s timeout, which
+		// cancels the server side context mid-exchange.
+		{"caller gave up", urlErr(context.Canceled), IdPErrCanceled},
+		{"deadline exceeded", urlErr(context.DeadlineExceeded), IdPErrTimeout},
+		// A stalled connection to the provider eventually fails with a reset.
+		{
+			"reset by peer",
+			urlErr(&net.OpError{Op: "read", Err: os.NewSyscallError("read", syscall.ECONNRESET)}),
+			IdPErrConnectionReset,
+		},
+		{
+			"connection refused",
+			urlErr(&net.OpError{Op: "dial", Err: os.NewSyscallError("connect", syscall.ECONNREFUSED)}),
+			IdPErrConnectionRefused,
+		},
+		{
+			"name resolution failure",
+			urlErr(&net.DNSError{Err: "no such host", Name: "example.okta.com"}),
+			IdPErrDNS,
+		},
+		{
+			"certificate rejected",
+			urlErr(&tls.CertificateVerificationError{}),
+			IdPErrTLS,
+		},
+		{
+			"handshake failure",
+			urlErr(tls.RecordHeaderError{Msg: "first record does not look like a TLS handshake"}),
+			IdPErrTLS,
+		},
+		{
+			"other network failure",
+			urlErr(&net.OpError{Op: "read", Err: errors.New("broken")}),
+			IdPErrNetwork,
+		},
+		{"plain error", errors.New("boom"), IdPErrOther},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ClassifyIdPError(tt.err))
+		})
+	}
+}
+
+func TestClassifyIdPErrorNetworkTimeout(t *testing.T) {
+	// The outbound client's own timeout surfaces as a *url.Error that reports
+	// Timeout() without wrapping context.DeadlineExceeded.
+	assert.Equal(t, IdPErrTimeout, ClassifyIdPError(urlErr(&net.OpError{Op: "dial", Err: &timeoutError{}})))
+}
+
+// timeoutError is a net.Error that reports itself as a timeout.
+type timeoutError struct{}
+
+func (e *timeoutError) Error() string   { return "i/o timeout" }
+func (e *timeoutError) Timeout() bool   { return true }
+func (e *timeoutError) Temporary() bool { return true }
+
+func TestObserveIdPRequest(t *testing.T) {
+	const operation = "test_observe_idp"
+
+	ObserveIdPRequest(operation, time.Now(), nil)
+	assert.Equal(t, uint64(1), idpRequestCount(t, operation, statusSuccess))
+
+	ObserveIdPRequest(operation, time.Now(), urlErr(context.Canceled))
+	assert.Equal(t, uint64(1), idpRequestCount(t, operation, statusError))
+	assert.Equal(t, 1.0, testutil.ToFloat64(ssoIdPErrors.WithLabelValues(operation, IdPErrCanceled)))
+}
+
+func TestObserveLogin(t *testing.T) {
+	before := testutil.ToFloat64(ssoLogins.WithLabelValues(resultSuccess, StageOK))
+	ObserveLoginSuccess()
+	assert.Equal(t, before+1, testutil.ToFloat64(ssoLogins.WithLabelValues(resultSuccess, StageOK)))
+
+	// The stage label is what lets an alert say whether the identity provider
+	// or the database broke the login.
+	ObserveLoginFailure(StageTokenExchange)
+	assert.Equal(t, 1.0, testutil.ToFloat64(ssoLogins.WithLabelValues(resultFailure, StageTokenExchange)))
+	ObserveLoginFailure(StageDBSession)
+	assert.Equal(t, 1.0, testutil.ToFloat64(ssoLogins.WithLabelValues(resultFailure, StageDBSession)))
+}
+
+// idpRequestCount reports how many observations landed on one series of
+// ssoIdPRequestDuration.
+func idpRequestCount(t *testing.T, operation, status string) uint64 {
+	t.Helper()
+	observer, err := ssoIdPRequestDuration.GetMetricWithLabelValues(operation, status)
+	require.NoError(t, err)
+	var collected dto.Metric
+	require.NoError(t, observer.(prometheus.Metric).Write(&collected))
+	return collected.GetHistogram().GetSampleCount()
+}

--- a/SaFE/common/go.mod
+++ b/SaFE/common/go.mod
@@ -79,6 +79,7 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-sqlite3 v1.14.28 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect

--- a/SaFE/common/pkg/database/client/client.go
+++ b/SaFE/common/pkg/database/client/client.go
@@ -19,6 +19,7 @@ import (
 	commonconfig "github.com/AMD-AIG-AIMA/SAFE/common/pkg/config"
 	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/database/utils"
 	commonerrors "github.com/AMD-AIG-AIMA/SAFE/common/pkg/errors"
+	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/metrics"
 )
 
 var (
@@ -146,6 +147,10 @@ func (c *Client) Close() {
 	if err != nil {
 		klog.ErrorS(err, "failed to close db connection")
 	}
+	// Both pools belong to this client, so neither should keep reporting once
+	// the client is discarded.
+	metrics.UnregisterDBPool(utils.SqlxPoolKey(c.DBConfig))
+	metrics.UnregisterDBPool(utils.GormPoolKey(c.DBConfig))
 }
 
 // getDB retrieves DB for internal use. The handle is wrapped so that every

--- a/SaFE/common/pkg/database/client/client.go
+++ b/SaFE/common/pkg/database/client/client.go
@@ -148,12 +148,13 @@ func (c *Client) Close() {
 	}
 }
 
-// getDB retrieves DB for internal use.
-func (c *Client) getDB() (*sqlx.DB, error) {
+// getDB retrieves DB for internal use. The handle is wrapped so that every
+// query issued through it is reported to Prometheus.
+func (c *Client) getDB() (*instrumentedDB, error) {
 	if c.db == nil {
 		return nil, commonerrors.NewInternalError("The client of db has not been initialized")
 	}
-	return c.db.Unsafe(), nil
+	return &instrumentedDB{DB: c.db.Unsafe()}, nil
 }
 
 // GetGormDB retrieves the GORM DB instance for external use.

--- a/SaFE/common/pkg/database/client/instrumented_db.go
+++ b/SaFE/common/pkg/database/client/instrumented_db.go
@@ -18,10 +18,6 @@ import (
 // instrumentedDB wraps a sqlx handle and records Prometheus metrics for the
 // query methods the client package uses. Everything else is promoted from the
 // embedded *sqlx.DB unchanged.
-//
-// Statements issued inside a transaction obtained from BeginTxx are not
-// measured individually; the GORM path and the direct query methods below cover
-// every other database call in this package.
 type instrumentedDB struct {
 	*sqlx.DB
 }
@@ -59,4 +55,58 @@ func (db *instrumentedDB) NamedQueryContext(ctx context.Context, query string, a
 	rows, err := db.DB.NamedQueryContext(ctx, query, arg)
 	metrics.ObserveDBOperation(metrics.DriverSqlx, metrics.SQLOperation(query), start, err)
 	return rows, err
+}
+
+// BeginTxx returns an instrumented transaction so that batched writes are
+// measured too. They are the first thing to fail when the server turns
+// read-only, so they must not be a blind spot.
+func (db *instrumentedDB) BeginTxx(ctx context.Context, opts *sql.TxOptions) (*instrumentedTx, error) {
+	tx, err := db.DB.BeginTxx(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	return &instrumentedTx{Tx: tx}, nil
+}
+
+// instrumentedTx wraps a sqlx transaction and reports the statements issued
+// inside it, plus the commit. Rollback is deliberately left uninstrumented:
+// callers defer it unconditionally, so it reports sql.ErrTxDone on every
+// transaction that already committed.
+type instrumentedTx struct {
+	*sqlx.Tx
+}
+
+func (tx *instrumentedTx) SelectContext(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
+	start := time.Now()
+	err := tx.Tx.SelectContext(ctx, dest, query, args...)
+	metrics.ObserveDBOperation(metrics.DriverSqlx, metrics.SQLOperation(query), start, err)
+	return err
+}
+
+func (tx *instrumentedTx) GetContext(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
+	start := time.Now()
+	err := tx.Tx.GetContext(ctx, dest, query, args...)
+	metrics.ObserveDBOperation(metrics.DriverSqlx, metrics.SQLOperation(query), start, err)
+	return err
+}
+
+func (tx *instrumentedTx) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	start := time.Now()
+	res, err := tx.Tx.ExecContext(ctx, query, args...)
+	metrics.ObserveDBOperation(metrics.DriverSqlx, metrics.SQLOperation(query), start, err)
+	return res, err
+}
+
+func (tx *instrumentedTx) NamedExecContext(ctx context.Context, query string, arg interface{}) (sql.Result, error) {
+	start := time.Now()
+	res, err := tx.Tx.NamedExecContext(ctx, query, arg)
+	metrics.ObserveDBOperation(metrics.DriverSqlx, metrics.SQLOperation(query), start, err)
+	return res, err
+}
+
+func (tx *instrumentedTx) Commit() error {
+	start := time.Now()
+	err := tx.Tx.Commit()
+	metrics.ObserveDBOperation(metrics.DriverSqlx, metrics.OpCommit, start, err)
+	return err
 }

--- a/SaFE/common/pkg/database/client/instrumented_db.go
+++ b/SaFE/common/pkg/database/client/instrumented_db.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+package client
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/metrics"
+)
+
+// instrumentedDB wraps a sqlx handle and records Prometheus metrics for the
+// query methods the client package uses. Everything else is promoted from the
+// embedded *sqlx.DB unchanged.
+//
+// Statements issued inside a transaction obtained from BeginTxx are not
+// measured individually; the GORM path and the direct query methods below cover
+// every other database call in this package.
+type instrumentedDB struct {
+	*sqlx.DB
+}
+
+func (db *instrumentedDB) SelectContext(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
+	start := time.Now()
+	err := db.DB.SelectContext(ctx, dest, query, args...)
+	metrics.ObserveDBOperation(metrics.DriverSqlx, metrics.SQLOperation(query), start, err)
+	return err
+}
+
+func (db *instrumentedDB) GetContext(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
+	start := time.Now()
+	err := db.DB.GetContext(ctx, dest, query, args...)
+	metrics.ObserveDBOperation(metrics.DriverSqlx, metrics.SQLOperation(query), start, err)
+	return err
+}
+
+func (db *instrumentedDB) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	start := time.Now()
+	res, err := db.DB.ExecContext(ctx, query, args...)
+	metrics.ObserveDBOperation(metrics.DriverSqlx, metrics.SQLOperation(query), start, err)
+	return res, err
+}
+
+func (db *instrumentedDB) NamedExecContext(ctx context.Context, query string, arg interface{}) (sql.Result, error) {
+	start := time.Now()
+	res, err := db.DB.NamedExecContext(ctx, query, arg)
+	metrics.ObserveDBOperation(metrics.DriverSqlx, metrics.SQLOperation(query), start, err)
+	return res, err
+}
+
+func (db *instrumentedDB) NamedQueryContext(ctx context.Context, query string, arg interface{}) (*sqlx.Rows, error) {
+	start := time.Now()
+	rows, err := db.DB.NamedQueryContext(ctx, query, arg)
+	metrics.ObserveDBOperation(metrics.DriverSqlx, metrics.SQLOperation(query), start, err)
+	return rows, err
+}

--- a/SaFE/common/pkg/database/client/instrumented_db_test.go
+++ b/SaFE/common/pkg/database/client/instrumented_db_test.go
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+package client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/lib/pq"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/metrics"
+)
+
+// The status label values are part of the metric contract that alert rules are
+// written against, so they are spelled out here rather than imported.
+const (
+	statusSuccess = "success"
+	statusError   = "error"
+)
+
+func TestSqlxQueriesAreInstrumented(t *testing.T) {
+	c, mock := newMockClient(t)
+	before := histogramCount(t, metrics.DriverSqlx, metrics.OpInsert, statusSuccess)
+
+	mock.ExpectExec("INSERT INTO user_token").WillReturnResult(sqlmock.NewResult(1, 1))
+	require.NoError(t, c.UpsertUserToken(context.Background(), &UserToken{UserId: "u", SessionId: "s"}))
+
+	assert.Equal(t, before+1, histogramCount(t, metrics.DriverSqlx, metrics.OpInsert, statusSuccess))
+}
+
+// A read-only transaction rejection is what a PostgreSQL replica returns while
+// it is being promoted. It must reach the metrics as its own error kind so that
+// it can be alerted on separately from ordinary query failures.
+func TestSqlxReadOnlyTransactionIsClassified(t *testing.T) {
+	c, mock := newMockClient(t)
+	before := counterValue(t, metrics.DriverSqlx, metrics.OpInsert, metrics.ErrKindReadOnlyTransaction)
+
+	mock.ExpectExec("INSERT INTO user_token").
+		WillReturnError(&pq.Error{Code: "25006", Message: "cannot execute INSERT in a read-only transaction"})
+	require.Error(t, c.UpsertUserToken(context.Background(), &UserToken{UserId: "u", SessionId: "s"}))
+
+	assert.Equal(t, before+1, counterValue(t, metrics.DriverSqlx, metrics.OpInsert, metrics.ErrKindReadOnlyTransaction))
+	assert.Positive(t, histogramCount(t, metrics.DriverSqlx, metrics.OpInsert, statusError))
+}
+
+func TestSqlxSelectIsInstrumented(t *testing.T) {
+	c, mock := newMockClient(t)
+	before := histogramCount(t, metrics.DriverSqlx, metrics.OpSelect, statusSuccess)
+
+	mock.ExpectQuery("SELECT").WillReturnRows(sqlmock.NewRows([]string{"user_id"}).AddRow("u"))
+	_, err := c.SelectUserTokens(context.Background(), nil, nil, 1, 0)
+	require.NoError(t, err)
+
+	assert.Equal(t, before+1, histogramCount(t, metrics.DriverSqlx, metrics.OpSelect, statusSuccess))
+}
+
+// histogramCount reports the observation count on one series of
+// safe_db_operation_duration_seconds.
+func histogramCount(t *testing.T, driver, operation, status string) uint64 {
+	t.Helper()
+	metric := findMetric(t, "safe_db_operation_duration_seconds", map[string]string{
+		"driver": driver, "operation": operation, "status": status,
+	})
+	if metric == nil {
+		return 0
+	}
+	return metric.GetHistogram().GetSampleCount()
+}
+
+// counterValue reports the value of one series of safe_db_errors_total.
+func counterValue(t *testing.T, driver, operation, kind string) float64 {
+	t.Helper()
+	metric := findMetric(t, "safe_db_errors_total", map[string]string{
+		"driver": driver, "operation": operation, "kind": kind,
+	})
+	if metric == nil {
+		return 0
+	}
+	return metric.GetCounter().GetValue()
+}
+
+// findMetric gathers the default registry and returns the sample carrying
+// exactly the given labels, or nil when it has not been emitted yet.
+func findMetric(t *testing.T, name string, labels map[string]string) *dto.Metric {
+	t.Helper()
+	families, err := ctrlmetrics.Registry.Gather()
+	require.NoError(t, err)
+	for _, family := range families {
+		if family.GetName() != name {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			if labelsMatch(metric, labels) {
+				return metric
+			}
+		}
+	}
+	return nil
+}
+
+func labelsMatch(metric *dto.Metric, want map[string]string) bool {
+	got := make(map[string]string, len(metric.GetLabel()))
+	for _, label := range metric.GetLabel() {
+		got[label.GetName()] = label.GetValue()
+	}
+	for name, value := range want {
+		if got[name] != value {
+			return false
+		}
+	}
+	return true
+}

--- a/SaFE/common/pkg/database/client/instrumented_db_test.go
+++ b/SaFE/common/pkg/database/client/instrumented_db_test.go
@@ -51,6 +51,56 @@ func TestSqlxReadOnlyTransactionIsClassified(t *testing.T) {
 	assert.Positive(t, histogramCount(t, metrics.DriverSqlx, metrics.OpInsert, statusError))
 }
 
+// Batched writes go through a transaction, and that is the path a read-only
+// server rejects first, so it must produce the same metrics as any other write.
+func TestTransactionWritesAreInstrumented(t *testing.T) {
+	c, mock := newMockClient(t)
+	beforeInsert := histogramCount(t, metrics.DriverSqlx, metrics.OpInsert, statusSuccess)
+	beforeCommit := histogramCount(t, metrics.DriverSqlx, metrics.OpCommit, statusSuccess)
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO workload_pod").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO workload_pod").WillReturnResult(sqlmock.NewResult(2, 1))
+	mock.ExpectCommit()
+
+	pods := []*WorkloadPod{{WorkloadId: "w", PodId: "p1"}, {WorkloadId: "w", PodId: "p2"}}
+	require.NoError(t, c.BatchUpsertWorkloadPods(context.Background(), pods))
+
+	assert.Equal(t, beforeInsert+2, histogramCount(t, metrics.DriverSqlx, metrics.OpInsert, statusSuccess))
+	assert.Equal(t, beforeCommit+1, histogramCount(t, metrics.DriverSqlx, metrics.OpCommit, statusSuccess))
+}
+
+func TestTransactionReadOnlyTransactionIsClassified(t *testing.T) {
+	c, mock := newMockClient(t)
+	before := counterValue(t, metrics.DriverSqlx, metrics.OpInsert, metrics.ErrKindReadOnlyTransaction)
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO workload_pod").
+		WillReturnError(&pq.Error{Code: "25006", Message: "cannot execute INSERT in a read-only transaction"})
+	mock.ExpectRollback()
+
+	pods := []*WorkloadPod{{WorkloadId: "w", PodId: "p1"}}
+	require.Error(t, c.BatchUpsertWorkloadPods(context.Background(), pods))
+
+	assert.Equal(t, before+1, counterValue(t, metrics.DriverSqlx, metrics.OpInsert, metrics.ErrKindReadOnlyTransaction))
+}
+
+// Callers defer Rollback unconditionally, so instrumenting it would report
+// sql.ErrTxDone on every transaction that already committed.
+func TestTransactionRollbackIsNotCounted(t *testing.T) {
+	c, mock := newMockClient(t)
+	before := counterValue(t, metrics.DriverSqlx, metrics.OpOther, metrics.ErrKindOther)
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO workload_pod").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	pods := []*WorkloadPod{{WorkloadId: "w", PodId: "p1"}}
+	require.NoError(t, c.BatchUpsertWorkloadPods(context.Background(), pods))
+
+	assert.Equal(t, before, counterValue(t, metrics.DriverSqlx, metrics.OpOther, metrics.ErrKindOther))
+}
+
 func TestSqlxSelectIsInstrumented(t *testing.T) {
 	c, mock := newMockClient(t)
 	before := histogramCount(t, metrics.DriverSqlx, metrics.OpSelect, statusSuccess)

--- a/SaFE/common/pkg/database/utils/config.go
+++ b/SaFE/common/pkg/database/utils/config.go
@@ -35,3 +35,9 @@ func (c *DBConfig) SourceName() string {
 	return fmt.Sprintf("user=%s password=%s dbname=%s host=%s port=%d sslmode=%s connect_timeout=%d",
 		c.Username, c.Password, c.DBName, c.Host, c.Port, c.SSLMode, c.ConnectTimeout)
 }
+
+// PoolName identifies the server and database this configuration points at, for
+// use as a metric label. It carries no credentials.
+func (c *DBConfig) PoolName() string {
+	return fmt.Sprintf("%s:%d/%s", c.Host, c.Port, c.DBName)
+}

--- a/SaFE/common/pkg/database/utils/config.go
+++ b/SaFE/common/pkg/database/utils/config.go
@@ -35,9 +35,3 @@ func (c *DBConfig) SourceName() string {
 	return fmt.Sprintf("user=%s password=%s dbname=%s host=%s port=%d sslmode=%s connect_timeout=%d",
 		c.Username, c.Password, c.DBName, c.Host, c.Port, c.SSLMode, c.ConnectTimeout)
 }
-
-// PoolName identifies the server and database this configuration points at, for
-// use as a metric label. It carries no credentials.
-func (c *DBConfig) PoolName() string {
-	return fmt.Sprintf("%s:%d/%s", c.Host, c.Port, c.DBName)
-}

--- a/SaFE/common/pkg/database/utils/db.go
+++ b/SaFE/common/pkg/database/utils/db.go
@@ -60,15 +60,21 @@ func Connect(cfg *DBConfig, driverName DBDriver) (*sqlx.DB, error) {
 	return db, nil
 }
 
+// poolName identifies the server and database a configuration points at, for
+// use as a metric label. It carries no credentials.
+func poolName(cfg *DBConfig) string {
+	return fmt.Sprintf("%s:%d/%s", cfg.Host, cfg.Port, cfg.DBName)
+}
+
 // SqlxPoolKey identifies the sqlx pool of a configuration in the pool metrics.
 func SqlxPoolKey(cfg *DBConfig) metrics.PoolKey {
-	return metrics.PoolKey{Pool: cfg.PoolName(), Driver: metrics.DriverSqlx}
+	return metrics.PoolKey{Pool: poolName(cfg), Driver: metrics.DriverSqlx}
 }
 
 // GormPoolKey identifies the GORM pool of a configuration in the pool metrics.
 // GORM opens its own pool, separate from the sqlx one.
 func GormPoolKey(cfg *DBConfig) metrics.PoolKey {
-	return metrics.PoolKey{Pool: cfg.PoolName(), Driver: metrics.DriverGorm}
+	return metrics.PoolKey{Pool: poolName(cfg), Driver: metrics.DriverGorm}
 }
 
 // ConnectGorm establishes a connection to the database using GORM ORM.

--- a/SaFE/common/pkg/database/utils/db.go
+++ b/SaFE/common/pkg/database/utils/db.go
@@ -19,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 
+	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/metrics"
 	jsonutils "github.com/AMD-AIG-AIMA/SAFE/utils/pkg/json"
 	"github.com/AMD-AIG-AIMA/SAFE/utils/pkg/timeutil"
 )
@@ -55,6 +56,7 @@ func Connect(cfg *DBConfig, driverName DBDriver) (*sqlx.DB, error) {
 	}
 	db.SetConnMaxIdleTime(cfg.MaxIdleTime)
 	db.SetConnMaxLifetime(cfg.MaxLifetime)
+	metrics.RegisterDBPool(cfg.DBName, db.Stats)
 	return db, nil
 }
 
@@ -90,6 +92,9 @@ func ConnectGorm(cfg *DBConfig) (*gorm.DB, error) {
 		Plugins:                                  nil,
 	})
 	if err != nil {
+		return nil, err
+	}
+	if err = gormDB.Use(gormMetricsPlugin{}); err != nil {
 		return nil, err
 	}
 	return gormDB, nil

--- a/SaFE/common/pkg/database/utils/db.go
+++ b/SaFE/common/pkg/database/utils/db.go
@@ -56,8 +56,19 @@ func Connect(cfg *DBConfig, driverName DBDriver) (*sqlx.DB, error) {
 	}
 	db.SetConnMaxIdleTime(cfg.MaxIdleTime)
 	db.SetConnMaxLifetime(cfg.MaxLifetime)
-	metrics.RegisterDBPool(cfg.DBName, db.Stats)
+	metrics.RegisterDBPool(SqlxPoolKey(cfg), db.Stats)
 	return db, nil
+}
+
+// SqlxPoolKey identifies the sqlx pool of a configuration in the pool metrics.
+func SqlxPoolKey(cfg *DBConfig) metrics.PoolKey {
+	return metrics.PoolKey{Pool: cfg.PoolName(), Driver: metrics.DriverSqlx}
+}
+
+// GormPoolKey identifies the GORM pool of a configuration in the pool metrics.
+// GORM opens its own pool, separate from the sqlx one.
+func GormPoolKey(cfg *DBConfig) metrics.PoolKey {
+	return metrics.PoolKey{Pool: cfg.PoolName(), Driver: metrics.DriverGorm}
 }
 
 // ConnectGorm establishes a connection to the database using GORM ORM.
@@ -97,6 +108,13 @@ func ConnectGorm(cfg *DBConfig) (*gorm.DB, error) {
 	if err = gormDB.Use(gormMetricsPlugin{}); err != nil {
 		return nil, err
 	}
+	// GORM opens a pool of its own rather than sharing the sqlx one, and it is
+	// left on the database/sql defaults, so it needs its own pool metrics.
+	sqlDB, err := gormDB.DB()
+	if err != nil {
+		return nil, err
+	}
+	metrics.RegisterDBPool(GormPoolKey(cfg), sqlDB.Stats)
 	return gormDB, nil
 }
 

--- a/SaFE/common/pkg/database/utils/gorm_metrics.go
+++ b/SaFE/common/pkg/database/utils/gorm_metrics.go
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+package utils
+
+import (
+	"errors"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/metrics"
+)
+
+const (
+	gormPluginName = "safe:metrics"
+	gormStartKey   = "safe:metrics:start"
+)
+
+// gormMetricsPlugin records Prometheus metrics for every statement issued
+// through GORM by pairing a before callback that stamps the start time with an
+// after callback that reports the latency and error.
+type gormMetricsPlugin struct{}
+
+func (gormMetricsPlugin) Name() string { return gormPluginName }
+
+func (gormMetricsPlugin) Initialize(db *gorm.DB) error {
+	cb := db.Callback()
+	return errors.Join(
+		cb.Create().Before("gorm:create").Register(beforeName("create"), gormBefore),
+		cb.Create().After("gorm:create").Register(afterName("create"), gormAfter(metrics.OpInsert)),
+		cb.Query().Before("gorm:query").Register(beforeName("query"), gormBefore),
+		cb.Query().After("gorm:query").Register(afterName("query"), gormAfter(metrics.OpSelect)),
+		cb.Update().Before("gorm:update").Register(beforeName("update"), gormBefore),
+		cb.Update().After("gorm:update").Register(afterName("update"), gormAfter(metrics.OpUpdate)),
+		cb.Delete().Before("gorm:delete").Register(beforeName("delete"), gormBefore),
+		cb.Delete().After("gorm:delete").Register(afterName("delete"), gormAfter(metrics.OpDelete)),
+		cb.Row().Before("gorm:row").Register(beforeName("row"), gormBefore),
+		cb.Row().After("gorm:row").Register(afterName("row"), gormAfter(metrics.OpOther)),
+		cb.Raw().Before("gorm:raw").Register(beforeName("raw"), gormBefore),
+		cb.Raw().After("gorm:raw").Register(afterName("raw"), gormAfter(metrics.OpOther)),
+	)
+}
+
+func beforeName(action string) string { return gormPluginName + ":before_" + action }
+
+func afterName(action string) string { return gormPluginName + ":after_" + action }
+
+// gormBefore stamps the statement with its start time.
+func gormBefore(db *gorm.DB) {
+	db.InstanceSet(gormStartKey, time.Now())
+}
+
+// gormAfter reports the outcome of the statement. The SQL verb is preferred
+// over the fallback because Raw and Row statements can be anything.
+func gormAfter(fallback string) func(*gorm.DB) {
+	return func(db *gorm.DB) {
+		value, ok := db.InstanceGet(gormStartKey)
+		if !ok {
+			return
+		}
+		start, ok := value.(time.Time)
+		if !ok {
+			return
+		}
+		operation := fallback
+		if statement := db.Statement.SQL.String(); statement != "" {
+			operation = metrics.SQLOperation(statement)
+		}
+		metrics.ObserveDBOperation(metrics.DriverGorm, operation, start, db.Error)
+	}
+}

--- a/SaFE/common/pkg/database/utils/gorm_metrics_test.go
+++ b/SaFE/common/pkg/database/utils/gorm_metrics_test.go
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/lib/pq"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/metrics"
+)
+
+const (
+	statusSuccess = "success"
+	statusError   = "error"
+)
+
+type gormRow struct {
+	ID int64 `gorm:"column:id;primaryKey"`
+}
+
+func (*gormRow) TableName() string { return "gorm_metrics_test" }
+
+// newMockGorm builds a GORM handle over go-sqlmock with the metrics plugin
+// installed, mirroring what ConnectGorm does for a real connection.
+func newMockGorm(t *testing.T) (*gorm.DB, sqlmock.Sqlmock) {
+	t.Helper()
+	sqldb, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqldb.Close() })
+
+	db, err := gorm.Open(postgres.New(postgres.Config{
+		Conn:                 sqldb,
+		PreferSimpleProtocol: true,
+	}), &gorm.Config{SkipDefaultTransaction: true})
+	require.NoError(t, err)
+	require.NoError(t, db.Use(gormMetricsPlugin{}))
+	return db, mock
+}
+
+func TestGormQueriesAreInstrumented(t *testing.T) {
+	db, mock := newMockGorm(t)
+	before := histogramCount(t, metrics.DriverGorm, metrics.OpSelect, statusSuccess)
+
+	mock.ExpectQuery("SELECT").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(1)))
+	var row gormRow
+	require.NoError(t, db.First(&row).Error)
+
+	assert.Equal(t, before+1, histogramCount(t, metrics.DriverGorm, metrics.OpSelect, statusSuccess))
+}
+
+// An empty result set is reported by GORM as ErrRecordNotFound. It is a normal
+// outcome and must not inflate the error counter that alerts are built on.
+func TestGormRecordNotFoundIsNotAnError(t *testing.T) {
+	db, mock := newMockGorm(t)
+	before := counterValue(t, metrics.DriverGorm, metrics.OpSelect, metrics.ErrKindNoRows)
+
+	mock.ExpectQuery("SELECT").WillReturnRows(sqlmock.NewRows([]string{"id"}))
+	var row gormRow
+	require.ErrorIs(t, db.First(&row).Error, gorm.ErrRecordNotFound)
+
+	assert.Equal(t, before, counterValue(t, metrics.DriverGorm, metrics.OpSelect, metrics.ErrKindNoRows))
+}
+
+func TestGormReadOnlyTransactionIsClassified(t *testing.T) {
+	db, mock := newMockGorm(t)
+	before := counterValue(t, metrics.DriverGorm, metrics.OpInsert, metrics.ErrKindReadOnlyTransaction)
+
+	mock.ExpectQuery("INSERT").
+		WillReturnError(&pq.Error{Code: "25006", Message: "cannot execute INSERT in a read-only transaction"})
+	require.Error(t, db.Create(&gormRow{ID: 1}).Error)
+
+	assert.Equal(t, before+1, counterValue(t, metrics.DriverGorm, metrics.OpInsert, metrics.ErrKindReadOnlyTransaction))
+}
+
+// histogramCount reports the observation count on one series of
+// safe_db_operation_duration_seconds.
+func histogramCount(t *testing.T, driver, operation, status string) uint64 {
+	t.Helper()
+	metric := findMetric(t, "safe_db_operation_duration_seconds", map[string]string{
+		"driver": driver, "operation": operation, "status": status,
+	})
+	if metric == nil {
+		return 0
+	}
+	return metric.GetHistogram().GetSampleCount()
+}
+
+// counterValue reports the value of one series of safe_db_errors_total.
+func counterValue(t *testing.T, driver, operation, kind string) float64 {
+	t.Helper()
+	metric := findMetric(t, "safe_db_errors_total", map[string]string{
+		"driver": driver, "operation": operation, "kind": kind,
+	})
+	if metric == nil {
+		return 0
+	}
+	return metric.GetCounter().GetValue()
+}
+
+// findMetric gathers the default registry and returns the sample carrying
+// exactly the given labels, or nil when it has not been emitted yet.
+func findMetric(t *testing.T, name string, labels map[string]string) *dto.Metric {
+	t.Helper()
+	families, err := ctrlmetrics.Registry.Gather()
+	require.NoError(t, err)
+	for _, family := range families {
+		if family.GetName() != name {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			if labelsMatch(metric, labels) {
+				return metric
+			}
+		}
+	}
+	return nil
+}
+
+func labelsMatch(metric *dto.Metric, want map[string]string) bool {
+	got := make(map[string]string, len(metric.GetLabel()))
+	for _, label := range metric.GetLabel() {
+		got[label.GetName()] = label.GetValue()
+	}
+	for name, value := range want {
+		if got[name] != value {
+			return false
+		}
+	}
+	return true
+}

--- a/SaFE/common/pkg/metrics/db.go
+++ b/SaFE/common/pkg/metrics/db.go
@@ -82,6 +82,7 @@ const (
 	OpUpdate = "update"
 	OpDelete = "delete"
 	OpWith   = "with"
+	OpCommit = "commit"
 	OpOther  = "other"
 )
 
@@ -210,12 +211,22 @@ func classifyPQCode(code pq.ErrorCode) string {
 // PoolStatsFunc reports the current statistics of a connection pool.
 type PoolStatsFunc func() sql.DBStats
 
+// PoolKey identifies one connection pool. A process holds a separate pool per
+// driver, and may hold pools for several servers, so the database name alone is
+// not unique enough to key them by.
+type PoolKey struct {
+	// Pool identifies the server and database, as host:port/dbname.
+	Pool string
+	// Driver is DriverSqlx or DriverGorm.
+	Driver string
+}
+
 // dbPoolCollector publishes sql.DBStats for every registered pool. A single
 // collector serves all pools so that additional pools can be registered after
-// the collector is already bound to the default registry.
+// the collector is already bound to the registry.
 type dbPoolCollector struct {
 	mu    sync.RWMutex
-	pools map[string]PoolStatsFunc
+	pools map[PoolKey]PoolStatsFunc
 
 	connections     *prometheus.Desc
 	maxOpen         *prometheus.Desc
@@ -228,32 +239,33 @@ type dbPoolCollector struct {
 var poolCollector = newDBPoolCollector()
 
 func newDBPoolCollector() *dbPoolCollector {
+	poolLabels := []string{"pool", "driver"}
 	return &dbPoolCollector{
-		pools: map[string]PoolStatsFunc{},
+		pools: map[PoolKey]PoolStatsFunc{},
 		connections: prometheus.NewDesc(
 			"safe_db_pool_connections",
 			"Number of database connections in the pool, by state.",
-			[]string{"pool", "state"}, nil),
+			[]string{"pool", "driver", "state"}, nil),
 		maxOpen: prometheus.NewDesc(
 			"safe_db_pool_max_open_connections",
-			"Configured upper bound on open connections.",
-			[]string{"pool"}, nil),
+			"Configured upper bound on open connections; 0 means unlimited.",
+			poolLabels, nil),
 		waitCount: prometheus.NewDesc(
 			"safe_db_pool_wait_count_total",
 			"Total number of times a caller had to wait for a connection.",
-			[]string{"pool"}, nil),
+			poolLabels, nil),
 		waitDuration: prometheus.NewDesc(
 			"safe_db_pool_wait_duration_seconds_total",
 			"Total time callers spent waiting for a connection.",
-			[]string{"pool"}, nil),
+			poolLabels, nil),
 		closedMaxIdle: prometheus.NewDesc(
 			"safe_db_pool_closed_max_idle_total",
 			"Total connections closed because the idle limit was reached.",
-			[]string{"pool"}, nil),
+			poolLabels, nil),
 		closedMaxLifeTm: prometheus.NewDesc(
 			"safe_db_pool_closed_max_lifetime_total",
 			"Total connections closed because the lifetime limit was reached.",
-			[]string{"pool"}, nil),
+			poolLabels, nil),
 	}
 }
 
@@ -265,16 +277,24 @@ func init() {
 	)
 }
 
-// RegisterDBPool starts publishing pool statistics under the given pool name.
-// Registering the same name twice replaces the previous source, which keeps the
-// call idempotent for singleton clients.
-func RegisterDBPool(pool string, stats PoolStatsFunc) {
+// RegisterDBPool starts publishing statistics for a pool. Registering the same
+// key twice replaces the previous source, which keeps the call idempotent for
+// singleton clients.
+func RegisterDBPool(key PoolKey, stats PoolStatsFunc) {
 	if stats == nil {
 		return
 	}
 	poolCollector.mu.Lock()
 	defer poolCollector.mu.Unlock()
-	poolCollector.pools[pool] = stats
+	poolCollector.pools[key] = stats
+}
+
+// UnregisterDBPool stops publishing statistics for a pool. Without it a closed
+// pool would keep reporting a frozen set of zeroes forever.
+func UnregisterDBPool(key PoolKey) {
+	poolCollector.mu.Lock()
+	defer poolCollector.mu.Unlock()
+	delete(poolCollector.pools, key)
 }
 
 func (c *dbPoolCollector) Describe(ch chan<- *prometheus.Desc) {
@@ -289,15 +309,16 @@ func (c *dbPoolCollector) Describe(ch chan<- *prometheus.Desc) {
 func (c *dbPoolCollector) Collect(ch chan<- prometheus.Metric) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	for pool, stats := range c.pools {
+	for key, stats := range c.pools {
 		s := stats()
-		ch <- prometheus.MustNewConstMetric(c.connections, prometheus.GaugeValue, float64(s.OpenConnections), pool, "open")
-		ch <- prometheus.MustNewConstMetric(c.connections, prometheus.GaugeValue, float64(s.InUse), pool, "in_use")
-		ch <- prometheus.MustNewConstMetric(c.connections, prometheus.GaugeValue, float64(s.Idle), pool, "idle")
-		ch <- prometheus.MustNewConstMetric(c.maxOpen, prometheus.GaugeValue, float64(s.MaxOpenConnections), pool)
-		ch <- prometheus.MustNewConstMetric(c.waitCount, prometheus.CounterValue, float64(s.WaitCount), pool)
-		ch <- prometheus.MustNewConstMetric(c.waitDuration, prometheus.CounterValue, s.WaitDuration.Seconds(), pool)
-		ch <- prometheus.MustNewConstMetric(c.closedMaxIdle, prometheus.CounterValue, float64(s.MaxIdleClosed), pool)
-		ch <- prometheus.MustNewConstMetric(c.closedMaxLifeTm, prometheus.CounterValue, float64(s.MaxLifetimeClosed), pool)
+		pool, driverName := key.Pool, key.Driver
+		ch <- prometheus.MustNewConstMetric(c.connections, prometheus.GaugeValue, float64(s.OpenConnections), pool, driverName, "open")
+		ch <- prometheus.MustNewConstMetric(c.connections, prometheus.GaugeValue, float64(s.InUse), pool, driverName, "in_use")
+		ch <- prometheus.MustNewConstMetric(c.connections, prometheus.GaugeValue, float64(s.Idle), pool, driverName, "idle")
+		ch <- prometheus.MustNewConstMetric(c.maxOpen, prometheus.GaugeValue, float64(s.MaxOpenConnections), pool, driverName)
+		ch <- prometheus.MustNewConstMetric(c.waitCount, prometheus.CounterValue, float64(s.WaitCount), pool, driverName)
+		ch <- prometheus.MustNewConstMetric(c.waitDuration, prometheus.CounterValue, s.WaitDuration.Seconds(), pool, driverName)
+		ch <- prometheus.MustNewConstMetric(c.closedMaxIdle, prometheus.CounterValue, float64(s.MaxIdleClosed), pool, driverName)
+		ch <- prometheus.MustNewConstMetric(c.closedMaxLifeTm, prometheus.CounterValue, float64(s.MaxLifetimeClosed), pool, driverName)
 	}
 }

--- a/SaFE/common/pkg/metrics/db.go
+++ b/SaFE/common/pkg/metrics/db.go
@@ -1,0 +1,303 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+// Package metrics defines the PostgreSQL access metrics shared by every SaFE
+// service that talks to the database. They are registered on the
+// controller-runtime registry so they are exposed on the existing /metrics
+// endpoint and collected via pull.
+package metrics
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+
+	"github.com/lib/pq"
+	"github.com/prometheus/client_golang/prometheus"
+	"gorm.io/gorm"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// Driver names used as the "driver" label on the database metrics.
+const (
+	DriverSqlx = "sqlx"
+	DriverGorm = "gorm"
+)
+
+// Error kinds reported on the "kind" label of safe_db_errors_total. They are
+// deliberately coarse: each one maps to a distinct operational response.
+const (
+	// ErrKindNoRows is an empty result set. Reported so that it can be
+	// excluded from alerting, since it is a normal outcome for many queries.
+	ErrKindNoRows = "no_rows"
+	// ErrKindReadOnlyTransaction means PostgreSQL refused a write because the
+	// session is read-only, which is what a replica reports while it is being
+	// promoted. A sustained rate of these means writes are failing cluster-wide.
+	ErrKindReadOnlyTransaction = "read_only_transaction"
+	// ErrKindUnavailable covers administrator shutdown and "cannot connect now",
+	// i.e. the server is restarting or failing over.
+	ErrKindUnavailable = "unavailable"
+	// ErrKindTooManyConnections means the server rejected the connection because
+	// its connection slots are exhausted.
+	ErrKindTooManyConnections = "too_many_connections"
+	// ErrKindInsufficientResources covers the remaining out-of-resource errors.
+	ErrKindInsufficientResources = "insufficient_resources"
+	// ErrKindConnection is a transport level failure: refused, reset, bad conn.
+	ErrKindConnection = "connection"
+	// ErrKindTimeout is a deadline exceeded on the caller side.
+	ErrKindTimeout = "timeout"
+	// ErrKindCanceled means the caller's context was canceled, usually because
+	// the HTTP client that triggered the query went away.
+	ErrKindCanceled = "canceled"
+	// ErrKindConstraint is an integrity constraint violation (unique, fk, ...).
+	ErrKindConstraint = "constraint"
+	// ErrKindSerialization covers deadlocks and serialization failures.
+	ErrKindSerialization = "serialization"
+	// ErrKindInvalidTxState is an invalid transaction state other than read-only.
+	ErrKindInvalidTxState = "invalid_transaction_state"
+	// ErrKindSyntaxOrAccess is a malformed statement or a permission problem,
+	// which almost always means a code or migration bug rather than an outage.
+	ErrKindSyntaxOrAccess = "syntax_or_access"
+	// ErrKindSystemError is a server side I/O error.
+	ErrKindSystemError = "system_error"
+	// ErrKindOther is anything not recognised above.
+	ErrKindOther = "other"
+)
+
+// Operation values for the "operation" label. The SQL verb is used rather than
+// the calling method so that the label stays low cardinality across the ~150
+// database helpers in the client package.
+const (
+	OpSelect = "select"
+	OpInsert = "insert"
+	OpUpdate = "update"
+	OpDelete = "delete"
+	OpWith   = "with"
+	OpOther  = "other"
+)
+
+const (
+	statusSuccess = "success"
+	statusError   = "error"
+)
+
+var (
+	dbOperationDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "safe_db_operation_duration_seconds",
+		Help: "Latency of database operations, by driver, SQL verb and outcome.",
+		// Reaches 30s because the client-side request timeout defaults to 20s
+		// and connection acquisition can stall for longer during a failover.
+		Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30},
+	}, []string{"driver", "operation", "status"})
+
+	dbErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "safe_db_errors_total",
+		Help: "Database operation failures, by driver, SQL verb and error kind.",
+	}, []string{"driver", "operation", "kind"})
+)
+
+// ObserveDBOperation records the latency and outcome of a single database
+// operation. A nil err counts as a success; sql.ErrNoRows is treated as a
+// success as well because it is a normal result rather than a fault.
+func ObserveDBOperation(driverName, operation string, start time.Time, err error) {
+	kind := ClassifyDBError(err)
+	status := statusSuccess
+	if err != nil && kind != ErrKindNoRows {
+		status = statusError
+		dbErrors.WithLabelValues(driverName, operation, kind).Inc()
+	}
+	dbOperationDuration.WithLabelValues(driverName, operation, status).Observe(time.Since(start).Seconds())
+}
+
+// SQLOperation extracts the leading verb of a SQL statement so it can be used
+// as a metric label. Unrecognised statements collapse to OpOther to keep the
+// label bounded.
+func SQLOperation(query string) string {
+	statement := strings.TrimLeft(query, " \t\r\n(")
+	end := strings.IndexFunc(statement, unicode.IsSpace)
+	if end < 0 {
+		end = len(statement)
+	}
+	switch strings.ToLower(statement[:end]) {
+	case "select":
+		return OpSelect
+	case "insert":
+		return OpInsert
+	case "update":
+		return OpUpdate
+	case "delete":
+		return OpDelete
+	case "with":
+		return OpWith
+	default:
+		return OpOther
+	}
+}
+
+// ClassifyDBError maps an error returned by the database layer onto one of the
+// ErrKind constants. It returns an empty string for a nil error.
+func ClassifyDBError(err error) string {
+	if err == nil {
+		return ""
+	}
+	switch {
+	case errors.Is(err, sql.ErrNoRows), errors.Is(err, gorm.ErrRecordNotFound):
+		return ErrKindNoRows
+	case errors.Is(err, context.DeadlineExceeded):
+		return ErrKindTimeout
+	case errors.Is(err, context.Canceled):
+		return ErrKindCanceled
+	case errors.Is(err, driver.ErrBadConn), errors.Is(err, io.EOF), errors.Is(err, io.ErrUnexpectedEOF):
+		return ErrKindConnection
+	}
+
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) {
+		return classifyPQCode(pqErr.Code)
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		if netErr.Timeout() {
+			return ErrKindTimeout
+		}
+		return ErrKindConnection
+	}
+	return ErrKindOther
+}
+
+// classifyPQCode maps a PostgreSQL SQLSTATE onto an error kind. Specific codes
+// are checked before falling back to the two character class.
+func classifyPQCode(code pq.ErrorCode) string {
+	switch code {
+	case "25006": // read_only_sql_transaction
+		return ErrKindReadOnlyTransaction
+	case "53300": // too_many_connections
+		return ErrKindTooManyConnections
+	case "57P01", "57P02", "57P03": // admin_shutdown, crash_shutdown, cannot_connect_now
+		return ErrKindUnavailable
+	}
+	switch code.Class() {
+	case "08": // connection_exception
+		return ErrKindConnection
+	case "23": // integrity_constraint_violation
+		return ErrKindConstraint
+	case "25": // invalid_transaction_state
+		return ErrKindInvalidTxState
+	case "40": // transaction_rollback, includes deadlock_detected
+		return ErrKindSerialization
+	case "42": // syntax_error_or_access_rule_violation
+		return ErrKindSyntaxOrAccess
+	case "53": // insufficient_resources
+		return ErrKindInsufficientResources
+	case "57": // operator_intervention
+		return ErrKindUnavailable
+	case "58": // system_error
+		return ErrKindSystemError
+	}
+	return ErrKindOther
+}
+
+// PoolStatsFunc reports the current statistics of a connection pool.
+type PoolStatsFunc func() sql.DBStats
+
+// dbPoolCollector publishes sql.DBStats for every registered pool. A single
+// collector serves all pools so that additional pools can be registered after
+// the collector is already bound to the default registry.
+type dbPoolCollector struct {
+	mu    sync.RWMutex
+	pools map[string]PoolStatsFunc
+
+	connections     *prometheus.Desc
+	maxOpen         *prometheus.Desc
+	waitCount       *prometheus.Desc
+	waitDuration    *prometheus.Desc
+	closedMaxIdle   *prometheus.Desc
+	closedMaxLifeTm *prometheus.Desc
+}
+
+var poolCollector = newDBPoolCollector()
+
+func newDBPoolCollector() *dbPoolCollector {
+	return &dbPoolCollector{
+		pools: map[string]PoolStatsFunc{},
+		connections: prometheus.NewDesc(
+			"safe_db_pool_connections",
+			"Number of database connections in the pool, by state.",
+			[]string{"pool", "state"}, nil),
+		maxOpen: prometheus.NewDesc(
+			"safe_db_pool_max_open_connections",
+			"Configured upper bound on open connections.",
+			[]string{"pool"}, nil),
+		waitCount: prometheus.NewDesc(
+			"safe_db_pool_wait_count_total",
+			"Total number of times a caller had to wait for a connection.",
+			[]string{"pool"}, nil),
+		waitDuration: prometheus.NewDesc(
+			"safe_db_pool_wait_duration_seconds_total",
+			"Total time callers spent waiting for a connection.",
+			[]string{"pool"}, nil),
+		closedMaxIdle: prometheus.NewDesc(
+			"safe_db_pool_closed_max_idle_total",
+			"Total connections closed because the idle limit was reached.",
+			[]string{"pool"}, nil),
+		closedMaxLifeTm: prometheus.NewDesc(
+			"safe_db_pool_closed_max_lifetime_total",
+			"Total connections closed because the lifetime limit was reached.",
+			[]string{"pool"}, nil),
+	}
+}
+
+func init() {
+	ctrlmetrics.Registry.MustRegister(
+		dbOperationDuration,
+		dbErrors,
+		poolCollector,
+	)
+}
+
+// RegisterDBPool starts publishing pool statistics under the given pool name.
+// Registering the same name twice replaces the previous source, which keeps the
+// call idempotent for singleton clients.
+func RegisterDBPool(pool string, stats PoolStatsFunc) {
+	if stats == nil {
+		return
+	}
+	poolCollector.mu.Lock()
+	defer poolCollector.mu.Unlock()
+	poolCollector.pools[pool] = stats
+}
+
+func (c *dbPoolCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.connections
+	ch <- c.maxOpen
+	ch <- c.waitCount
+	ch <- c.waitDuration
+	ch <- c.closedMaxIdle
+	ch <- c.closedMaxLifeTm
+}
+
+func (c *dbPoolCollector) Collect(ch chan<- prometheus.Metric) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	for pool, stats := range c.pools {
+		s := stats()
+		ch <- prometheus.MustNewConstMetric(c.connections, prometheus.GaugeValue, float64(s.OpenConnections), pool, "open")
+		ch <- prometheus.MustNewConstMetric(c.connections, prometheus.GaugeValue, float64(s.InUse), pool, "in_use")
+		ch <- prometheus.MustNewConstMetric(c.connections, prometheus.GaugeValue, float64(s.Idle), pool, "idle")
+		ch <- prometheus.MustNewConstMetric(c.maxOpen, prometheus.GaugeValue, float64(s.MaxOpenConnections), pool)
+		ch <- prometheus.MustNewConstMetric(c.waitCount, prometheus.CounterValue, float64(s.WaitCount), pool)
+		ch <- prometheus.MustNewConstMetric(c.waitDuration, prometheus.CounterValue, s.WaitDuration.Seconds(), pool)
+		ch <- prometheus.MustNewConstMetric(c.closedMaxIdle, prometheus.CounterValue, float64(s.MaxIdleClosed), pool)
+		ch <- prometheus.MustNewConstMetric(c.closedMaxLifeTm, prometheus.CounterValue, float64(s.MaxLifetimeClosed), pool)
+	}
+}

--- a/SaFE/common/pkg/metrics/db_test.go
+++ b/SaFE/common/pkg/metrics/db_test.go
@@ -132,22 +132,65 @@ func histogramCount(t *testing.T, labels ...string) uint64 {
 	return collected.GetHistogram().GetSampleCount()
 }
 
-func TestRegisterDBPool(t *testing.T) {
-	RegisterDBPool("test_pool", func() sql.DBStats {
-		return sql.DBStats{MaxOpenConnections: 100, OpenConnections: 7, InUse: 3, Idle: 4, WaitCount: 11}
+// The sqlx and GORM pools of one database are distinct connection pools and
+// must be reported separately rather than one silently shadowing the other.
+func TestRegisterDBPoolSeparatesDrivers(t *testing.T) {
+	sqlxKey := PoolKey{Pool: "db-a:5432/safe", Driver: DriverSqlx}
+	gormKey := PoolKey{Pool: "db-a:5432/safe", Driver: DriverGorm}
+	t.Cleanup(func() {
+		UnregisterDBPool(sqlxKey)
+		UnregisterDBPool(gormKey)
+	})
+
+	RegisterDBPool(sqlxKey, func() sql.DBStats {
+		return sql.DBStats{MaxOpenConnections: 100, OpenConnections: 7, InUse: 3, Idle: 4}
+	})
+	RegisterDBPool(gormKey, func() sql.DBStats {
+		return sql.DBStats{OpenConnections: 5, InUse: 1, Idle: 4}
 	})
 
 	expected := `
 # HELP safe_db_pool_connections Number of database connections in the pool, by state.
 # TYPE safe_db_pool_connections gauge
-safe_db_pool_connections{pool="test_pool",state="idle"} 4
-safe_db_pool_connections{pool="test_pool",state="in_use"} 3
-safe_db_pool_connections{pool="test_pool",state="open"} 7
+safe_db_pool_connections{driver="gorm",pool="db-a:5432/safe",state="idle"} 4
+safe_db_pool_connections{driver="gorm",pool="db-a:5432/safe",state="in_use"} 1
+safe_db_pool_connections{driver="gorm",pool="db-a:5432/safe",state="open"} 5
+safe_db_pool_connections{driver="sqlx",pool="db-a:5432/safe",state="idle"} 4
+safe_db_pool_connections{driver="sqlx",pool="db-a:5432/safe",state="in_use"} 3
+safe_db_pool_connections{driver="sqlx",pool="db-a:5432/safe",state="open"} 7
 `
 	assert.NoError(t, testutil.CollectAndCompare(poolCollector, strings.NewReader(expected), "safe_db_pool_connections"))
 }
 
+// Two clients against the same database name on different servers must not
+// shadow each other, which is why the key carries the host and port.
+func TestRegisterDBPoolDistinguishesHosts(t *testing.T) {
+	first := PoolKey{Pool: "db-a:5432/safe", Driver: DriverSqlx}
+	second := PoolKey{Pool: "db-b:5432/safe", Driver: DriverSqlx}
+	t.Cleanup(func() {
+		UnregisterDBPool(first)
+		UnregisterDBPool(second)
+	})
+
+	RegisterDBPool(first, func() sql.DBStats { return sql.DBStats{OpenConnections: 1} })
+	RegisterDBPool(second, func() sql.DBStats { return sql.DBStats{OpenConnections: 2} })
+
+	assert.Equal(t, 6, testutil.CollectAndCount(poolCollector, "safe_db_pool_connections"))
+}
+
+// A closed pool otherwise keeps reporting a frozen set of zeroes forever.
+func TestUnregisterDBPool(t *testing.T) {
+	key := PoolKey{Pool: "db-gone:5432/safe", Driver: DriverSqlx}
+	RegisterDBPool(key, func() sql.DBStats { return sql.DBStats{OpenConnections: 3} })
+	require.Equal(t, 3, testutil.CollectAndCount(poolCollector, "safe_db_pool_connections"))
+
+	UnregisterDBPool(key)
+	assert.Equal(t, 0, testutil.CollectAndCount(poolCollector, "safe_db_pool_connections"))
+}
+
 // RegisterDBPool must not panic when handed a nil source.
 func TestRegisterDBPoolNil(t *testing.T) {
-	assert.NotPanics(t, func() { RegisterDBPool("nil_pool", nil) })
+	assert.NotPanics(t, func() {
+		RegisterDBPool(PoolKey{Pool: "nil-pool", Driver: DriverSqlx}, nil)
+	})
 }

--- a/SaFE/common/pkg/metrics/db_test.go
+++ b/SaFE/common/pkg/metrics/db_test.go
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+package metrics
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func TestClassifyDBError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"nil is not an error", nil, ""},
+		{"no rows from sqlx", sql.ErrNoRows, ErrKindNoRows},
+		{"no rows from gorm", gorm.ErrRecordNotFound, ErrKindNoRows},
+		{"deadline exceeded", context.DeadlineExceeded, ErrKindTimeout},
+		{"canceled", context.Canceled, ErrKindCanceled},
+		{"bad connection", driver.ErrBadConn, ErrKindConnection},
+		{"unexpected eof", io.ErrUnexpectedEOF, ErrKindConnection},
+		// 25006 is what a PostgreSQL replica returns for a write while it is
+		// being promoted, which is the signal an operator needs to page on.
+		{"read only transaction", &pq.Error{Code: "25006"}, ErrKindReadOnlyTransaction},
+		{"other invalid tx state", &pq.Error{Code: "25001"}, ErrKindInvalidTxState},
+		{"too many connections", &pq.Error{Code: "53300"}, ErrKindTooManyConnections},
+		{"other insufficient resources", &pq.Error{Code: "53200"}, ErrKindInsufficientResources},
+		{"cannot connect now", &pq.Error{Code: "57P03"}, ErrKindUnavailable},
+		{"admin shutdown", &pq.Error{Code: "57P01"}, ErrKindUnavailable},
+		{"connection exception", &pq.Error{Code: "08006"}, ErrKindConnection},
+		{"unique violation", &pq.Error{Code: "23505"}, ErrKindConstraint},
+		{"deadlock", &pq.Error{Code: "40P01"}, ErrKindSerialization},
+		{"syntax error", &pq.Error{Code: "42601"}, ErrKindSyntaxOrAccess},
+		{"system error", &pq.Error{Code: "58030"}, ErrKindSystemError},
+		{"unknown pq class", &pq.Error{Code: "P0001"}, ErrKindOther},
+		{"wrapped pq error", fmt.Errorf("upsert failed: %w", &pq.Error{Code: "25006"}), ErrKindReadOnlyTransaction},
+		{"connection reset", &net.OpError{Op: "read", Err: syscall.ECONNRESET}, ErrKindConnection},
+		{"plain error", errors.New("boom"), ErrKindOther},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ClassifyDBError(tt.err))
+		})
+	}
+}
+
+func TestClassifyDBErrorNetworkTimeout(t *testing.T) {
+	// A dial timeout reports Timeout() true and must not be lumped in with
+	// connection failures, because the two have different remediations.
+	err := &net.OpError{Op: "dial", Err: &timeoutError{}}
+	assert.Equal(t, ErrKindTimeout, ClassifyDBError(err))
+}
+
+// timeoutError is a net.Error that reports itself as a timeout.
+type timeoutError struct{}
+
+func (e *timeoutError) Error() string   { return "i/o timeout" }
+func (e *timeoutError) Timeout() bool   { return true }
+func (e *timeoutError) Temporary() bool { return true }
+
+func TestSQLOperation(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+		want  string
+	}{
+		{"select", "SELECT * FROM workload WHERE id = $1", OpSelect},
+		{"lowercase select", "select 1", OpSelect},
+		{"insert with leading newline", "\nINSERT INTO user_token (a)\nVALUES (:a)\n", OpInsert},
+		{"verb followed by newline", "SELECT\n*\nFROM workload", OpSelect},
+		{"update with leading spaces", "   UPDATE workload SET x = 1", OpUpdate},
+		{"delete", "DELETE FROM workload", OpDelete},
+		{"cte", "WITH ranked AS (SELECT 1) SELECT * FROM ranked", OpWith},
+		{"parenthesised select", "(SELECT 1)", OpSelect},
+		{"unknown verb", "EXPLAIN ANALYZE SELECT 1", OpOther},
+		{"empty", "", OpOther},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, SQLOperation(tt.query))
+		})
+	}
+}
+
+func TestObserveDBOperation(t *testing.T) {
+	// Use a driver label unique to this test so the series stay isolated from
+	// other tests sharing the default registry.
+	const testDriver = "test_observe"
+
+	ObserveDBOperation(testDriver, OpSelect, time.Now(), nil)
+	assert.Equal(t, uint64(1), histogramCount(t, testDriver, OpSelect, statusSuccess))
+
+	// An empty result set is a normal outcome and must not count as an error.
+	ObserveDBOperation(testDriver, OpSelect, time.Now(), sql.ErrNoRows)
+	assert.Equal(t, uint64(2), histogramCount(t, testDriver, OpSelect, statusSuccess))
+	assert.Equal(t, 0.0, testutil.ToFloat64(dbErrors.WithLabelValues(testDriver, OpSelect, ErrKindNoRows)))
+
+	ObserveDBOperation(testDriver, OpInsert, time.Now(), &pq.Error{Code: "25006"})
+	assert.Equal(t, 1.0, testutil.ToFloat64(dbErrors.WithLabelValues(testDriver, OpInsert, ErrKindReadOnlyTransaction)))
+	assert.Equal(t, uint64(1), histogramCount(t, testDriver, OpInsert, statusError))
+}
+
+// histogramCount reports how many observations landed on one series of
+// dbOperationDuration.
+func histogramCount(t *testing.T, labels ...string) uint64 {
+	t.Helper()
+	observer, err := dbOperationDuration.GetMetricWithLabelValues(labels...)
+	require.NoError(t, err)
+	var collected dto.Metric
+	require.NoError(t, observer.(prometheus.Metric).Write(&collected))
+	return collected.GetHistogram().GetSampleCount()
+}
+
+func TestRegisterDBPool(t *testing.T) {
+	RegisterDBPool("test_pool", func() sql.DBStats {
+		return sql.DBStats{MaxOpenConnections: 100, OpenConnections: 7, InUse: 3, Idle: 4, WaitCount: 11}
+	})
+
+	expected := `
+# HELP safe_db_pool_connections Number of database connections in the pool, by state.
+# TYPE safe_db_pool_connections gauge
+safe_db_pool_connections{pool="test_pool",state="idle"} 4
+safe_db_pool_connections{pool="test_pool",state="in_use"} 3
+safe_db_pool_connections{pool="test_pool",state="open"} 7
+`
+	assert.NoError(t, testutil.CollectAndCompare(poolCollector, strings.NewReader(expected), "safe_db_pool_connections"))
+}
+
+// RegisterDBPool must not panic when handed a nil source.
+func TestRegisterDBPoolNil(t *testing.T) {
+	assert.NotPanics(t, func() { RegisterDBPool("nil_pool", nil) })
+}


### PR DESCRIPTION
## Why

`/api/v1/login` has been failing intermittently, and the only way to investigate was container logs, which rotate within a couple of hours under the current log volume. There was no signal that could tell us whether a given failure came from the Okta token exchange or from PostgreSQL — the two suspects behind the failures seen so far (stalled token exchanges ending in a TCP reset, and `cannot execute INSERT in a read-only transaction`).

This adds the metrics needed to answer that question at the moment it happens rather than afterwards.

## What

**SSO / Okta** (`SaFE/apiserver/pkg/metrics`)

- `safe_apiserver_sso_login_total{result,stage}` — every login attempt, labelled with the stage that decided it. `stage="token_exchange"` means Okta broke the login, `stage="db_session"` means the database did.
- `safe_apiserver_sso_idp_request_duration_seconds{operation,status}` — latency of outbound calls to the provider (`token_exchange`, `token_verify`, `provider_discovery`), with buckets up to 60s since a stalled exchange can run that long.
- `safe_apiserver_sso_idp_errors_total{operation,kind}` — `canceled`, `timeout`, `connection_reset`, `dns`, `tls`, `invalid_grant` and friends are separated, because those are exactly the shapes the observed failures take: `canceled` is the browser giving up at its own 10s timeout, `connection_reset` is the stalled connection finally dying.

**Database** (`SaFE/common/pkg/metrics`)

- `safe_db_operation_duration_seconds{driver,operation,status}` and `safe_db_errors_total{driver,operation,kind}` for every query.
- `safe_db_pool_*` gauges and counters from `sql.DBStats` (open/in-use/idle, wait count and duration), so pool exhaustion is visible.
- PostgreSQL SQLSTATEs are folded into coarse kinds, keeping `read_only_transaction` (25006) as its own kind since that is what a replica returns while it is being promoted. `no_rows` is deliberately not counted as an error.

## How it is wired

No CRUD helper had to change. The client package issues queries through two paths, so instrumentation went in at each connection choke point:

- **sqlx** — `getDB()` now returns a wrapper that embeds `*sqlx.DB` and overrides the five query methods the package uses. All 89 call sites are unaffected.
- **GORM** — `ConnectGorm` installs a callback plugin covering create/query/update/delete/row/raw.

Statements inside a transaction from `BeginTxx` (one call site) are not measured individually.

## Registry choice

Metrics register on the **controller-runtime registry**, matching `job-manager` and `resource-manager`. This is load-bearing: controller-runtime's metrics server serves only its own registry, so anything registered on the Prometheus default registry via `promauto` is never exposed. I confirmed against the running cluster that `/metrics` on the apiserver's port 8000 serves that registry, and that the `safe-to-global` vmagent scrapes it.

## Test plan

- [x] Unit tests for SQLSTATE and identity-provider error classification, including a case that reproduces the exact `25006` failure and one that reproduces a `connection_reset` behind a `*url.Error`.
- [x] End-to-end tests through the real client over `go-sqlmock`, asserting both the sqlx wrapper and the GORM plugin emit the expected series.
- [x] `go build` and `go test` clean for `common` and `apiserver`; `job-manager` and `resource-manager` build against the changed `common`.
- [ ] After deploy, confirm the new `safe_apiserver_sso_*` and `safe_db_*` series appear on the apiserver `/metrics` endpoint.

Alert rules are intentionally not included; where they should live still needs to be decided.

Made with [Cursor](https://cursor.com)