### PR TITLE
feat(addon): consume the upstream infera-operator instead of a mirror

### DIFF
--- a/SaFE/charts/primus-safe-cr/templates/addon_template/infera-operator.0.1.0.yaml
+++ b/SaFE/charts/primus-safe-cr/templates/addon_template/infera-operator.0.1.0.yaml
@@ -11,27 +11,40 @@
 # direct-mode frontend sidecar into worker pods, and creates an InferencePool +
 # HTTPRoute attaching to a Kubernetes Inference Gateway (kgateway).
 #
-# 0.1.2: ServiceSpec.skipReadinessProbe — the operator no longer injects its
-# default /health readiness probe on worker services that set the flag. Idle-pod
-# / SSH-managed workers (the optimizer create-infera model) launch the engine
-# out-of-band after deploy, so a /health probe never passes at deploy time,
-# leaving readyReplicas=0 and the InferaDeployment stuck in "pending" (which
-# blocks create-infera's wait-for-Running). CRD schema changed — ops must
-# `kubectl apply` the new CRD to each data plane (Helm never upgrades CRDs).
+# 0.1.0: the Infera project now publishes the operator itself, so this addon
+# consumes the upstream artefacts under rocm/ rather than a primussafe/ copy
+# ops had to mirror by hand. The version line restarts at 0.1.0 to track
+# upstream's; both earlier fixes are present in it (verified against the
+# sources, not assumed):
 #
-# 0.1.1: Reconcile() early-returns on a non-zero DeletionTimestamp so the
-# operator no longer recreates child Deployments/StatefulSets while job-manager
-# (or Kubernetes GC) tears an InferaDeployment down.
+#   chart  oci://<helm_registry>/rocm/infera-operator:0.1.0
+#   image  <proxy_image_registry>/rocm/infera:operator-v0.1.0
+#
+# The image is a tag of the shared rocm/infera repo, alongside the engine
+# images; the chart is a separate OCI repo, so an image tag and a chart version
+# cannot overwrite each other. Both registries default to registry-1.docker.io,
+# so a stock install pulls straight from Docker Hub — install.sh / upgrade.sh
+# repoint them at the Harbor proxy-cache when deploying against Harbor.
+#
+# Carried forward from the mirrored builds this replaces:
+#   0.1.2: ServiceSpec.skipReadinessProbe — the operator no longer injects its
+#   default /health readiness probe on worker services that set the flag.
+#   Idle-pod / SSH-managed workers (the optimizer create-infera model) launch
+#   the engine out-of-band after deploy, so a /health probe never passes at
+#   deploy time, leaving readyReplicas=0 and the InferaDeployment stuck in
+#   "pending" (which blocks create-infera's wait-for-Running).
+#
+#   0.1.1: Reconcile() early-returns on a non-zero DeletionTimestamp so the
+#   operator no longer recreates child Deployments/StatefulSets while
+#   job-manager (or Kubernetes GC) tears an InferaDeployment down.
 #
 # Notes:
 #   - Reuses cluster addons: nats.1.3.2 (KV-event plane; the workload template
 #     sets nats.deploy=false + NATS_SERVER) and lws.0.8.0 (multi-node only).
-#   - Ops must mirror to Harbor: chart oci://<helm_registry>/primussafe/
-#     infera-operator and image <registry>/primussafe/infera-operator-manager
-#     (distinct repos to avoid an OCI tag clash; build via make docker-build).
 #   - CRD ships in the chart crds/, but Helm only installs crds/ on first
-#     install (never on upgrade). When bumping the operator version with CRD
-#     schema changes, ops must `kubectl apply` the new CRD to each data plane.
+#     install (never on upgrade). Coming from a mirrored 0.1.x, ops must
+#     `kubectl apply` the chart's CRD to each data plane — the schema differs
+#     from what those builds installed.
 #   - Default addon (auto-installed per cluster); drop the
 #     primus-safe.addon.default label to make it opt-in.
 #
@@ -40,28 +53,28 @@ apiVersion: amd.com/v1
 kind: AddonTemplate
 metadata:
   labels:
-    primus-safe.display.name: "infera-operator.0.1.2"
+    primus-safe.display.name: "infera-operator.0.1.0"
     app.kubernetes.io/managed-by: Helm
     primus-safe.addon.default: ""
   annotations:
     meta.helm.sh/release-name: {{ .Release.Name }}
     meta.helm.sh/release-namespace: {{ .Release.Namespace }}
-  name: infera-operator.0.1.2
+  name: infera-operator.0.1.0
 spec:
   category: plugin
   description: Infera Kubernetes operator. Reconciles InferaDeployment (infera.amd.com/v1alpha1) into Deployments / LeaderWorkerSets for aggregated and disaggregated (prefill/decode) LLM serving on AMD MI300X. Underlying resource for the InferaDeployment workload kind. Self-contained — does not require the NVIDIA dynamo operator; reuses the cluster NATS (nats.1.3.2) and, for multi-node, the LWS controller (lws.0.8.0). Includes Gateway API Inference Extension (GAIE) integration.
-  # OCI helm chart mirrored on SaFE Harbor (ops to mirror, see header note 2).
+  # Published upstream by the Infera project; no primussafe mirror to maintain.
   # Upstream source path: deploy/operator/helm/infera-operator
-  url: oci://{{ .Values.global.helm_registry }}/primussafe/infera-operator
-  version: 0.1.2
+  url: oci://{{ .Values.global.helm_registry }}/rocm/infera-operator
+  version: 0.1.0
   type: helm
   helmDefaultNamespace: infera-system
   helmDefaultValues: |
     replicaCount: 1
 
     image:
-      repository: {{ .Values.global.proxy_image_registry }}/primussafe/infera-operator-manager
-      tag: "0.1.2"
+      repository: {{ .Values.global.proxy_image_registry }}/rocm/infera
+      tag: "operator-v0.1.0"
       pullPolicy: IfNotPresent
 
     leaderElection:
@@ -80,5 +93,4 @@ spec:
     serviceAccount:
       create: true
 
-    # SaFE Harbor allows anonymous pull for primussafe/* repos.
     imagePullSecrets: []


### PR DESCRIPTION
## Summary

The Infera project now publishes the operator chart and image itself, so this addon can consume them directly instead of the `primussafe/` copies ops had to mirror by hand before every release.

|  | before | after |
|---|---|---|
| chart | `oci://<helm_registry>/primussafe/infera-operator:0.1.2` | `oci://<helm_registry>/rocm/infera-operator:0.1.0` |
| image | `<proxy_image_registry>/primussafe/infera-operator-manager:0.1.2` | `<proxy_image_registry>/rocm/infera:operator-v0.1.0` |

Both registries still come from `values.global.*`, so Harbor deployments keep resolving through the proxy-cache — only the repository path changes. With the defaults (`registry-1.docker.io`) a stock install now pulls straight from the public repos.

The image is a tag of the shared `rocm/infera` repo alongside the engine images; the chart is a separate OCI repo, so an image tag and a chart version cannot overwrite each other.

Upstream side: AMD-AGI/Infera#90.

## Version restarts at 0.1.0

That is what upstream publishes, so it is forced — Helm has to resolve `version: 0.1.0` from the registry.

Nothing is lost by going backwards from the mirrored 0.1.2. Both earlier fixes are present in the upstream sources, verified rather than assumed:

- `skipReadinessProbe` (mirrored 0.1.2) — `api/v1alpha1/inferadeployment_types.go:95`
- `DeletionTimestamp` early-return (mirrored 0.1.1) — `internal/controller/inferadeployment_controller.go:66`

The file header keeps the record of what each one fixed, so a reader coming from 0.1.2 does not have to guess.

## For ops, before rolling this out

- **CRD needs a manual apply.** The schema differs from the mirrored builds and Helm never upgrades `crds/`, so each data plane needs `kubectl apply` of the chart's CRD.
- **The template name moves backwards** (`infera-operator.0.1.2` → `infera-operator.0.1.0`). Worth confirming against `isTemplateVersionEqual` / `shouldIgnoreUpgrade` that clusters already running 0.1.2 detect this as an upgrade rather than skipping it.

## Test plan

- [x] `helm template primus-safe-cr ./primus-safe-cr` renders `url: oci://registry-1.docker.io/rocm/infera-operator`, `version: 0.1.0`, `repository: registry-1.docker.io/rocm/infera`, `tag: operator-v0.1.0`
- [x] Confirmed no SaFE code reads Infera's `config/rbac/role.yaml`; the addon sets `rbac.create: true`, so the ClusterRole comes from the chart template
- [ ] Install on a data plane once the upstream artefacts are promoted to `rocm/`
- [ ] Confirm the addon upgrade path from a cluster running `infera-operator.0.1.2`

Made with [Cursor](https://cursor.com)