### PR TITLE
feat(safe): multi control-plane apiserver HA failover

### DIFF
--- a/SaFE/apiserver/pkg/controllers/cluster_controller.go
+++ b/SaFE/apiserver/pkg/controllers/cluster_controller.go
@@ -134,6 +134,7 @@ func (r *ClusterReconciler) addClientFactory(ctx context.Context, cluster *v1.Cl
 	if obj, ok := clientManager.Get(cluster.Name); ok {
 		if factory, ok := obj.(*commonclient.ClientFactory); ok &&
 			!commoncluster.ClientFactoryNeedsRefresh(ctx, r.Client, cluster, factory) {
+			invalidateUnreachableClientFactory(factory)
 			return nil
 		}
 	}
@@ -150,4 +151,21 @@ func (r *ClusterReconciler) addClientFactory(ctx context.Context, cluster *v1.Cl
 	klog.Infof("add cluster %s clients, endpoint: %s, selected: %s",
 		cluster.Name, endpoint, k8sClientFactory.Endpoint())
 	return nil
+}
+
+// invalidateUnreachableClientFactory marks a factory invalid once its apiserver stops responding.
+// apiserver runs its data-plane clients without informers, so there is no watch error handler to
+// report broken connections and requests would otherwise keep using a dead client.
+func invalidateUnreachableClientFactory(factory *commonclient.ClientFactory) {
+	if !factory.IsValid() {
+		return
+	}
+	restCfg := factory.RestConfig()
+	if restCfg == nil {
+		return
+	}
+	if err := commonclient.ProbeRESTConfig(restCfg); err != nil {
+		klog.Warningf("cluster %s data-plane apiserver is unreachable: %v", factory.Name(), err)
+		factory.SetValid(false, err.Error())
+	}
 }

--- a/SaFE/apiserver/pkg/controllers/cluster_controller.go
+++ b/SaFE/apiserver/pkg/controllers/cluster_controller.go
@@ -8,6 +8,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"k8s.io/klog/v2"
 	ctrlruntime "sigs.k8s.io/controller-runtime"
@@ -21,6 +22,11 @@ import (
 	commoncluster "github.com/AMD-AIG-AIMA/SAFE/common/pkg/cluster"
 	commonclient "github.com/AMD-AIG-AIMA/SAFE/common/pkg/k8sclient"
 	commonutils "github.com/AMD-AIG-AIMA/SAFE/common/pkg/utils"
+)
+
+const (
+	// clusterClientFactoryRefreshInterval requeues ready clusters to rebuild invalid data-plane clients.
+	clusterClientFactoryRefreshInterval = 15 * time.Second
 )
 
 type ClusterReconciler struct {
@@ -86,11 +92,19 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrlruntime.Reque
 	if !cluster.GetDeletionTimestamp().IsZero() {
 		return ctrlruntime.Result{}, r.deleteClientFactory(cluster)
 	}
-	if err = r.addClientFactory(r.ctx, cluster); err != nil {
+	if err = r.addClientFactory(ctx, cluster); err != nil {
 		klog.Errorf("failed to add cluster clients, err: %v", err)
 		return ctrlruntime.Result{}, err
 	}
+	if shouldPeriodicRefreshClientFactory(cluster) {
+		return ctrlruntime.Result{RequeueAfter: clusterClientFactoryRefreshInterval}, nil
+	}
 	return ctrlruntime.Result{}, nil
+}
+
+// shouldPeriodicRefreshClientFactory reports whether reconcile should requeue to refresh clients.
+func shouldPeriodicRefreshClientFactory(cluster *v1.Cluster) bool {
+	return cluster != nil && cluster.GetDeletionTimestamp().IsZero() && cluster.IsReady()
 }
 
 // deleteClientFactory removes the Kubernetes client factory for a cluster being deleted.
@@ -109,7 +123,6 @@ func (r *ClusterReconciler) deleteClientFactory(cluster *v1.Cluster) error {
 }
 
 // addClientFactory creates and registers a new Kubernetes client factory for a ready cluster.
-// It retrieves cluster endpoint and credentials, then initializes a client factory for communicating with the cluster.
 func (r *ClusterReconciler) addClientFactory(ctx context.Context, cluster *v1.Cluster) error {
 	if !cluster.IsReady() {
 		return nil
@@ -118,21 +131,23 @@ func (r *ClusterReconciler) addClientFactory(ctx context.Context, cluster *v1.Cl
 	if clientManager == nil {
 		return fmt.Errorf("failed to initialize cluster client manager for cluster %s", cluster.Name)
 	}
-	if clientManager.Has(cluster.Name) {
-		return nil
+	if obj, ok := clientManager.Get(cluster.Name); ok {
+		if factory, ok := obj.(*commonclient.ClientFactory); ok &&
+			!commoncluster.ClientFactoryNeedsRefresh(ctx, r.Client, cluster, factory) {
+			return nil
+		}
 	}
 	endpoint, err := commoncluster.GetEndpoint(ctx, r.Client, cluster)
 	if err != nil {
 		return err
 	}
-
-	controlPlane := &cluster.Status.ControlPlaneStatus
-	k8sClientFactory, err := commonclient.NewClientFactory(ctx, cluster.Name, endpoint,
-		controlPlane.CertData, controlPlane.KeyData, controlPlane.CAData, commonclient.DisableInformer)
+	k8sClientFactory, err := commoncluster.NewClientFactoryForCluster(ctx, r.Client, cluster,
+		commonclient.DisableInformer)
 	if err != nil {
 		return err
 	}
 	clientManager.AddOrReplace(cluster.Name, k8sClientFactory)
-	klog.Infof("add cluster %s clients", cluster.Name)
+	klog.Infof("add cluster %s clients, endpoint: %s, selected: %s",
+		cluster.Name, endpoint, k8sClientFactory.Endpoint())
 	return nil
 }

--- a/SaFE/apiserver/pkg/controllers/cluster_controller.go
+++ b/SaFE/apiserver/pkg/controllers/cluster_controller.go
@@ -8,6 +8,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -27,11 +28,18 @@ import (
 const (
 	// clusterClientFactoryRefreshInterval requeues ready clusters to rebuild invalid data-plane clients.
 	clusterClientFactoryRefreshInterval = 15 * time.Second
+	// clusterProbeFailureThreshold is how many consecutive probe failures drop a client factory.
+	// Requests are rejected while a factory is invalid, so one transient failure must not take a
+	// cluster out of service.
+	clusterProbeFailureThreshold = 3
 )
 
 type ClusterReconciler struct {
 	ctx context.Context
 	client.Client
+	// probeFailures counts consecutive data-plane probe failures per cluster.
+	probeMu       sync.Mutex
+	probeFailures map[string]int
 }
 
 // SetupClusterController sets up the cluster controller with the manager.
@@ -110,6 +118,7 @@ func shouldPeriodicRefreshClientFactory(cluster *v1.Cluster) bool {
 // deleteClientFactory removes the Kubernetes client factory for a cluster being deleted.
 // It cleans up the client manager and releases resources associated with the cluster.
 func (r *ClusterReconciler) deleteClientFactory(cluster *v1.Cluster) error {
+	r.clearProbeFailures(cluster.Name)
 	mgr := commonutils.NewObjectManagerSingleton()
 	if mgr == nil {
 		return nil
@@ -134,7 +143,7 @@ func (r *ClusterReconciler) addClientFactory(ctx context.Context, cluster *v1.Cl
 	if obj, ok := clientManager.Get(cluster.Name); ok {
 		if factory, ok := obj.(*commonclient.ClientFactory); ok &&
 			!commoncluster.ClientFactoryNeedsRefresh(ctx, r.Client, cluster, factory) {
-			invalidateUnreachableClientFactory(factory)
+			r.invalidateUnreachableClientFactory(cluster.Name, factory)
 			return nil
 		}
 	}
@@ -153,10 +162,12 @@ func (r *ClusterReconciler) addClientFactory(ctx context.Context, cluster *v1.Cl
 	return nil
 }
 
-// invalidateUnreachableClientFactory marks a factory invalid once its apiserver stops responding.
-// apiserver runs its data-plane clients without informers, so there is no watch error handler to
-// report broken connections and requests would otherwise keep using a dead client.
-func invalidateUnreachableClientFactory(factory *commonclient.ClientFactory) {
+// invalidateUnreachableClientFactory marks a factory invalid once its apiserver has stopped
+// responding for several consecutive probes. apiserver runs its data-plane clients without
+// informers, so nothing else reports a broken connection, but an invalid factory rejects every
+// request for the cluster and a single failed probe is not enough evidence for that.
+func (r *ClusterReconciler) invalidateUnreachableClientFactory(clusterName string,
+	factory *commonclient.ClientFactory) {
 	if !factory.IsValid() {
 		return
 	}
@@ -164,8 +175,33 @@ func invalidateUnreachableClientFactory(factory *commonclient.ClientFactory) {
 	if restCfg == nil {
 		return
 	}
-	if err := commonclient.ProbeRESTConfig(restCfg); err != nil {
-		klog.Warningf("cluster %s data-plane apiserver is unreachable: %v", factory.Name(), err)
+	err := commonclient.ProbeRESTConfig(restCfg)
+	if err == nil {
+		r.clearProbeFailures(clusterName)
+		return
+	}
+	failures := r.recordProbeFailure(clusterName)
+	klog.Warningf("cluster %s data-plane apiserver probe failed (%d/%d): %v",
+		clusterName, failures, clusterProbeFailureThreshold, err)
+	if failures >= clusterProbeFailureThreshold {
 		factory.SetValid(false, err.Error())
 	}
+}
+
+// recordProbeFailure counts one more consecutive failure and returns the running total.
+func (r *ClusterReconciler) recordProbeFailure(clusterName string) int {
+	r.probeMu.Lock()
+	defer r.probeMu.Unlock()
+	if r.probeFailures == nil {
+		r.probeFailures = make(map[string]int)
+	}
+	r.probeFailures[clusterName]++
+	return r.probeFailures[clusterName]
+}
+
+// clearProbeFailures forgets a cluster's failure streak.
+func (r *ClusterReconciler) clearProbeFailures(clusterName string) {
+	r.probeMu.Lock()
+	defer r.probeMu.Unlock()
+	delete(r.probeFailures, clusterName)
 }

--- a/SaFE/apiserver/pkg/controllers/cluster_reconcile_test.go
+++ b/SaFE/apiserver/pkg/controllers/cluster_reconcile_test.go
@@ -49,6 +49,20 @@ func TestClusterReconcileNotReady(t *testing.T) {
 	assert.Equal(t, time.Duration(0), res.RequeueAfter)
 }
 
+func TestShouldPeriodicRefreshClientFactory(t *testing.T) {
+	ready := &v1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c1"}}
+	ready.Status.ControlPlaneStatus.Phase = v1.ReadyPhase
+	assert.True(t, shouldPeriodicRefreshClientFactory(ready))
+
+	notReady := &v1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c2"}}
+	assert.False(t, shouldPeriodicRefreshClientFactory(notReady))
+
+	deleting := ready.DeepCopy()
+	now := metav1.Now()
+	deleting.DeletionTimestamp = &now
+	assert.False(t, shouldPeriodicRefreshClientFactory(deleting))
+}
+
 func TestClusterReconcileReadyEndpointError(t *testing.T) {
 	cluster := &v1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c1"}}
 	cluster.Status.ControlPlaneStatus.Phase = v1.ReadyPhase

--- a/SaFE/apiserver/pkg/controllers/cluster_reconcile_test.go
+++ b/SaFE/apiserver/pkg/controllers/cluster_reconcile_test.go
@@ -7,15 +7,124 @@ package controllers
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
+	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/common"
+	commonclient "github.com/AMD-AIG-AIMA/SAFE/common/pkg/k8sclient"
+	commonutils "github.com/AMD-AIG-AIMA/SAFE/common/pkg/utils"
 )
+
+// probeClusterCert returns a base64-encoded self-signed cert/key pair accepted by tls.X509KeyPair,
+// which lets data-plane client construction run against a local probe server.
+func probeClusterCert(t *testing.T) (certData, keyData string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	assert.NoError(t, err)
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "safe-unit-test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		IsCA:         true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	assert.NoError(t, err)
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	assert.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	return base64.StdEncoding.EncodeToString(certPEM), base64.StdEncoding.EncodeToString(keyPEM)
+}
+
+// newProbeAPIServer starts a TLS server answering the ServerVersion reachability probe.
+func newProbeAPIServer(t *testing.T) int32 {
+	t.Helper()
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"major":"1","minor":"30"}`))
+	}))
+	t.Cleanup(srv.Close)
+	addr, ok := srv.Listener.Addr().(*net.TCPAddr)
+	assert.True(t, ok)
+	return int32(addr.Port)
+}
+
+func TestAddClientFactoryBuildsAndReusesFactory(t *testing.T) {
+	const clusterName = "probe-cluster"
+	certData, keyData := probeClusterCert(t)
+	cluster := &v1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: clusterName}}
+	cluster.Status.ControlPlaneStatus.Phase = v1.ReadyPhase
+	cluster.Status.ControlPlaneStatus.CertData = certData
+	cluster.Status.ControlPlaneStatus.KeyData = keyData
+
+	scheme := ctrlScheme(t)
+	assert.NoError(t, corev1.AddToScheme(scheme))
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: common.PrimusSafeNamespace},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "127.0.0.1",
+			Ports:     []corev1.ServicePort{{Port: newProbeAPIServer(t)}},
+		},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster, service).Build()
+	r := &ClusterReconciler{Client: cl, ctx: context.Background()}
+
+	clientManager := commonutils.NewObjectManagerSingleton()
+	t.Cleanup(func() { _ = clientManager.Delete(clusterName) })
+
+	assert.NoError(t, r.addClientFactory(context.Background(), cluster))
+	obj, ok := clientManager.Get(clusterName)
+	assert.True(t, ok)
+	first := obj.(*commonclient.ClientFactory)
+
+	// The apiserver reaches the data plane, so the existing factory is kept and stays valid.
+	assert.NoError(t, r.addClientFactory(context.Background(), cluster))
+	obj, ok = clientManager.Get(clusterName)
+	assert.True(t, ok)
+	assert.Same(t, first, obj.(*commonclient.ClientFactory))
+	assert.True(t, first.IsValid())
+}
+
+func TestInvalidateUnreachableClientFactory(t *testing.T) {
+	factory := commonclient.NewClientFactoryForTest("c1", "10.96.1.1:6443")
+	factory.AttachRestConfigForTest(&rest.Config{
+		Host:    "https://127.0.0.1:1",
+		Timeout: time.Millisecond * 100,
+	})
+	invalidateUnreachableClientFactory(factory)
+	assert.False(t, factory.IsValid())
+}
+
+func TestInvalidateUnreachableClientFactoryWithoutRestConfig(t *testing.T) {
+	factory := commonclient.NewClientFactoryForTest("c1", "10.96.1.1:6443")
+	invalidateUnreachableClientFactory(factory)
+	assert.True(t, factory.IsValid())
+
+	factory.SetValid(false, "already invalid")
+	invalidateUnreachableClientFactory(factory)
+	assert.Equal(t, "already invalid", factory.GetInvalidReason())
+}
 
 func TestClusterReconcileNotFound(t *testing.T) {
 	cl := fake.NewClientBuilder().WithScheme(ctrlScheme(t)).Build()

--- a/SaFE/apiserver/pkg/controllers/cluster_reconcile_test.go
+++ b/SaFE/apiserver/pkg/controllers/cluster_reconcile_test.go
@@ -18,6 +18,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -106,23 +107,53 @@ func TestAddClientFactoryBuildsAndReusesFactory(t *testing.T) {
 	assert.True(t, first.IsValid())
 }
 
-func TestInvalidateUnreachableClientFactory(t *testing.T) {
+func TestInvalidateUnreachableClientFactoryNeedsRepeatedFailures(t *testing.T) {
+	r := &ClusterReconciler{}
 	factory := commonclient.NewClientFactoryForTest("c1", "10.96.1.1:6443")
 	factory.AttachRestConfigForTest(&rest.Config{
 		Host:    "https://127.0.0.1:1",
 		Timeout: time.Millisecond * 100,
 	})
-	invalidateUnreachableClientFactory(factory)
+
+	// A single blip must not take the cluster out of service.
+	for i := 1; i < clusterProbeFailureThreshold; i++ {
+		r.invalidateUnreachableClientFactory("c1", factory)
+		assert.True(t, factory.IsValid())
+	}
+	r.invalidateUnreachableClientFactory("c1", factory)
 	assert.False(t, factory.IsValid())
 }
 
-func TestInvalidateUnreachableClientFactoryWithoutRestConfig(t *testing.T) {
+func TestInvalidateUnreachableClientFactoryResetsStreakOnSuccess(t *testing.T) {
+	r := &ClusterReconciler{}
 	factory := commonclient.NewClientFactoryForTest("c1", "10.96.1.1:6443")
-	invalidateUnreachableClientFactory(factory)
+	factory.AttachRestConfigForTest(&rest.Config{
+		Host:    "https://127.0.0.1:1",
+		Timeout: time.Millisecond * 100,
+	})
+	r.invalidateUnreachableClientFactory("c1", factory)
+	assert.Equal(t, 1, r.probeFailures["c1"])
+
+	// A reachable apiserver clears the streak, so later blips start counting again from zero.
+	reachable := commonclient.NewClientFactoryForTest("c1", "10.96.1.1:6443")
+	reachable.AttachRestConfigForTest(&rest.Config{
+		Host:            "https://127.0.0.1:" + strconv.Itoa(int(newProbeAPIServer(t))),
+		Timeout:         time.Second,
+		TLSClientConfig: rest.TLSClientConfig{Insecure: true},
+	})
+	r.invalidateUnreachableClientFactory("c1", reachable)
+	assert.NotContains(t, r.probeFailures, "c1")
+	assert.True(t, reachable.IsValid())
+}
+
+func TestInvalidateUnreachableClientFactoryWithoutRestConfig(t *testing.T) {
+	r := &ClusterReconciler{}
+	factory := commonclient.NewClientFactoryForTest("c1", "10.96.1.1:6443")
+	r.invalidateUnreachableClientFactory("c1", factory)
 	assert.True(t, factory.IsValid())
 
 	factory.SetValid(false, "already invalid")
-	invalidateUnreachableClientFactory(factory)
+	r.invalidateUnreachableClientFactory("c1", factory)
 	assert.Equal(t, "already invalid", factory.GetInvalidReason())
 }
 

--- a/SaFE/apiserver/pkg/utils/utils.go
+++ b/SaFE/apiserver/pkg/utils/utils.go
@@ -71,5 +71,13 @@ func GetK8sClientFactory(clientManager *commonutils.ObjectManager, clusterId str
 	if !ok {
 		return nil, commonerrors.NewInternalError("the object type is not matched")
 	}
+	if !k8sClients.IsValid() {
+		reason := k8sClients.GetInvalidReason()
+		if reason == "" {
+			reason = "client factory is invalid"
+		}
+		err := fmt.Errorf("the client of cluster %s is invalid: %s. please retry later", clusterId, reason)
+		return nil, commonerrors.NewInternalError(err.Error())
+	}
 	return k8sClients, nil
 }

--- a/SaFE/apiserver/pkg/utils/utils_test.go
+++ b/SaFE/apiserver/pkg/utils/utils_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	commonclient "github.com/AMD-AIG-AIMA/SAFE/common/pkg/k8sclient"
 	commonutils "github.com/AMD-AIG-AIMA/SAFE/common/pkg/utils"
 )
 
@@ -66,4 +67,14 @@ func TestGetK8sClientFactoryNotFound(t *testing.T) {
 	mgr := commonutils.NewObjectManagerSingleton()
 	_, err := GetK8sClientFactory(mgr, "nonexistent-cluster")
 	assert.Error(t, err)
+}
+
+func TestGetK8sClientFactoryInvalid(t *testing.T) {
+	mgr := commonutils.NewObjectManager()
+	factory := commonclient.NewClientFactoryForTest("c1", "https://10.0.0.1:6443")
+	factory.SetValid(false, "control plane endpoints changed")
+	assert.NoError(t, mgr.Add("c1", factory))
+	_, err := GetK8sClientFactory(mgr, "c1")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid")
 }

--- a/SaFE/common/pkg/cluster/cluster.go
+++ b/SaFE/common/pkg/cluster/cluster.go
@@ -150,12 +150,23 @@ func NewClientFactoryForCluster(ctx context.Context, adminClient client.Client, 
 }
 
 // ClientFactoryNeedsRefresh reports whether an existing factory should be replaced.
+// A rebuild is only reported when it can actually succeed, so a full control-plane outage
+// keeps the current factory instead of rebuilding it on every reconcile.
 func ClientFactoryNeedsRefresh(ctx context.Context, adminClient client.Client, cluster *v1.Cluster,
 	factory *commonclient.ClientFactory) bool {
-	if factory == nil || !factory.IsValid() {
+	if factory == nil || cluster == nil {
 		return true
 	}
-	if cluster == nil {
+	if !clientFactoryOutdated(ctx, adminClient, cluster, factory) {
+		return false
+	}
+	return rebuildTargetReachable(ctx, adminClient, cluster, factory)
+}
+
+// clientFactoryOutdated reports whether the factory no longer matches the desired apiserver target.
+func clientFactoryOutdated(ctx context.Context, adminClient client.Client, cluster *v1.Cluster,
+	factory *commonclient.ClientFactory) bool {
+	if !factory.IsValid() {
 		return true
 	}
 	selected := commonclient.NormalizeEndpointHost(factory.Endpoint())
@@ -185,6 +196,30 @@ func ClientFactoryNeedsRefresh(ctx context.Context, adminClient client.Client, c
 		}
 	}
 	return len(GetFallbackEndpoints(cluster)) > 0
+}
+
+// rebuildTargetReachable reports whether rebuilding the factory can produce a working client.
+// Service mode always dials the same ClusterIP, so an unreachable target means every backend is
+// down and a rebuild would only churn clients and informers until a control plane recovers.
+func rebuildTargetReachable(ctx context.Context, adminClient client.Client, cluster *v1.Cluster,
+	factory *commonclient.ClientFactory) bool {
+	if !UsesServiceEndpoint(ctx, adminClient, cluster) {
+		// Direct mode probes every candidate endpoint while building the factory.
+		return true
+	}
+	endpoint, err := GetEndpoint(ctx, adminClient, cluster)
+	if err != nil {
+		return false
+	}
+	if commonclient.NormalizeEndpointHost(factory.Endpoint()) != commonclient.NormalizeEndpointHost(endpoint) {
+		// The Service address moved, so the current client says nothing about the new target.
+		return true
+	}
+	restCfg := factory.RestConfig()
+	if restCfg == nil {
+		return true
+	}
+	return commonclient.ProbeRESTConfig(restCfg) == nil
 }
 
 // directModeFactoryNeedsRefresh reports whether a direct-mode factory should be rebuilt.

--- a/SaFE/common/pkg/cluster/cluster.go
+++ b/SaFE/common/pkg/cluster/cluster.go
@@ -151,8 +151,7 @@ func NewClientFactoryForCluster(ctx context.Context, adminClient client.Client, 
 
 // ClientFactoryNeedsRefresh reports whether an existing factory should be replaced.
 func ClientFactoryNeedsRefresh(ctx context.Context, adminClient client.Client, cluster *v1.Cluster,
-	factory *commonclient.ClientFactory,
-) bool {
+	factory *commonclient.ClientFactory) bool {
 	if factory == nil || !factory.IsValid() {
 		return true
 	}
@@ -182,8 +181,17 @@ func ClientFactoryNeedsRefresh(ctx context.Context, adminClient client.Client, c
 	}
 	for _, ep := range GetFallbackEndpoints(cluster) {
 		if selected == commonclient.NormalizeEndpointHost(ep) {
-			return false
+			return directModeFactoryNeedsRefresh(factory)
 		}
 	}
 	return len(GetFallbackEndpoints(cluster)) > 0
+}
+
+// directModeFactoryNeedsRefresh reports whether a direct-mode factory should be rebuilt.
+func directModeFactoryNeedsRefresh(factory *commonclient.ClientFactory) bool {
+	restCfg := factory.RestConfig()
+	if restCfg == nil {
+		return false
+	}
+	return commonclient.ProbeRESTConfig(restCfg) != nil
 }

--- a/SaFE/common/pkg/cluster/cluster.go
+++ b/SaFE/common/pkg/cluster/cluster.go
@@ -8,17 +8,21 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
 	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/common"
+	commonclient "github.com/AMD-AIG-AIMA/SAFE/common/pkg/k8sclient"
 )
 
 // GetEndpoint retrieve the endpoint address of the given cluster.
-// It first tries to get the endpoint from the Kubernetes Service associated with the cluster.
-// If the Service is not found or has no ports, it falls back to using the endpoint from the cluster status.
+// It first tries the ClusterIP of the Kubernetes Service associated with the cluster.
+// If the Service is not found or has no ports, it falls back to status endpoints.
 // Returns an error if the cluster is nil, not ready, or no valid endpoint can be found.
 func GetEndpoint(ctx context.Context, cli client.Client, cluster *v1.Cluster) (string, error) {
 	if cluster == nil || !cluster.IsReady() {
@@ -30,11 +34,131 @@ func GetEndpoint(ctx context.Context, cli client.Client, cluster *v1.Cluster) (s
 		if len(service.Spec.Ports) == 0 {
 			return "", fmt.Errorf("service ports are empty")
 		}
-		// return fmt.Sprintf("https://%s.%s.svc", clusterName, common.PrimusSafeNamespace), nil
 		return fmt.Sprintf("%s:%d", service.Spec.ClusterIP, service.Spec.Ports[0].Port), nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return "", fmt.Errorf("get service %s: %w", cluster.Name, err)
 	}
 	if len(cluster.Status.ControlPlaneStatus.Endpoints) == 0 {
 		return "", fmt.Errorf("either the Service address or the Endpoint is empty")
 	}
 	return cluster.Status.ControlPlaneStatus.Endpoints[0], nil
+}
+
+// GetFallbackEndpoints returns direct apiserver endpoints from cluster status.
+func GetFallbackEndpoints(cluster *v1.Cluster) []string {
+	if cluster == nil {
+		return nil
+	}
+	return append([]string(nil), cluster.Status.ControlPlaneStatus.Endpoints...)
+}
+
+// UsesServiceEndpoint reports whether the cluster has a Service fronting its apiserver.
+func UsesServiceEndpoint(ctx context.Context, cli client.Client, cluster *v1.Cluster) bool {
+	if cluster == nil {
+		return false
+	}
+	service := &corev1.Service{}
+	err := cli.Get(ctx, client.ObjectKey{Name: cluster.Name, Namespace: common.PrimusSafeNamespace}, service)
+	return err == nil && len(service.Spec.Ports) > 0
+}
+
+// GetControlPlaneBackendIPs returns sorted apiserver backend IPs from admin-plane Endpoints.
+func GetControlPlaneBackendIPs(ctx context.Context, cli client.Client, cluster *v1.Cluster) ([]string, error) {
+	if cluster == nil {
+		return nil, fmt.Errorf("cluster is nil")
+	}
+	endpoints := &corev1.Endpoints{}
+	err := cli.Get(ctx, client.ObjectKey{Name: cluster.Name, Namespace: common.PrimusSafeNamespace}, endpoints)
+	if err != nil {
+		return nil, err
+	}
+	ips := make([]string, 0)
+	for _, subset := range endpoints.Subsets {
+		for _, addr := range subset.Addresses {
+			if addr.IP != "" {
+				ips = append(ips, addr.IP)
+			}
+		}
+	}
+	sort.Strings(ips)
+	return ips, nil
+}
+
+// BackendIPsFingerprint builds a stable fingerprint for control-plane backend IPs.
+func BackendIPsFingerprint(ips []string) string {
+	if len(ips) == 0 {
+		return ""
+	}
+	sorted := append([]string(nil), ips...)
+	sort.Strings(sorted)
+	return strings.Join(sorted, ",")
+}
+
+// NewClientFactoryForCluster builds a data-plane client factory for the cluster.
+// Service mode relies on client-go dial defaults; direct endpoints use ServerVersion probe failover.
+func NewClientFactoryForCluster(ctx context.Context, adminClient client.Client, cluster *v1.Cluster,
+	informerType commonclient.InformerType,
+) (*commonclient.ClientFactory, error) {
+	endpoint, err := GetEndpoint(ctx, adminClient, cluster)
+	if err != nil {
+		return nil, err
+	}
+	cps := &cluster.Status.ControlPlaneStatus
+	if UsesServiceEndpoint(ctx, adminClient, cluster) {
+		factory, err := commonclient.NewClientFactory(ctx, cluster.Name, endpoint,
+			cps.CertData, cps.KeyData, cps.CAData, informerType)
+		if err != nil {
+			return nil, err
+		}
+		if ips, ipErr := GetControlPlaneBackendIPs(ctx, adminClient, cluster); ipErr == nil {
+			factory.SetBackendFingerprint(BackendIPsFingerprint(ips))
+		}
+		return factory, nil
+	}
+	fallbacks := GetFallbackEndpoints(cluster)
+	primary := endpoint
+	var rest []string
+	if len(fallbacks) > 0 {
+		primary = fallbacks[0]
+		rest = fallbacks[1:]
+	}
+	return commonclient.NewClientFactoryWithFallbacks(ctx, cluster.Name, primary, rest,
+		cps.CertData, cps.KeyData, cps.CAData, informerType)
+}
+
+// ClientFactoryNeedsRefresh reports whether an existing factory should be replaced.
+func ClientFactoryNeedsRefresh(ctx context.Context, adminClient client.Client, cluster *v1.Cluster,
+	factory *commonclient.ClientFactory,
+) bool {
+	if factory == nil || !factory.IsValid() {
+		return true
+	}
+	if cluster == nil {
+		return true
+	}
+	selected := commonclient.NormalizeEndpointHost(factory.Endpoint())
+	if UsesServiceEndpoint(ctx, adminClient, cluster) {
+		endpoint, err := GetEndpoint(ctx, adminClient, cluster)
+		if err != nil {
+			return false
+		}
+		if selected != commonclient.NormalizeEndpointHost(endpoint) {
+			return true
+		}
+		ips, err := GetControlPlaneBackendIPs(ctx, adminClient, cluster)
+		if err != nil {
+			return false
+		}
+		return factory.BackendFingerprint() != BackendIPsFingerprint(ips)
+	}
+	if selected == "" {
+		return true
+	}
+	for _, ep := range GetFallbackEndpoints(cluster) {
+		if selected == commonclient.NormalizeEndpointHost(ep) {
+			return false
+		}
+	}
+	return len(GetFallbackEndpoints(cluster)) > 0
 }

--- a/SaFE/common/pkg/cluster/cluster.go
+++ b/SaFE/common/pkg/cluster/cluster.go
@@ -13,6 +13,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
@@ -37,7 +38,10 @@ func GetEndpoint(ctx context.Context, cli client.Client, cluster *v1.Cluster) (s
 		return fmt.Sprintf("%s:%d", service.Spec.ClusterIP, service.Spec.Ports[0].Port), nil
 	}
 	if !apierrors.IsNotFound(err) {
-		return "", fmt.Errorf("get service %s: %w", cluster.Name, err)
+		// Degrade to the status endpoints instead of failing outright: direct mode probes every
+		// candidate, so it still yields a working client. Log it because an unreadable Service is a
+		// different problem from an absent one.
+		klog.Warningf("failed to read service %s, falling back to status endpoints: %v", cluster.Name, err)
 	}
 	if len(cluster.Status.ControlPlaneStatus.Endpoints) == 0 {
 		return "", fmt.Errorf("either the Service address or the Endpoint is empty")

--- a/SaFE/common/pkg/cluster/cluster.go
+++ b/SaFE/common/pkg/cluster/cluster.go
@@ -95,6 +95,23 @@ func BackendIPsFingerprint(ips []string) string {
 	return strings.Join(sorted, ",")
 }
 
+// StatusEndpointsFingerprint builds a fingerprint for apiserver endpoints recorded on the cluster.
+func StatusEndpointsFingerprint(cluster *v1.Cluster) string {
+	endpoints := GetFallbackEndpoints(cluster)
+	if len(endpoints) == 0 {
+		return ""
+	}
+	normalized := make([]string, 0, len(endpoints))
+	for _, ep := range endpoints {
+		ep = commonclient.NormalizeEndpointHost(ep)
+		if ep != "" {
+			normalized = append(normalized, ep)
+		}
+	}
+	sort.Strings(normalized)
+	return strings.Join(normalized, ",")
+}
+
 // NewClientFactoryForCluster builds a data-plane client factory for the cluster.
 // Service mode relies on client-go dial defaults; direct endpoints use ServerVersion probe failover.
 func NewClientFactoryForCluster(ctx context.Context, adminClient client.Client, cluster *v1.Cluster,
@@ -123,8 +140,13 @@ func NewClientFactoryForCluster(ctx context.Context, adminClient client.Client, 
 		primary = fallbacks[0]
 		rest = fallbacks[1:]
 	}
-	return commonclient.NewClientFactoryWithFallbacks(ctx, cluster.Name, primary, rest,
+	factory, err := commonclient.NewClientFactoryWithFallbacks(ctx, cluster.Name, primary, rest,
 		cps.CertData, cps.KeyData, cps.CAData, informerType)
+	if err != nil {
+		return nil, err
+	}
+	factory.SetBackendFingerprint(StatusEndpointsFingerprint(cluster))
+	return factory, nil
 }
 
 // ClientFactoryNeedsRefresh reports whether an existing factory should be replaced.
@@ -141,18 +163,21 @@ func ClientFactoryNeedsRefresh(ctx context.Context, adminClient client.Client, c
 	if UsesServiceEndpoint(ctx, adminClient, cluster) {
 		endpoint, err := GetEndpoint(ctx, adminClient, cluster)
 		if err != nil {
-			return false
+			return factory.BackendFingerprint() != ""
 		}
 		if selected != commonclient.NormalizeEndpointHost(endpoint) {
 			return true
 		}
 		ips, err := GetControlPlaneBackendIPs(ctx, adminClient, cluster)
 		if err != nil {
-			return false
+			return factory.BackendFingerprint() != ""
 		}
 		return factory.BackendFingerprint() != BackendIPsFingerprint(ips)
 	}
 	if selected == "" {
+		return true
+	}
+	if StatusEndpointsFingerprint(cluster) != factory.BackendFingerprint() {
 		return true
 	}
 	for _, ep := range GetFallbackEndpoints(cluster) {

--- a/SaFE/common/pkg/cluster/cluster_test.go
+++ b/SaFE/common/pkg/cluster/cluster_test.go
@@ -7,6 +7,14 @@ package cluster
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"math/big"
 	"testing"
 	"time"
 
@@ -452,4 +460,123 @@ func TestClientFactoryNeedsRefreshDirectModeUnreachable(t *testing.T) {
 func TestDirectModeFactoryNeedsRefreshWithoutRestConfig(t *testing.T) {
 	factory := commonclient.NewClientFactoryForTest("c1", "https://10.0.0.1:6443")
 	assert.False(t, directModeFactoryNeedsRefresh(factory))
+}
+
+// clusterTestCert returns a base64-encoded self-signed cert/key pair so factory construction can
+// run without reaching an apiserver.
+func clusterTestCert(t *testing.T) (certData, keyData string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	assert.NoError(t, err)
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "safe-unit-test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		IsCA:         true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	assert.NoError(t, err)
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	assert.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	return base64.StdEncoding.EncodeToString(certPEM), base64.StdEncoding.EncodeToString(keyPEM)
+}
+
+func TestNewClientFactoryForClusterServiceMode(t *testing.T) {
+	ctx := context.Background()
+	mockScheme := scheme.Scheme
+	_ = corev1.AddToScheme(mockScheme)
+	_ = v1.AddToScheme(mockScheme)
+
+	certData, keyData := clusterTestCert(t)
+	cluster := &v1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1"},
+		Status: v1.ClusterStatus{ControlPlaneStatus: v1.ControlPlaneStatus{
+			Phase:    v1.ReadyPhase,
+			CertData: certData,
+			KeyData:  keyData,
+		}},
+	}
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: common.PrimusSafeNamespace},
+		Spec:       corev1.ServiceSpec{ClusterIP: "10.96.1.1", Ports: []corev1.ServicePort{{Port: 6443}}},
+	}
+	endpoints := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: common.PrimusSafeNamespace},
+		Subsets: []corev1.EndpointSubset{{
+			Addresses: []corev1.EndpointAddress{{IP: "10.0.0.2"}, {IP: "10.0.0.1"}},
+		}},
+	}
+	cl := fake.NewClientBuilder().WithScheme(mockScheme).WithObjects(service, endpoints).Build()
+
+	factory, err := NewClientFactoryForCluster(ctx, cl, cluster, commonclient.DisableInformer)
+	assert.NoError(t, err)
+	// Service mode dials the ClusterIP and records the current backend pool.
+	assert.Equal(t, "https://10.96.1.1:6443", factory.Endpoint())
+	assert.Equal(t, "10.0.0.1,10.0.0.2", factory.BackendFingerprint())
+	assert.NoError(t, factory.Release())
+
+	// A freshly built factory matches the cluster, so no refresh is required.
+	assert.False(t, ClientFactoryNeedsRefresh(ctx, cl, cluster, factory))
+}
+
+func TestNewClientFactoryForClusterDirectModeUnreachable(t *testing.T) {
+	ctx := context.Background()
+	mockScheme := scheme.Scheme
+	_ = corev1.AddToScheme(mockScheme)
+	_ = v1.AddToScheme(mockScheme)
+
+	certData, keyData := clusterTestCert(t)
+	cluster := &v1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1"},
+		Status: v1.ClusterStatus{ControlPlaneStatus: v1.ControlPlaneStatus{
+			Phase:     v1.ReadyPhase,
+			CertData:  certData,
+			KeyData:   keyData,
+			Endpoints: []string{"https://127.0.0.1:1", "https://127.0.0.1:2"},
+		}},
+	}
+	cl := fake.NewClientBuilder().WithScheme(mockScheme).Build()
+
+	// Direct mode probes every candidate, so an all-down control plane surfaces an error.
+	_, err := NewClientFactoryForCluster(ctx, cl, cluster, commonclient.DisableInformer)
+	assert.ErrorContains(t, err, "no reachable apiserver endpoint")
+}
+
+func TestNewClientFactoryForClusterNotReady(t *testing.T) {
+	mockScheme := scheme.Scheme
+	_ = v1.AddToScheme(mockScheme)
+	cl := fake.NewClientBuilder().WithScheme(mockScheme).Build()
+	_, err := NewClientFactoryForCluster(context.Background(), cl,
+		&v1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c1"}}, commonclient.DisableInformer)
+	assert.Error(t, err)
+}
+
+func TestClientFactoryNeedsRefreshSkipsRebuildWhenServiceUnreachable(t *testing.T) {
+	ctx := context.Background()
+	mockScheme := scheme.Scheme
+	_ = corev1.AddToScheme(mockScheme)
+	_ = v1.AddToScheme(mockScheme)
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: common.PrimusSafeNamespace},
+		Spec:       corev1.ServiceSpec{ClusterIP: "127.0.0.1", Ports: []corev1.ServicePort{{Port: 1}}},
+	}
+	cl := fake.NewClientBuilder().WithScheme(mockScheme).WithObjects(service).Build()
+	cluster := &v1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1"},
+		Status:     v1.ClusterStatus{ControlPlaneStatus: v1.ControlPlaneStatus{Phase: v1.ReadyPhase}},
+	}
+	factory := commonclient.NewClientFactoryForTest("c1", "127.0.0.1:1")
+	factory.SetValid(false, "watch error")
+	factory.AttachRestConfigForTest(&rest.Config{Host: "https://127.0.0.1:1", Timeout: time.Millisecond * 100})
+
+	// Every backend is down: keep the current factory instead of rebuilding it every reconcile.
+	assert.False(t, ClientFactoryNeedsRefresh(ctx, cl, cluster, factory))
+	// The outdated check itself still reports the factory as stale.
+	assert.True(t, clientFactoryOutdated(ctx, cl, cluster, factory))
 }

--- a/SaFE/common/pkg/cluster/cluster_test.go
+++ b/SaFE/common/pkg/cluster/cluster_test.go
@@ -348,9 +348,10 @@ func TestClientFactoryNeedsRefresh(t *testing.T) {
 	invalid.SetValid(false, "down")
 	assert.True(t, ClientFactoryNeedsRefresh(ctx, serviceClient, readyCluster(), invalid))
 
-	// Direct mode: factory on second endpoint should not refresh when first is GetEndpoint default.
+	// Direct mode: factory on second endpoint should not refresh when status fingerprint matches.
 	cluster := readyCluster("https://10.0.0.1:6443", "https://10.0.0.2:6443")
 	factory := commonclient.NewClientFactoryForTest("c1", "https://10.0.0.2:6443")
+	factory.SetBackendFingerprint(StatusEndpointsFingerprint(cluster))
 	assert.False(t, ClientFactoryNeedsRefresh(ctx, directClient, cluster, factory))
 
 	// Service mode: ClusterIP change triggers refresh.
@@ -408,5 +409,20 @@ func TestClientFactoryNeedsRefreshBackendIPsChanged(t *testing.T) {
 	}
 	factory := commonclient.NewClientFactoryForTest("c1", "10.96.1.1:6443")
 	factory.SetBackendFingerprint("10.0.0.1,10.0.0.2")
+	assert.True(t, ClientFactoryNeedsRefresh(ctx, cl, cluster, factory))
+}
+
+func TestClientFactoryNeedsRefreshWhenBackendLookupFails(t *testing.T) {
+	ctx := context.Background()
+	mockScheme := scheme.Scheme
+	_ = v1.AddToScheme(mockScheme)
+
+	cluster := &v1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1"},
+		Status:     v1.ClusterStatus{ControlPlaneStatus: v1.ControlPlaneStatus{Phase: v1.ReadyPhase}},
+	}
+	cl := fake.NewClientBuilder().WithScheme(mockScheme).Build()
+	factory := commonclient.NewClientFactoryForTest("c1", "10.96.1.1:6443")
+	factory.SetBackendFingerprint("10.0.0.1")
 	assert.True(t, ClientFactoryNeedsRefresh(ctx, cl, cluster, factory))
 }

--- a/SaFE/common/pkg/cluster/cluster_test.go
+++ b/SaFE/common/pkg/cluster/cluster_test.go
@@ -18,6 +18,7 @@ import (
 	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
 	"github.com/AMD-AIG-AIMA/SAFE/apis/pkg/client/clientset/versioned/scheme"
 	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/common"
+	commonclient "github.com/AMD-AIG-AIMA/SAFE/common/pkg/k8sclient"
 )
 
 // TestGetEndpoint tests the GetEndpoint function
@@ -312,4 +313,100 @@ func TestGetEndpointServicePriority(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "10.96.100.50:6443", result)
 	assert.NotContains(t, result, "status-endpoint", "Should use service endpoint, not status endpoint")
+}
+
+func TestClientFactoryNeedsRefresh(t *testing.T) {
+	ctx := context.Background()
+	mockScheme := scheme.Scheme
+	_ = corev1.AddToScheme(mockScheme)
+	_ = v1.AddToScheme(mockScheme)
+
+	readyCluster := func(endpoints ...string) *v1.Cluster {
+		return &v1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "c1"},
+			Status: v1.ClusterStatus{
+				ControlPlaneStatus: v1.ControlPlaneStatus{
+					Phase:     v1.ReadyPhase,
+					Endpoints: endpoints,
+				},
+			},
+		}
+	}
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: common.PrimusSafeNamespace},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "10.96.1.1",
+			Ports:     []corev1.ServicePort{{Port: 6443}},
+		},
+	}
+	serviceClient := fake.NewClientBuilder().WithScheme(mockScheme).WithObjects(service).Build()
+	directClient := fake.NewClientBuilder().WithScheme(mockScheme).Build()
+
+	assert.True(t, ClientFactoryNeedsRefresh(ctx, serviceClient, readyCluster(), nil))
+
+	invalid := commonclient.NewClientFactoryWithOnlyClient(ctx, "c1", nil)
+	invalid.SetValid(false, "down")
+	assert.True(t, ClientFactoryNeedsRefresh(ctx, serviceClient, readyCluster(), invalid))
+
+	// Direct mode: factory on second endpoint should not refresh when first is GetEndpoint default.
+	cluster := readyCluster("https://10.0.0.1:6443", "https://10.0.0.2:6443")
+	factory := commonclient.NewClientFactoryForTest("c1", "https://10.0.0.2:6443")
+	assert.False(t, ClientFactoryNeedsRefresh(ctx, directClient, cluster, factory))
+
+	// Service mode: ClusterIP change triggers refresh.
+	factorySvc := commonclient.NewClientFactoryForTest("c1", "10.96.1.1:6443")
+	assert.False(t, ClientFactoryNeedsRefresh(ctx, serviceClient, readyCluster("https://10.0.0.1:6443"), factorySvc))
+	otherService := service.DeepCopy()
+	otherService.Spec.ClusterIP = "10.96.2.2"
+	otherClient := fake.NewClientBuilder().WithScheme(mockScheme).WithObjects(otherService).Build()
+	assert.True(t, ClientFactoryNeedsRefresh(ctx, otherClient, readyCluster("https://10.0.0.1:6443"), factorySvc))
+}
+
+func TestBackendIPsFingerprint(t *testing.T) {
+	assert.Equal(t, "", BackendIPsFingerprint(nil))
+	assert.Equal(t, "10.0.0.1,10.0.0.2", BackendIPsFingerprint([]string{"10.0.0.2", "10.0.0.1"}))
+}
+
+func TestGetControlPlaneBackendIPs(t *testing.T) {
+	ctx := context.Background()
+	mockScheme := scheme.Scheme
+	_ = corev1.AddToScheme(mockScheme)
+	_ = v1.AddToScheme(mockScheme)
+
+	endpoints := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: common.PrimusSafeNamespace},
+		Subsets: []corev1.EndpointSubset{{
+			Addresses: []corev1.EndpointAddress{{IP: "10.0.0.2"}, {IP: "10.0.0.1"}},
+		}},
+	}
+	cl := fake.NewClientBuilder().WithScheme(mockScheme).WithObjects(endpoints).Build()
+	ips, err := GetControlPlaneBackendIPs(ctx, cl, &v1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c1"}})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"10.0.0.1", "10.0.0.2"}, ips)
+}
+
+func TestClientFactoryNeedsRefreshBackendIPsChanged(t *testing.T) {
+	ctx := context.Background()
+	mockScheme := scheme.Scheme
+	_ = corev1.AddToScheme(mockScheme)
+	_ = v1.AddToScheme(mockScheme)
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: common.PrimusSafeNamespace},
+		Spec:       corev1.ServiceSpec{ClusterIP: "10.96.1.1", Ports: []corev1.ServicePort{{Port: 6443}}},
+	}
+	endpoints := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: common.PrimusSafeNamespace},
+		Subsets: []corev1.EndpointSubset{{
+			Addresses: []corev1.EndpointAddress{{IP: "10.0.0.1"}},
+		}},
+	}
+	cl := fake.NewClientBuilder().WithScheme(mockScheme).WithObjects(service, endpoints).Build()
+	cluster := &v1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1"},
+		Status:     v1.ClusterStatus{ControlPlaneStatus: v1.ControlPlaneStatus{Phase: v1.ReadyPhase}},
+	}
+	factory := commonclient.NewClientFactoryForTest("c1", "10.96.1.1:6443")
+	factory.SetBackendFingerprint("10.0.0.1,10.0.0.2")
+	assert.True(t, ClientFactoryNeedsRefresh(ctx, cl, cluster, factory))
 }

--- a/SaFE/common/pkg/cluster/cluster_test.go
+++ b/SaFE/common/pkg/cluster/cluster_test.go
@@ -8,11 +8,13 @@ package cluster
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
@@ -425,4 +427,29 @@ func TestClientFactoryNeedsRefreshWhenBackendLookupFails(t *testing.T) {
 	factory := commonclient.NewClientFactoryForTest("c1", "10.96.1.1:6443")
 	factory.SetBackendFingerprint("10.0.0.1")
 	assert.True(t, ClientFactoryNeedsRefresh(ctx, cl, cluster, factory))
+}
+
+func TestClientFactoryNeedsRefreshDirectModeUnreachable(t *testing.T) {
+	ctx := context.Background()
+	cluster := &v1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1"},
+		Status: v1.ClusterStatus{
+			ControlPlaneStatus: v1.ControlPlaneStatus{
+				Phase:     v1.ReadyPhase,
+				Endpoints: []string{"https://10.0.0.1:6443", "https://10.0.0.2:6443"},
+			},
+		},
+	}
+	factory := commonclient.NewClientFactoryForTest("c1", "https://10.0.0.1:6443")
+	factory.SetBackendFingerprint(StatusEndpointsFingerprint(cluster))
+	factory.AttachRestConfigForTest(&rest.Config{
+		Host:    "https://127.0.0.1:1",
+		Timeout: time.Millisecond * 100,
+	})
+	assert.True(t, ClientFactoryNeedsRefresh(ctx, fake.NewClientBuilder().WithScheme(scheme.Scheme).Build(), cluster, factory))
+}
+
+func TestDirectModeFactoryNeedsRefreshWithoutRestConfig(t *testing.T) {
+	factory := commonclient.NewClientFactoryForTest("c1", "https://10.0.0.1:6443")
+	assert.False(t, directModeFactoryNeedsRefresh(factory))
 }

--- a/SaFE/common/pkg/k8sclient/client.go
+++ b/SaFE/common/pkg/k8sclient/client.go
@@ -46,7 +46,8 @@ func NewClientSet(endpoint, certData, keyData, caData string,
 }
 
 // NewClientSetWithProbe builds a client and verifies apiserver reachability via ServerVersion.
-// It tries primary first, then each fallback endpoint until one succeeds.
+// It tries primary first, then each fallback endpoint until one succeeds. The caller's deadline is
+// honoured, so probing a run of unreachable endpoints cannot outlast it.
 func NewClientSetWithProbe(ctx context.Context, primary string, fallbackEndpoints []string,
 	certData, keyData, caData string, insecure bool,
 ) (kubernetes.Interface, *rest.Config, string, error) {
@@ -57,12 +58,16 @@ func NewClientSetWithProbe(ctx context.Context, primary string, fallbackEndpoint
 
 	var lastErr error
 	for _, endpoint := range candidates {
+		if err := ctx.Err(); err != nil {
+			lastErr = err
+			break
+		}
 		clientSet, restCfg, err := NewClientSet(endpoint, certData, keyData, caData, insecure)
 		if err != nil {
 			lastErr = err
 			continue
 		}
-		if err = ProbeRESTConfig(restCfg); err != nil {
+		if err = probeRESTConfig(restCfg, probeTimeout(ctx)); err != nil {
 			lastErr = err
 			continue
 		}
@@ -76,17 +81,48 @@ func NewClientSetWithProbe(ctx context.Context, primary string, fallbackEndpoint
 
 // ProbeRESTConfig verifies apiserver reachability with a bounded ServerVersion call.
 func ProbeRESTConfig(restCfg *rest.Config) error {
+	return probeRESTConfig(restCfg, DefaultAPIServerProbeTimeout)
+}
+
+// ProbeRESTConfigWithContext verifies apiserver reachability without outliving the caller.
+func ProbeRESTConfigWithContext(ctx context.Context, restCfg *rest.Config) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return probeRESTConfig(restCfg, probeTimeout(ctx))
+}
+
+// probeRESTConfig runs a ServerVersion call bounded by timeout. The discovery client takes no
+// context, so a deadline can only be applied through the REST client timeout.
+func probeRESTConfig(restCfg *rest.Config, timeout time.Duration) error {
 	if restCfg == nil {
 		return fmt.Errorf("rest config is nil")
 	}
 	cfg := rest.CopyConfig(restCfg)
-	cfg.Timeout = DefaultAPIServerProbeTimeout
+	cfg.Timeout = timeout
 	clientSet, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		return err
 	}
 	_, err = clientSet.Discovery().ServerVersion()
 	return err
+}
+
+// probeTimeout caps a probe at the caller's remaining budget. A non-positive rest.Config timeout
+// means "no timeout", so an expired deadline is floored instead of removing the bound entirely.
+func probeTimeout(ctx context.Context) time.Duration {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return DefaultAPIServerProbeTimeout
+	}
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return time.Millisecond
+	}
+	if remaining < DefaultAPIServerProbeTimeout {
+		return remaining
+	}
+	return DefaultAPIServerProbeTimeout
 }
 
 // ProbeAPIServer verifies apiserver reachability using the REST config behind the client.

--- a/SaFE/common/pkg/k8sclient/client.go
+++ b/SaFE/common/pkg/k8sclient/client.go
@@ -6,7 +6,10 @@
 package k8sclient
 
 import (
+	"context"
 	"fmt"
+	"strings"
+	"time"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -14,6 +17,11 @@ import (
 
 	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/common"
 	"github.com/AMD-AIG-AIMA/SAFE/utils/pkg/stringutil"
+)
+
+const (
+	// DefaultAPIServerProbeTimeout bounds a single apiserver reachability probe.
+	DefaultAPIServerProbeTimeout = 10 * time.Second
 )
 
 // NewClientSetInCluster creates and returns a new ClientSetInCluster instance.
@@ -37,6 +45,91 @@ func NewClientSet(endpoint, certData, keyData, caData string,
 	return cli, restConfig, err
 }
 
+// NewClientSetWithProbe builds a client and verifies apiserver reachability via ServerVersion.
+// It tries primary first, then each fallback endpoint until one succeeds.
+func NewClientSetWithProbe(ctx context.Context, primary string, fallbackEndpoints []string,
+	certData, keyData, caData string, insecure bool,
+) (kubernetes.Interface, *rest.Config, string, error) {
+	candidates := uniqueEndpoints(append([]string{primary}, fallbackEndpoints...))
+	if len(candidates) == 0 {
+		return nil, nil, "", fmt.Errorf("no apiserver endpoint candidates")
+	}
+
+	var lastErr error
+	for _, endpoint := range candidates {
+		clientSet, restCfg, err := NewClientSet(endpoint, certData, keyData, caData, insecure)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if err = ProbeRESTConfig(restCfg); err != nil {
+			lastErr = err
+			continue
+		}
+		return clientSet, restCfg, endpoint, nil
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("all apiserver probes failed")
+	}
+	return nil, nil, "", fmt.Errorf("no reachable apiserver endpoint: %w", lastErr)
+}
+
+// ProbeRESTConfig verifies apiserver reachability with a bounded ServerVersion call.
+func ProbeRESTConfig(restCfg *rest.Config) error {
+	if restCfg == nil {
+		return fmt.Errorf("rest config is nil")
+	}
+	cfg := rest.CopyConfig(restCfg)
+	cfg.Timeout = DefaultAPIServerProbeTimeout
+	clientSet, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return err
+	}
+	_, err = clientSet.Discovery().ServerVersion()
+	return err
+}
+
+// ProbeAPIServer verifies apiserver reachability using the REST config behind the client.
+func ProbeAPIServer(_ context.Context, clientSet kubernetes.Interface, restCfg *rest.Config) error {
+	if restCfg != nil {
+		return ProbeRESTConfig(restCfg)
+	}
+	if clientSet == nil {
+		return fmt.Errorf("client set is nil")
+	}
+	_, err := clientSet.Discovery().ServerVersion()
+	return err
+}
+
+// NormalizeEndpointHost ensures the apiserver host includes an HTTP scheme.
+func NormalizeEndpointHost(endpoint string) string {
+	endpoint = strings.TrimSpace(endpoint)
+	if endpoint == "" {
+		return endpoint
+	}
+	if strings.HasPrefix(endpoint, "http://") || strings.HasPrefix(endpoint, "https://") {
+		return endpoint
+	}
+	return "https://" + endpoint
+}
+
+func uniqueEndpoints(endpoints []string) []string {
+	seen := make(map[string]struct{}, len(endpoints))
+	out := make([]string, 0, len(endpoints))
+	for _, ep := range endpoints {
+		ep = NormalizeEndpointHost(ep)
+		if ep == "" {
+			continue
+		}
+		if _, ok := seen[ep]; ok {
+			continue
+		}
+		seen[ep] = struct{}{}
+		out = append(out, ep)
+	}
+	return out
+}
+
 // NewClientSetWithRestConfig creates and returns a new ClientSetWithRestConfig instance.
 func NewClientSetWithRestConfig(cfg *rest.Config) (kubernetes.Interface, error) {
 	return kubernetes.NewForConfig(cfg)
@@ -57,6 +150,7 @@ func GetRestConfigInCluster() (*rest.Config, error) {
 func createRestConfig(endpoint, certData, keyData, caData string, insecure bool) (*rest.Config, error) {
 	cert := stringutil.Base64Decode(certData)
 	key := stringutil.Base64Decode(keyData)
+	endpoint = NormalizeEndpointHost(endpoint)
 	if endpoint == "" || cert == "" || key == "" {
 		return nil, fmt.Errorf("invalid input")
 	}

--- a/SaFE/common/pkg/k8sclient/client_factory.go
+++ b/SaFE/common/pkg/k8sclient/client_factory.go
@@ -135,6 +135,19 @@ func (f *ClientFactory) AttachRestConfigForTest(cfg *rest.Config) {
 	f.restConfig = cfg
 }
 
+// NewClientFactoryForTestWithInformer builds a factory backed by the given clientset and a live
+// shared informer factory, so informer wiring can be exercised in unit tests.
+func NewClientFactoryForTestWithInformer(name string, clientSet kubernetes.Interface) *ClientFactory {
+	return &ClientFactory{
+		name:                  name,
+		clientSet:             clientSet,
+		informerType:          EnableInformer,
+		stopCh:                make(chan struct{}),
+		sharedInformerFactory: informers.NewSharedInformerFactory(clientSet, time.Minute),
+		valid:                 true,
+	}
+}
+
 // NewClientFactoryWithOnlyClient create factory instance with client only (without Informer).
 func NewClientFactoryWithOnlyClient(ctx context.Context, name string, clientSet kubernetes.Interface) *ClientFactory {
 	return &ClientFactory{

--- a/SaFE/common/pkg/k8sclient/client_factory.go
+++ b/SaFE/common/pkg/k8sclient/client_factory.go
@@ -34,6 +34,8 @@ type ClientFactory struct {
 	ctx context.Context
 	// Factory name, typically refers to cluster name
 	name          string
+	endpoint      string
+	backendFingerprint string
 	clientSet     kubernetes.Interface
 	restConfig    *rest.Config
 	dynamicClient *dynamic.DynamicClient
@@ -53,11 +55,30 @@ type ClientFactory struct {
 	invalidReason string
 }
 
-// NewClientFactory creates a new client factory.
+// NewClientFactory creates a new client factory for a single reachable endpoint (service mode).
 func NewClientFactory(ctx context.Context, name, endpoint, certData,
 	keyData, caData string, informerType InformerType,
 ) (*ClientFactory, error) {
-	clientSet, restCfg, err := NewClientSet(endpoint, certData, keyData, caData, true)
+	return NewClientFactoryWithFallbacks(ctx, name, endpoint, nil, certData, keyData, caData, informerType)
+}
+
+// NewClientFactoryWithFallbacks creates a client factory, probing fallback endpoints when provided.
+func NewClientFactoryWithFallbacks(ctx context.Context, name, endpoint string, fallbackEndpoints []string,
+	certData, keyData, caData string, informerType InformerType,
+) (*ClientFactory, error) {
+	var (
+		clientSet        kubernetes.Interface
+		restCfg          *rest.Config
+		selectedEndpoint string
+		err              error
+	)
+	if len(fallbackEndpoints) > 0 {
+		clientSet, restCfg, selectedEndpoint, err = NewClientSetWithProbe(
+			ctx, endpoint, fallbackEndpoints, certData, keyData, caData, true)
+	} else {
+		clientSet, restCfg, err = NewClientSet(endpoint, certData, keyData, caData, true)
+		selectedEndpoint = NormalizeEndpointHost(endpoint)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -68,6 +89,7 @@ func NewClientFactory(ctx context.Context, name, endpoint, certData,
 	factory := &ClientFactory{
 		ctx:           ctx,
 		name:          name,
+		endpoint:      selectedEndpoint,
 		clientSet:     clientSet,
 		restConfig:    restCfg,
 		dynamicClient: dynamicClient,
@@ -94,8 +116,18 @@ func NewClientFactory(ctx context.Context, name, endpoint, certData,
 		factory.dynamicSharedInformerFactory = dynamicinformer.NewDynamicSharedInformerFactory(dynamicClient, defaultResyncPeriod)
 	default:
 	}
-	klog.Infof("new k8s client factory. name: %s, informer type: %d", name, informerType)
+	klog.Infof("new k8s client factory. name: %s, endpoint: %s, informer type: %d",
+		name, selectedEndpoint, informerType)
 	return factory, nil
+}
+
+// NewClientFactoryForTest builds a minimal valid factory for unit tests.
+func NewClientFactoryForTest(name, endpoint string) *ClientFactory {
+	return &ClientFactory{
+		name:     name,
+		endpoint: NormalizeEndpointHost(endpoint),
+		valid:    true,
+	}
 }
 
 // NewClientFactoryWithOnlyClient create factory instance with client only (without Informer).
@@ -111,6 +143,21 @@ func NewClientFactoryWithOnlyClient(ctx context.Context, name string, clientSet 
 // Name get factory name.
 func (f *ClientFactory) Name() string {
 	return f.name
+}
+
+// Endpoint returns the apiserver endpoint selected for this factory.
+func (f *ClientFactory) Endpoint() string {
+	return f.endpoint
+}
+
+// BackendFingerprint returns the control-plane backend IP fingerprint for service mode.
+func (f *ClientFactory) BackendFingerprint() string {
+	return f.backendFingerprint
+}
+
+// SetBackendFingerprint records the control-plane backend IP fingerprint.
+func (f *ClientFactory) SetBackendFingerprint(fingerprint string) {
+	f.backendFingerprint = fingerprint
 }
 
 // Release factory resources, stop Informer (if enabled).

--- a/SaFE/common/pkg/k8sclient/client_factory.go
+++ b/SaFE/common/pkg/k8sclient/client_factory.go
@@ -130,6 +130,11 @@ func NewClientFactoryForTest(name, endpoint string) *ClientFactory {
 	}
 }
 
+// AttachRestConfigForTest sets REST config on a test factory.
+func (f *ClientFactory) AttachRestConfigForTest(cfg *rest.Config) {
+	f.restConfig = cfg
+}
+
 // NewClientFactoryWithOnlyClient create factory instance with client only (without Informer).
 func NewClientFactoryWithOnlyClient(ctx context.Context, name string, clientSet kubernetes.Interface) *ClientFactory {
 	return &ClientFactory{

--- a/SaFE/common/pkg/k8sclient/client_factory.go
+++ b/SaFE/common/pkg/k8sclient/client_factory.go
@@ -7,6 +7,7 @@ package k8sclient
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -49,6 +50,11 @@ type ClientFactory struct {
 	// Informer type enum definition. 0: disable informer; 1: sharedInformer; 2 dynamicSharedInformer
 	// default 0
 	informerType InformerType
+	// validMu guards valid and invalidReason, which are updated after the factory is published:
+	// watch error handlers write from reflector goroutines while reconcilers and API request
+	// handlers read concurrently. The pair is kept under one lock so a reader never sees a status
+	// and a reason that disagree.
+	validMu sync.RWMutex
 	// Whether the ClientFactory is valid
 	valid bool
 	// If the factory is invalid, explain the reason
@@ -188,11 +194,15 @@ func (f *ClientFactory) Release() error {
 
 // IsValid returns true if factory is valid
 func (f *ClientFactory) IsValid() bool {
+	f.validMu.RLock()
+	defer f.validMu.RUnlock()
 	return f.valid
 }
 
 // SetValid set factory validity status and reason.
 func (f *ClientFactory) SetValid(valid bool, msg string) {
+	f.validMu.Lock()
+	defer f.validMu.Unlock()
 	f.valid = valid
 	f.invalidReason = msg
 }
@@ -235,6 +245,8 @@ func (f *ClientFactory) DynamicSharedInformerFactory() dynamicinformer.DynamicSh
 
 // GetInvalidReason get reason for factory invalidity.
 func (f *ClientFactory) GetInvalidReason() string {
+	f.validMu.RLock()
+	defer f.validMu.RUnlock()
 	return f.invalidReason
 }
 

--- a/SaFE/common/pkg/k8sclient/client_factory_test.go
+++ b/SaFE/common/pkg/k8sclient/client_factory_test.go
@@ -7,11 +7,46 @@ package k8sclient
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"math/big"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
 )
+
+// testClientCert returns a base64-encoded self-signed cert/key pair accepted by tls.X509KeyPair,
+// which lets factory construction run without reaching an apiserver.
+func testClientCert(t *testing.T) (certData, keyData string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	assert.NoError(t, err)
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "safe-unit-test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		IsCA:         true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	assert.NoError(t, err)
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	assert.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	return base64.StdEncoding.EncodeToString(certPEM), base64.StdEncoding.EncodeToString(keyPEM)
+}
 
 func TestClientFactoryWithOnlyClient(t *testing.T) {
 	cs := k8sfake.NewSimpleClientset()
@@ -33,4 +68,69 @@ func TestNewClientFactoryWithFallbacksInvalidInput(t *testing.T) {
 	_, err := NewClientFactoryWithFallbacks(context.Background(), "c1", "", []string{"https://10.0.0.2:6443"},
 		"", "", "", DisableInformer)
 	assert.Error(t, err)
+}
+
+func TestNewClientFactoryDisableInformer(t *testing.T) {
+	certData, keyData := testClientCert(t)
+	f, err := NewClientFactory(context.Background(), "c1", "10.96.1.1:6443", certData, keyData, "", DisableInformer)
+	assert.NoError(t, err)
+	assert.Equal(t, "c1", f.Name())
+	// Service mode keeps the address it was given, normalized with a scheme.
+	assert.Equal(t, "https://10.96.1.1:6443", f.Endpoint())
+	assert.NotNil(t, f.RestConfig())
+	assert.NotNil(t, f.DynamicClient())
+	assert.Nil(t, f.SharedInformerFactory())
+	assert.Nil(t, f.DynamicSharedInformerFactory())
+	assert.Nil(t, f.Mapper())
+
+	assert.Equal(t, "", f.BackendFingerprint())
+	f.SetBackendFingerprint("10.0.0.1,10.0.0.2")
+	assert.Equal(t, "10.0.0.1,10.0.0.2", f.BackendFingerprint())
+	assert.NoError(t, f.Release())
+}
+
+func TestNewClientFactoryEnableInformer(t *testing.T) {
+	certData, keyData := testClientCert(t)
+	f, err := NewClientFactory(context.Background(), "c1", "10.96.1.1:6443", certData, keyData, "", EnableInformer)
+	assert.NoError(t, err)
+	assert.NotNil(t, f.SharedInformerFactory())
+	assert.Nil(t, f.DynamicSharedInformerFactory())
+	// Release stops the informer factory and is safe to call twice.
+	assert.NoError(t, f.Release())
+	assert.NoError(t, f.Release())
+}
+
+func TestNewClientFactoryEnableDynamicInformer(t *testing.T) {
+	certData, keyData := testClientCert(t)
+	f, err := NewClientFactory(context.Background(), "c1", "10.96.1.1:6443", certData, keyData, "",
+		EnableDynamicInformer)
+	assert.NoError(t, err)
+	assert.NotNil(t, f.DynamicSharedInformerFactory())
+	// The REST mapper resolves lazily, so no apiserver call happens during construction.
+	assert.NotNil(t, f.Mapper())
+	assert.Nil(t, f.SharedInformerFactory())
+	assert.NoError(t, f.Release())
+}
+
+func TestNewClientFactoryWithFallbacksAllUnreachable(t *testing.T) {
+	certData, keyData := testClientCert(t)
+	_, err := NewClientFactoryWithFallbacks(context.Background(), "c1", "https://127.0.0.1:1",
+		[]string{"https://127.0.0.1:2"}, certData, keyData, "", DisableInformer)
+	assert.ErrorContains(t, err, "no reachable apiserver endpoint")
+}
+
+func TestClientFactoryTestHelpers(t *testing.T) {
+	f := NewClientFactoryForTest("c1", "10.96.1.1:6443")
+	assert.Equal(t, "https://10.96.1.1:6443", f.Endpoint())
+	assert.True(t, f.IsValid())
+	assert.Nil(t, f.RestConfig())
+
+	cfg := &rest.Config{Host: "https://127.0.0.1:1"}
+	f.AttachRestConfigForTest(cfg)
+	assert.Same(t, cfg, f.RestConfig())
+
+	informerFactory := NewClientFactoryForTestWithInformer("c1", k8sfake.NewSimpleClientset())
+	assert.NotNil(t, informerFactory.SharedInformerFactory())
+	informerFactory.StartInformer()
+	assert.NoError(t, informerFactory.Release())
 }

--- a/SaFE/common/pkg/k8sclient/client_factory_test.go
+++ b/SaFE/common/pkg/k8sclient/client_factory_test.go
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+package k8sclient
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestClientFactoryWithOnlyClient(t *testing.T) {
+	cs := k8sfake.NewSimpleClientset()
+	f := NewClientFactoryWithOnlyClient(context.Background(), "c1", cs)
+	assert.Equal(t, "c1", f.Name())
+	assert.NotNil(t, f.ClientSet())
+
+	f.SetValid(false, "down")
+	assert.False(t, f.IsValid())
+	assert.Equal(t, "down", f.GetInvalidReason())
+	f.SetValid(true, "")
+	assert.True(t, f.IsValid())
+
+	// Release on a factory without informers should not error.
+	assert.NoError(t, f.Release())
+}
+
+func TestNewClientFactoryWithFallbacksInvalidInput(t *testing.T) {
+	_, err := NewClientFactoryWithFallbacks(context.Background(), "c1", "", []string{"https://10.0.0.2:6443"},
+		"", "", "", DisableInformer)
+	assert.Error(t, err)
+}

--- a/SaFE/common/pkg/k8sclient/client_factory_test.go
+++ b/SaFE/common/pkg/k8sclient/client_factory_test.go
@@ -14,7 +14,9 @@ import (
 	"crypto/x509/pkix"
 	"encoding/base64"
 	"encoding/pem"
+	"fmt"
 	"math/big"
+	"sync"
 	"testing"
 	"time"
 
@@ -117,6 +119,42 @@ func TestNewClientFactoryWithFallbacksAllUnreachable(t *testing.T) {
 	_, err := NewClientFactoryWithFallbacks(context.Background(), "c1", "https://127.0.0.1:1",
 		[]string{"https://127.0.0.1:2"}, certData, keyData, "", DisableInformer)
 	assert.ErrorContains(t, err, "no reachable apiserver endpoint")
+}
+
+// TestClientFactoryValidityUnderConcurrency mirrors production access: watch error handlers write
+// validity from reflector goroutines while reconcilers and API request handlers read it. The common
+// module runs with -race in CI, so this guards the accessors from losing their synchronization.
+func TestClientFactoryValidityUnderConcurrency(t *testing.T) {
+	factory := NewClientFactoryWithOnlyClient(context.Background(), "c1", k8sfake.NewSimpleClientset())
+
+	const iterations = 200
+	var wg sync.WaitGroup
+	for writer := 0; writer < 4; writer++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				factory.SetValid(false, fmt.Sprintf("connection refused on watch %d-%d", id, i))
+				factory.SetValid(true, "")
+			}
+		}(writer)
+	}
+	for reader := 0; reader < 4; reader++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				if !factory.IsValid() {
+					_ = factory.GetInvalidReason()
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	factory.SetValid(false, "final")
+	assert.False(t, factory.IsValid())
+	assert.Equal(t, "final", factory.GetInvalidReason())
 }
 
 func TestClientFactoryTestHelpers(t *testing.T) {

--- a/SaFE/common/pkg/k8sclient/client_test.go
+++ b/SaFE/common/pkg/k8sclient/client_test.go
@@ -10,28 +10,31 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
 )
-
-func TestClientFactoryWithOnlyClient(t *testing.T) {
-	cs := k8sfake.NewSimpleClientset()
-	f := NewClientFactoryWithOnlyClient(context.Background(), "c1", cs)
-	assert.Equal(t, "c1", f.Name())
-	assert.NotNil(t, f.ClientSet())
-
-	f.SetValid(false, "down")
-	assert.False(t, f.IsValid())
-	assert.Equal(t, "down", f.GetInvalidReason())
-	f.SetValid(true, "")
-	assert.True(t, f.IsValid())
-
-	// Release on a factory without informers should not error.
-	assert.NoError(t, f.Release())
-}
 
 func TestNewClientSetWithRestConfig(t *testing.T) {
 	cs, err := NewClientSetWithRestConfig(&rest.Config{Host: "http://127.0.0.1:60999"})
 	assert.NoError(t, err)
 	assert.NotNil(t, cs)
+}
+
+func TestNormalizeEndpointHost(t *testing.T) {
+	assert.Equal(t, "https://10.0.0.1:6443", NormalizeEndpointHost("10.0.0.1:6443"))
+	assert.Equal(t, "https://c1.primus-safe.svc:443", NormalizeEndpointHost("c1.primus-safe.svc:443"))
+	assert.Equal(t, "http://127.0.0.1:8080", NormalizeEndpointHost("http://127.0.0.1:8080"))
+}
+
+func TestUniqueEndpoints(t *testing.T) {
+	out := uniqueEndpoints([]string{"10.0.0.1:6443", "https://10.0.0.1:6443", ""})
+	assert.Len(t, out, 1)
+}
+
+func TestNewClientSetWithProbeNoCandidates(t *testing.T) {
+	_, _, _, err := NewClientSetWithProbe(context.Background(), "", nil, "", "", "", true)
+	assert.Error(t, err)
+}
+
+func TestProbeRESTConfigNil(t *testing.T) {
+	assert.Error(t, ProbeRESTConfig(nil))
 }

--- a/SaFE/common/pkg/k8sclient/client_test.go
+++ b/SaFE/common/pkg/k8sclient/client_test.go
@@ -8,8 +8,10 @@ package k8sclient
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
 )
 
@@ -37,4 +39,46 @@ func TestNewClientSetWithProbeNoCandidates(t *testing.T) {
 
 func TestProbeRESTConfigNil(t *testing.T) {
 	assert.Error(t, ProbeRESTConfig(nil))
+}
+
+func TestProbeRESTConfigUnreachable(t *testing.T) {
+	assert.Error(t, ProbeRESTConfig(&rest.Config{
+		Host:    "https://127.0.0.1:1",
+		Timeout: time.Millisecond * 200,
+	}))
+}
+
+func TestProbeAPIServer(t *testing.T) {
+	ctx := context.Background()
+	assert.Error(t, ProbeAPIServer(ctx, nil, nil))
+	assert.Error(t, ProbeAPIServer(ctx, nil, &rest.Config{
+		Host:    "https://127.0.0.1:1",
+		Timeout: time.Millisecond * 200,
+	}))
+	// Without a REST config the probe falls back to the supplied clientset.
+	assert.NoError(t, ProbeAPIServer(ctx, k8sfake.NewSimpleClientset(), nil))
+}
+
+func TestNewClientSetInsecureAndWithCA(t *testing.T) {
+	certData, keyData := testClientCert(t)
+
+	_, restCfg, err := NewClientSet("10.96.1.1:6443", certData, keyData, "", true)
+	assert.NoError(t, err)
+	assert.Equal(t, "https://10.96.1.1:6443", restCfg.Host)
+	assert.True(t, restCfg.TLSClientConfig.Insecure)
+
+	// Secure mode requires CA data.
+	_, _, err = NewClientSet("10.96.1.1:6443", certData, keyData, "", false)
+	assert.Error(t, err)
+
+	_, restCfg, err = NewClientSet("10.96.1.1:6443", certData, keyData, certData, false)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, restCfg.TLSClientConfig.CAData)
+}
+
+func TestNewClientSetWithProbeSkipsUnbuildableEndpoint(t *testing.T) {
+	// An empty endpoint cannot build a client, so the probe moves on and still fails overall.
+	_, _, _, err := NewClientSetWithProbe(context.Background(), "https://127.0.0.1:1", []string{""},
+		"", "", "", true)
+	assert.ErrorContains(t, err, "no reachable apiserver endpoint")
 }

--- a/SaFE/common/pkg/k8sclient/client_test.go
+++ b/SaFE/common/pkg/k8sclient/client_test.go
@@ -76,6 +76,42 @@ func TestNewClientSetInsecureAndWithCA(t *testing.T) {
 	assert.NotEmpty(t, restCfg.TLSClientConfig.CAData)
 }
 
+func TestProbeTimeoutHonoursDeadline(t *testing.T) {
+	// No deadline: fall back to the package default.
+	assert.Equal(t, DefaultAPIServerProbeTimeout, probeTimeout(context.Background()))
+
+	// A tighter deadline wins so a probe cannot outlast its caller.
+	tight, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	assert.Less(t, probeTimeout(tight), DefaultAPIServerProbeTimeout)
+
+	// A looser deadline leaves the default in place.
+	loose, cancelLoose := context.WithTimeout(context.Background(), time.Hour)
+	defer cancelLoose()
+	assert.Equal(t, DefaultAPIServerProbeTimeout, probeTimeout(loose))
+
+	// An expired deadline must stay bounded: a non-positive timeout would mean "no timeout".
+	expired, cancelExpired := context.WithTimeout(context.Background(), -time.Second)
+	defer cancelExpired()
+	assert.Positive(t, probeTimeout(expired))
+}
+
+func TestProbeRESTConfigWithContextRespectsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	assert.ErrorIs(t, ProbeRESTConfigWithContext(ctx, &rest.Config{Host: "https://127.0.0.1:1"}),
+		context.Canceled)
+}
+
+func TestNewClientSetWithProbeStopsOnCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	certData, keyData := testClientCert(t)
+	_, _, _, err := NewClientSetWithProbe(ctx, "https://127.0.0.1:1",
+		[]string{"https://127.0.0.1:2"}, certData, keyData, "", true)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
 func TestNewClientSetWithProbeSkipsUnbuildableEndpoint(t *testing.T) {
 	// An empty endpoint cannot build a client, so the probe moves on and still fails overall.
 	_, _, _, err := NewClientSetWithProbe(context.Background(), "https://127.0.0.1:1", []string{""},

--- a/SaFE/common/pkg/k8sclient/watch_handler.go
+++ b/SaFE/common/pkg/k8sclient/watch_handler.go
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+package k8sclient
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+// WatchErrorHandler marks the client factory invalid for non-recoverable watch errors
+// and delegates to the default handler.
+func WatchErrorHandler(ctx context.Context, factory *ClientFactory) cache.WatchErrorHandler {
+	return func(reflector *cache.Reflector, err error) {
+		cache.DefaultWatchErrorHandler(ctx, reflector, err)
+		if factory == nil || !shouldMarkFactoryInvalidOnWatchError(err) {
+			return
+		}
+		klog.Warningf("set clients: %s invalid, watch error: %v", factory.Name(), err)
+		factory.SetValid(false, err.Error())
+	}
+}
+
+// shouldMarkFactoryInvalidOnWatchError reports whether a watch error should invalidate the factory.
+// Reflector-retriable errors (e.g. expired resource version) are ignored.
+func shouldMarkFactoryInvalidOnWatchError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if apierrors.IsResourceExpired(err) {
+		return false
+	}
+	if errors.Is(err, context.Canceled) {
+		return false
+	}
+	errMsg := strings.ToLower(err.Error())
+	if strings.Contains(errMsg, "too old resource version") {
+		return false
+	}
+	if apierrors.IsUnauthorized(err) || apierrors.IsForbidden(err) {
+		return true
+	}
+	if strings.Contains(errMsg, "x509") || strings.Contains(errMsg, "tls:") {
+		return true
+	}
+	return true
+}

--- a/SaFE/common/pkg/k8sclient/watch_handler_test.go
+++ b/SaFE/common/pkg/k8sclient/watch_handler_test.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+package k8sclient
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestWatchErrorHandler(t *testing.T) {
+	cs := k8sfake.NewSimpleClientset()
+	factory := NewClientFactoryWithOnlyClient(context.Background(), "c1", cs)
+	factory.SetValid(true, "")
+
+	h := WatchErrorHandler(context.Background(), factory)
+	h(&cache.Reflector{}, errors.New("connection refused"))
+
+	assert.False(t, factory.IsValid())
+	assert.Equal(t, "connection refused", factory.GetInvalidReason())
+}
+
+func TestWatchErrorHandlerRecoverableError(t *testing.T) {
+	cs := k8sfake.NewSimpleClientset()
+	factory := NewClientFactoryWithOnlyClient(context.Background(), "c1", cs)
+	factory.SetValid(true, "")
+
+	h := WatchErrorHandler(context.Background(), factory)
+	h(&cache.Reflector{}, errors.New("too old resource version"))
+
+	assert.True(t, factory.IsValid())
+}
+
+func TestShouldMarkFactoryInvalidOnWatchError(t *testing.T) {
+	assert.False(t, shouldMarkFactoryInvalidOnWatchError(nil))
+	assert.False(t, shouldMarkFactoryInvalidOnWatchError(errors.New("too old resource version")))
+	assert.True(t, shouldMarkFactoryInvalidOnWatchError(errors.New("connection refused")))
+}

--- a/SaFE/job-manager/pkg/syncer/cluster_client_sets.go
+++ b/SaFE/job-manager/pkg/syncer/cluster_client_sets.go
@@ -89,12 +89,13 @@ func newClusterClientSets(ctx context.Context, cluster *v1.Cluster,
 	if err != nil {
 		return nil, err
 	}
-	clientFactory, err := commonclient.NewClientFactory(ctx, cluster.Name, endpoint,
-		controlPlane.CertData, controlPlane.KeyData, controlPlane.CAData, commonclient.EnableDynamicInformer)
+	clientFactory, err := commoncluster.NewClientFactoryForCluster(ctx, adminClient, cluster,
+		commonclient.EnableDynamicInformer)
 	if err != nil {
 		return nil, err
 	}
-	klog.Infof("create cluster client sets, cluster: %s, endpoint: %s", cluster.Name, endpoint)
+	klog.Infof("create cluster client sets, cluster: %s, endpoint: %s, selected: %s",
+		cluster.Name, endpoint, clientFactory.Endpoint())
 	return &ClusterClientSets{
 		ctx:               ctx,
 		name:              cluster.Name,
@@ -190,18 +191,31 @@ func (r *ClusterClientSets) addResourceTemplate(gvk schema.GroupVersionKind) err
 	}
 	_, err = informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
+			if !r.dataClientFactory.IsValid() {
+				r.dataClientFactory.SetValid(true, "")
+			}
 			r.handleResource(ctx, nil, obj, ResourceAdd)
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
+			if !r.dataClientFactory.IsValid() {
+				r.dataClientFactory.SetValid(true, "")
+			}
 			r.handleResource(ctx, oldObj, newObj, ResourceUpdate)
 		},
 		DeleteFunc: func(obj interface{}) {
+			if !r.dataClientFactory.IsValid() {
+				r.dataClientFactory.SetValid(true, "")
+			}
 			r.handleResource(ctx, obj, obj, ResourceDel)
 		},
 	})
 	if err != nil {
 		klog.ErrorS(err, "failed to add event handler for resource informer",
 			"cluster", r.name, "gvk", gvk)
+		return err
+	}
+	if err = informer.Informer().SetWatchErrorHandler(commonclient.WatchErrorHandler(r.ctx, r.dataClientFactory)); err != nil {
+		klog.ErrorS(err, "failed to set watch error handler", "cluster", r.name, "gvk", gvk)
 		return err
 	}
 
@@ -308,6 +322,32 @@ func (r *resourceInformer) Release() error {
 	}
 	r.cancel()
 	r.isExited = true
+	return nil
+}
+
+// needsClientFactoryRefresh reports whether the data-plane client factory should be rebuilt.
+func (r *ClusterClientSets) needsClientFactoryRefresh(ctx context.Context, cluster *v1.Cluster,
+	adminClient client.Client) bool {
+	if r.dataClientFactory == nil || !r.dataClientFactory.IsValid() {
+		return true
+	}
+	return commoncluster.ClientFactoryNeedsRefresh(ctx, adminClient, cluster, r.dataClientFactory)
+}
+
+// recreateClientFactory rebuilds the data-plane client and clears informers.
+func (r *ClusterClientSets) recreateClientFactory(ctx context.Context, cluster *v1.Cluster,
+	adminClient client.Client) error {
+	if r.dataClientFactory != nil {
+		_ = r.dataClientFactory.Release()
+	}
+	factory, err := commoncluster.NewClientFactoryForCluster(ctx, adminClient, cluster,
+		commonclient.EnableDynamicInformer)
+	if err != nil {
+		return err
+	}
+	r.dataClientFactory = factory
+	r.resourceInformers.Clear()
+	klog.Infof("recreated cluster client factory, cluster: %s, endpoint: %s", r.name, factory.Endpoint())
 	return nil
 }
 

--- a/SaFE/job-manager/pkg/syncer/cluster_client_sets.go
+++ b/SaFE/job-manager/pkg/syncer/cluster_client_sets.go
@@ -191,21 +191,12 @@ func (r *ClusterClientSets) addResourceTemplate(gvk schema.GroupVersionKind) err
 	}
 	_, err = informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			if !r.dataClientFactory.IsValid() {
-				r.dataClientFactory.SetValid(true, "")
-			}
 			r.handleResource(ctx, nil, obj, ResourceAdd)
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
-			if !r.dataClientFactory.IsValid() {
-				r.dataClientFactory.SetValid(true, "")
-			}
 			r.handleResource(ctx, oldObj, newObj, ResourceUpdate)
 		},
 		DeleteFunc: func(obj interface{}) {
-			if !r.dataClientFactory.IsValid() {
-				r.dataClientFactory.SetValid(true, "")
-			}
 			r.handleResource(ctx, obj, obj, ResourceDel)
 		},
 	})

--- a/SaFE/job-manager/pkg/syncer/cluster_client_sets_test.go
+++ b/SaFE/job-manager/pkg/syncer/cluster_client_sets_test.go
@@ -7,7 +7,19 @@ package syncer
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"gotest.tools/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -19,8 +31,9 @@ import (
 	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
 	"github.com/AMD-AIG-AIMA/SAFE/apis/pkg/client/clientset/versioned/scheme"
 	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/common"
-	commonutils "github.com/AMD-AIG-AIMA/SAFE/common/pkg/utils"
 	commonclient "github.com/AMD-AIG-AIMA/SAFE/common/pkg/k8sclient"
+	commonutils "github.com/AMD-AIG-AIMA/SAFE/common/pkg/utils"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -29,6 +42,152 @@ func newTestClientSets() *ClusterClientSets {
 		name:              "c1",
 		resourceInformers: commonutils.NewObjectManager(),
 	}
+}
+
+// syncerTestCert returns a base64-encoded self-signed cert/key pair accepted by tls.X509KeyPair,
+// which lets data-plane client construction run without a real apiserver.
+func syncerTestCert(t *testing.T) (certData, keyData string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	assert.NilError(t, err)
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "safe-unit-test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		IsCA:         true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	assert.NilError(t, err)
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	assert.NilError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	return base64.StdEncoding.EncodeToString(certPEM), base64.StdEncoding.EncodeToString(keyPEM)
+}
+
+// newProbeAPIServer starts a TLS server that answers the ServerVersion reachability probe.
+func newProbeAPIServer(t *testing.T) int32 {
+	t.Helper()
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"major":"1","minor":"30"}`))
+	}))
+	t.Cleanup(srv.Close)
+	addr, ok := srv.Listener.Addr().(*net.TCPAddr)
+	assert.Assert(t, ok)
+	return int32(addr.Port)
+}
+
+// newReadyClusterEnv builds a ready cluster fronted by an admin Service whose ClusterIP points at
+// a local probe server, so Service-mode factories can be created and refreshed in tests.
+func newReadyClusterEnv(t *testing.T) (*v1.Cluster, ctrlclient.Client) {
+	t.Helper()
+	certData, keyData := syncerTestCert(t)
+	cluster := &v1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1"},
+		Status: v1.ClusterStatus{ControlPlaneStatus: v1.ControlPlaneStatus{
+			Phase:    v1.ReadyPhase,
+			CertData: certData,
+			KeyData:  keyData,
+		}},
+	}
+	mockScheme := scheme.Scheme
+	assert.NilError(t, corev1.AddToScheme(mockScheme))
+	assert.NilError(t, v1.AddToScheme(mockScheme))
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: common.PrimusSafeNamespace},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "127.0.0.1",
+			Ports:     []corev1.ServicePort{{Port: newProbeAPIServer(t)}},
+		},
+	}
+	endpoints := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: common.PrimusSafeNamespace},
+		Subsets: []corev1.EndpointSubset{{
+			Addresses: []corev1.EndpointAddress{{IP: "10.0.0.1"}},
+		}},
+	}
+	cl := ctrlfake.NewClientBuilder().WithScheme(mockScheme).
+		WithObjects(cluster, service, endpoints).Build()
+	return cluster, cl
+}
+
+func TestNewClusterClientSets(t *testing.T) {
+	cluster, cl := newReadyClusterEnv(t)
+	cs, err := newClusterClientSets(context.Background(), cluster, cl, func(*resourceMessage) {})
+	assert.NilError(t, err)
+	assert.Equal(t, cs.name, "c1")
+	assert.Equal(t, cs.dataClientFactory.BackendFingerprint(), "10.0.0.1")
+	assert.NilError(t, cs.Release())
+}
+
+func TestNewClusterClientSetsWithoutEndpoint(t *testing.T) {
+	mockScheme := scheme.Scheme
+	assert.NilError(t, v1.AddToScheme(mockScheme))
+	cl := ctrlfake.NewClientBuilder().WithScheme(mockScheme).Build()
+	cluster := &v1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1"},
+		Status:     v1.ClusterStatus{ControlPlaneStatus: v1.ControlPlaneStatus{Phase: v1.ReadyPhase}},
+	}
+	_, err := newClusterClientSets(context.Background(), cluster, cl, func(*resourceMessage) {})
+	assert.Assert(t, err != nil)
+}
+
+func TestRecreateClientFactory(t *testing.T) {
+	cluster, cl := newReadyClusterEnv(t)
+	cs := newTestClientSets()
+	previous := commonclient.NewClientFactoryForTest("c1", "10.96.9.9:6443")
+	cs.dataClientFactory = previous
+
+	assert.NilError(t, cs.recreateClientFactory(context.Background(), cluster, cl))
+	assert.Assert(t, cs.dataClientFactory != previous)
+	// Informers must be dropped so they are rebuilt against the new client.
+	assert.Equal(t, cs.informerCount(), 0)
+	assert.NilError(t, cs.dataClientFactory.Release())
+}
+
+func TestEnsureClusterClientSetsNotReady(t *testing.T) {
+	r := &SyncerReconciler{clusterClientSets: commonutils.NewObjectManager()}
+	retry := r.ensureClusterClientSets(context.Background(),
+		&v1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c1"}}, &v1.ResourceTemplateList{})
+	assert.Assert(t, !retry)
+	assert.Equal(t, r.clusterClientSets.Len(), 0)
+}
+
+func TestEnsureClusterClientSetsCreatesThenRefreshes(t *testing.T) {
+	cluster, cl := newReadyClusterEnv(t)
+	ctx := context.Background()
+	r := &SyncerReconciler{ctx: ctx, Client: cl, clusterClientSets: commonutils.NewObjectManager()}
+	rtList := &v1.ResourceTemplateList{}
+
+	assert.Assert(t, !r.ensureClusterClientSets(ctx, cluster, rtList))
+	clientSets, err := GetClusterClientSets(r.clusterClientSets, "c1")
+	assert.NilError(t, err)
+	first := clientSets.dataClientFactory
+
+	// A healthy factory is reused instead of rebuilt.
+	assert.Assert(t, !r.ensureClusterClientSets(ctx, cluster, rtList))
+	assert.Assert(t, clientSets.dataClientFactory == first)
+
+	// An invalidated factory is rebuilt because the probe target is reachable.
+	first.SetValid(false, "watch error")
+	assert.Assert(t, !r.ensureClusterClientSets(ctx, cluster, rtList))
+	assert.Assert(t, clientSets.dataClientFactory != first)
+	assert.NilError(t, clientSets.dataClientFactory.Release())
+}
+
+func TestEnsureAllClusterClientSets(t *testing.T) {
+	_, cl := newReadyClusterEnv(t)
+	ctx := context.Background()
+	r := &SyncerReconciler{ctx: ctx, Client: cl, clusterClientSets: commonutils.NewObjectManager()}
+
+	r.ensureAllClusterClientSets(ctx)
+	clientSets, err := GetClusterClientSets(r.clusterClientSets, "c1")
+	assert.NilError(t, err)
+	assert.NilError(t, clientSets.dataClientFactory.Release())
 }
 
 func TestClusterClientSetsGettersSetters(t *testing.T) {

--- a/SaFE/job-manager/pkg/syncer/cluster_client_sets_test.go
+++ b/SaFE/job-manager/pkg/syncer/cluster_client_sets_test.go
@@ -11,12 +11,17 @@ import (
 
 	"gotest.tools/assert"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
 
 	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
+	"github.com/AMD-AIG-AIMA/SAFE/apis/pkg/client/clientset/versioned/scheme"
+	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/common"
 	commonutils "github.com/AMD-AIG-AIMA/SAFE/common/pkg/utils"
+	commonclient "github.com/AMD-AIG-AIMA/SAFE/common/pkg/k8sclient"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func newTestClientSets() *ClusterClientSets {
@@ -161,4 +166,46 @@ func TestHandleResourceManaged(t *testing.T) {
 	assert.Equal(t, captured.workloadId, "w")
 	assert.Equal(t, captured.dispatchCount, 3)
 	assert.Equal(t, captured.cluster, "cl")
+}
+
+func TestNeedsClientFactoryRefreshInvalid(t *testing.T) {
+	cs := newTestClientSets()
+	factory := commonclient.NewClientFactoryForTest("c1", "https://10.0.0.1:6443")
+	factory.SetValid(false, "watch error")
+	cs.dataClientFactory = factory
+	cluster := &v1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1"},
+		Status: v1.ClusterStatus{
+			ControlPlaneStatus: v1.ControlPlaneStatus{Phase: v1.ReadyPhase},
+		},
+	}
+	assert.Assert(t, cs.needsClientFactoryRefresh(context.Background(), cluster, nil))
+}
+
+func TestNeedsClientFactoryRefreshBackendIPsChanged(t *testing.T) {
+	ctx := context.Background()
+	mockScheme := scheme.Scheme
+	_ = corev1.AddToScheme(mockScheme)
+	_ = v1.AddToScheme(mockScheme)
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: common.PrimusSafeNamespace},
+		Spec:       corev1.ServiceSpec{ClusterIP: "10.96.1.1", Ports: []corev1.ServicePort{{Port: 6443}}},
+	}
+	endpoints := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: common.PrimusSafeNamespace},
+		Subsets: []corev1.EndpointSubset{{
+			Addresses: []corev1.EndpointAddress{{IP: "10.0.0.1"}},
+		}},
+	}
+	adminClient := ctrlfake.NewClientBuilder().WithScheme(mockScheme).WithObjects(service, endpoints).Build()
+	cluster := &v1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1"},
+		Status:     v1.ClusterStatus{ControlPlaneStatus: v1.ControlPlaneStatus{Phase: v1.ReadyPhase}},
+	}
+	cs := newTestClientSets()
+	factory := commonclient.NewClientFactoryForTest("c1", "10.96.1.1:6443")
+	factory.SetBackendFingerprint("10.0.0.1,10.0.0.2")
+	cs.dataClientFactory = factory
+	assert.Assert(t, cs.needsClientFactoryRefresh(ctx, cluster, adminClient))
 }

--- a/SaFE/job-manager/pkg/syncer/syncer.go
+++ b/SaFE/job-manager/pkg/syncer/syncer.go
@@ -158,6 +158,9 @@ func (r *SyncerReconciler) Reconcile(ctx context.Context, request ctrlruntime.Re
 // Returns true when setup is incomplete and should be retried.
 func (r *SyncerReconciler) ensureClusterClientSets(ctx context.Context, cluster *v1.Cluster,
 	rtList *v1.ResourceTemplateList) bool {
+	if !cluster.IsReady() {
+		return false
+	}
 	clientSets, err := GetClusterClientSets(r.clusterClientSets, cluster.Name)
 	if err != nil {
 		clientSets, err = newClusterClientSets(r.ctx, cluster, r.Client, r.Add)
@@ -167,6 +170,11 @@ func (r *SyncerReconciler) ensureClusterClientSets(ctx context.Context, cluster 
 		}
 		r.clusterClientSets.AddOrReplace(cluster.Name, clientSets)
 		klog.Infof("create cluster clientSets, name: %s", cluster.Name)
+	} else if clientSets.needsClientFactoryRefresh(ctx, cluster, r.Client) {
+		if err = clientSets.recreateClientFactory(ctx, cluster, r.Client); err != nil {
+			klog.ErrorS(err, "failed to recreate cluster clientSets", "cluster", cluster.Name)
+			return true
+		}
 	}
 	for i := range rtList.Items {
 		if err := clientSets.addResourceTemplate(rtList.Items[i].ToSchemaGVK()); err != nil {

--- a/SaFE/job-manager/pkg/syncer/syncer.go
+++ b/SaFE/job-manager/pkg/syncer/syncer.go
@@ -46,7 +46,7 @@ type SyncerReconciler struct {
 const syncerWorkers = 8
 
 // clusterClientSetsRetryInterval is the backoff for re-attempting data-plane informer setup.
-const clusterClientSetsRetryInterval = 30 * time.Second
+const clusterClientSetsRetryInterval = 15 * time.Second
 
 // resourceMessageKey identifies the k8s object a message is about. Messages with
 // the same key are serialized and coalesced by the KeyedController.

--- a/SaFE/resource-manager/pkg/health/reporter.go
+++ b/SaFE/resource-manager/pkg/health/reporter.go
@@ -21,6 +21,7 @@ import (
 
 	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
 	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/common"
+	commoncluster "github.com/AMD-AIG-AIMA/SAFE/common/pkg/cluster"
 	commonconfig "github.com/AMD-AIG-AIMA/SAFE/common/pkg/config"
 	dbclient "github.com/AMD-AIG-AIMA/SAFE/common/pkg/database/client"
 	commonhealth "github.com/AMD-AIG-AIMA/SAFE/common/pkg/health"
@@ -161,30 +162,31 @@ func (r *Reporter) collectClusters(ctx context.Context) {
 	}
 }
 
-// probeCluster attempts a bounded ServerVersion call against a data-plane
-// cluster using the credentials stored on the Cluster CR status.
+// probeCluster attempts a bounded ServerVersion call against a data-plane cluster.
 func (r *Reporter) probeCluster(ctx context.Context, c *v1.Cluster) bool {
+	if !c.IsReady() {
+		return false
+	}
 	cps := c.Status.ControlPlaneStatus
-	if len(cps.Endpoints) == 0 || cps.CertData == "" || cps.KeyData == "" {
+	if cps.CertData == "" || cps.KeyData == "" {
 		return false
 	}
-	clientSet, _, err := k8sclient.NewClientSet(cps.Endpoints[0], cps.CertData, cps.KeyData, cps.CAData, true)
+	endpoint, err := commoncluster.GetEndpoint(ctx, r.cli, c)
 	if err != nil {
-		klog.V(4).Infof("[self-health] cluster %s client build failed: %v", c.Name, err)
+		klog.V(4).Infof("[self-health] cluster %s resolve endpoint failed: %v", c.Name, err)
 		return false
 	}
-
+	var fallbacks []string
+	if !commoncluster.UsesServiceEndpoint(ctx, r.cli, c) {
+		all := commoncluster.GetFallbackEndpoints(c)
+		if len(all) > 0 {
+			endpoint = all[0]
+			fallbacks = all[1:]
+		}
+	}
 	probeCtx, cancel := context.WithTimeout(ctx, clusterProbeTimeout)
 	defer cancel()
-	done := make(chan bool, 1)
-	go func() {
-		_, verr := clientSet.Discovery().ServerVersion()
-		done <- verr == nil
-	}()
-	select {
-	case <-probeCtx.Done():
-		return false
-	case ok := <-done:
-		return ok
-	}
+	_, _, _, err = k8sclient.NewClientSetWithProbe(probeCtx, endpoint, fallbacks,
+		cps.CertData, cps.KeyData, cps.CAData, true)
+	return err == nil
 }

--- a/SaFE/resource-manager/pkg/health/reporter_test.go
+++ b/SaFE/resource-manager/pkg/health/reporter_test.go
@@ -7,9 +7,11 @@ package health
 
 import (
 	"context"
+	"encoding/base64"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -27,6 +29,73 @@ func TestNewReporter(t *testing.T) {
 	}
 	if !r.NeedLeaderElection() {
 		t.Fatal("reporter must run leader-only")
+	}
+}
+
+// probeTestScheme builds a scheme able to hold Cluster and Service objects.
+func probeTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("add client-go scheme: %v", err)
+	}
+	if err := v1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add safe scheme: %v", err)
+	}
+	return scheme
+}
+
+func readyProbeCluster(name string) *v1.Cluster {
+	c := &v1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	c.Status.ControlPlaneStatus.Phase = v1.ReadyPhase
+	// Base64 payloads only need to decode to something non-empty for config building.
+	c.Status.ControlPlaneStatus.CertData = base64.StdEncoding.EncodeToString([]byte("cert"))
+	c.Status.ControlPlaneStatus.KeyData = base64.StdEncoding.EncodeToString([]byte("key"))
+	return c
+}
+
+func TestProbeClusterNotReady(t *testing.T) {
+	r := NewReporter(fake.NewClientBuilder().WithScheme(probeTestScheme(t)).Build())
+	if r.probeCluster(context.Background(), &v1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c1"}}) {
+		t.Fatal("a cluster that is not ready must not be reported up")
+	}
+}
+
+func TestProbeClusterWithoutCredentials(t *testing.T) {
+	cluster := &v1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c1"}}
+	cluster.Status.ControlPlaneStatus.Phase = v1.ReadyPhase
+	r := NewReporter(fake.NewClientBuilder().WithScheme(probeTestScheme(t)).Build())
+	if r.probeCluster(context.Background(), cluster) {
+		t.Fatal("a cluster without credentials must not be reported up")
+	}
+}
+
+func TestProbeClusterWithoutEndpoint(t *testing.T) {
+	cluster := readyProbeCluster("c1")
+	r := NewReporter(fake.NewClientBuilder().WithScheme(probeTestScheme(t)).Build())
+	if r.probeCluster(context.Background(), cluster) {
+		t.Fatal("a cluster without Service or status endpoints must not be reported up")
+	}
+}
+
+func TestProbeClusterServiceModeUnreachable(t *testing.T) {
+	cluster := readyProbeCluster("c1")
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: common.PrimusSafeNamespace},
+		Spec:       corev1.ServiceSpec{ClusterIP: "127.0.0.1", Ports: []corev1.ServicePort{{Port: 1}}},
+	}
+	cli := fake.NewClientBuilder().WithScheme(probeTestScheme(t)).WithObjects(service).Build()
+	if NewReporter(cli).probeCluster(context.Background(), cluster) {
+		t.Fatal("an unreachable Service endpoint must not be reported up")
+	}
+}
+
+func TestProbeClusterDirectModeUnreachable(t *testing.T) {
+	cluster := readyProbeCluster("c1")
+	cluster.Status.ControlPlaneStatus.Endpoints = []string{"https://127.0.0.1:1", "https://127.0.0.2:1"}
+	cli := fake.NewClientBuilder().WithScheme(probeTestScheme(t)).Build()
+	if NewReporter(cli).probeCluster(context.Background(), cluster) {
+		t.Fatal("unreachable direct endpoints must not be reported up")
 	}
 }
 

--- a/SaFE/resource-manager/pkg/resource/big_controllers_extra_test.go
+++ b/SaFE/resource-manager/pkg/resource/big_controllers_extra_test.go
@@ -7,6 +7,7 @@ package resource
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -94,9 +95,33 @@ func TestIsClusterSourceEndpoints(t *testing.T) {
 }
 
 func TestBuildDNSServerBlock(t *testing.T) {
-	block := buildDNSServerBlock("foo.local", "10.0.0.1")
+	block := buildDNSServerBlock("foo.local", []string{"10.0.0.1", "10.0.0.3"})
 	assert.Contains(t, block, "foo.local")
-	assert.Contains(t, block, "10.0.0.1")
+	// Every healthy control plane gets its own A record so resolvers can fall over.
+	assert.Contains(t, block, "IN A 10.0.0.1")
+	assert.Contains(t, block, "IN A 10.0.0.3")
+}
+
+func TestStripDNSServerBlockRoundTrip(t *testing.T) {
+	existing := "cluster.local:53 {\n    kubernetes\n}"
+	corefile := existing + "\n" + buildDNSServerBlock("foo.local", []string{"10.0.0.1"})
+
+	// Removing our block restores the untouched Corefile.
+	assert.Equal(t, existing, stripDNSServerBlock(corefile, "foo.local"))
+	// Unrelated names are left alone.
+	assert.Equal(t, corefile, stripDNSServerBlock(corefile, "bar.local"))
+	// Rebuilding with a new address set replaces rather than appends.
+	rebuilt := stripDNSServerBlock(corefile, "foo.local") + "\n" +
+		buildDNSServerBlock("foo.local", []string{"10.0.0.3"})
+	assert.Equal(t, 1, strings.Count(rebuilt, dnsServerBlockPrefix))
+	assert.Contains(t, rebuilt, "IN A 10.0.0.3")
+	assert.NotContains(t, rebuilt, "IN A 10.0.0.1")
+}
+
+func TestStripDNSServerBlockKeepsUnbalancedCorefile(t *testing.T) {
+	// A block we cannot delimit is preserved instead of being mangled.
+	broken := ".:53 {\n    template IN A foo.local {\n        answer \"x\""
+	assert.Equal(t, broken, stripDNSServerBlock(broken, "foo.local"))
 }
 
 func TestGenerateForwardName(t *testing.T) {
@@ -108,9 +133,9 @@ func TestGenAllPriorityClass(t *testing.T) {
 	assert.Len(t, classes, 3)
 }
 
-func TestGetControlPlaneIPNoCluster(t *testing.T) {
+func TestGetControlPlaneIPsNoCluster(t *testing.T) {
 	r := newClusterReconciler(t)
-	_, err := r.getControlPlaneIP(context.Background())
+	_, err := r.getControlPlaneIPs(context.Background())
 	assert.Error(t, err)
 }
 

--- a/SaFE/resource-manager/pkg/resource/cluster_contoller_plane.go
+++ b/SaFE/resource-manager/pkg/resource/cluster_contoller_plane.go
@@ -672,7 +672,7 @@ func (r *ClusterReconciler) filterHealthyControlPlaneAddresses(ctx context.Conte
 			if err != nil {
 				return
 			}
-			if err = commonclient.ProbeRESTConfig(restCfg); err != nil {
+			if err = commonclient.ProbeRESTConfigWithContext(probeCtx, restCfg); err != nil {
 				klog.V(4).InfoS("control plane apiserver probe failed",
 					"cluster", cluster.Name, "node", node.Name, "err", err)
 				return

--- a/SaFE/resource-manager/pkg/resource/cluster_contoller_plane.go
+++ b/SaFE/resource-manager/pkg/resource/cluster_contoller_plane.go
@@ -661,10 +661,34 @@ func (r *ClusterReconciler) filterHealthyControlPlaneAddresses(ctx context.Conte
 	}
 	wg.Wait()
 	if len(healthy) == 0 {
+		if preserved := r.existingControlPlaneEndpointAddresses(ctx, cluster); len(preserved) > 0 {
+			klog.Warningf("no healthy control plane endpoints for cluster %s, preserving %d existing backends",
+				cluster.Name, len(preserved))
+			return preserved
+		}
 		klog.Warningf("no healthy control plane endpoints for cluster %s, keeping all registered nodes", cluster.Name)
 		return all
 	}
 	return healthy
+}
+
+// existingControlPlaneEndpointAddresses returns the current admin-plane backend pool.
+func (r *ClusterReconciler) existingControlPlaneEndpointAddresses(ctx context.Context,
+	cluster *v1.Cluster) []corev1.EndpointAddress {
+	existing := new(corev1.Endpoints)
+	err := r.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: common.PrimusSafeNamespace}, existing)
+	if err != nil {
+		return nil
+	}
+	addresses := make([]corev1.EndpointAddress, 0)
+	for _, subset := range existing.Subsets {
+		for _, addr := range subset.Addresses {
+			if addr.IP != "" {
+				addresses = append(addresses, addr)
+			}
+		}
+	}
+	return addresses
 }
 
 // guaranteeEndpoints creates or syncs the endpoints resource for the cluster.

--- a/SaFE/resource-manager/pkg/resource/cluster_contoller_plane.go
+++ b/SaFE/resource-manager/pkg/resource/cluster_contoller_plane.go
@@ -373,12 +373,35 @@ func (r *ClusterReconciler) fetchProvisionedClusterKubeConfig(ctx context.Contex
 		return err
 	}
 
-	config, err := r.fetchConfigFromSSH(ctx, nodes[0])
+	config, err := r.fetchConfigFromControlPlane(ctx, nodes)
 	if err != nil {
 		return err
 	}
 
 	return r.updateClusterKubeConfig(ctx, cluster, nodes, config)
+}
+
+// fetchConfigFromControlPlane reads the provisioned kubeconfig from the first control plane that
+// answers. Every control plane holds the same credentials, so one unreachable node must not block
+// adoption while its peers are healthy.
+func (r *ClusterReconciler) fetchConfigFromControlPlane(ctx context.Context,
+	nodes []*v1.Node) (*rest.Config, error) {
+	var lastErr error
+	for _, node := range nodes {
+		config, err := r.fetchConfigFromSSH(ctx, node)
+		if err != nil {
+			klog.ErrorS(err, "failed to read kubeconfig from control plane, trying peers",
+				"node", node.Name)
+			lastErr = err
+			continue
+		}
+		// fetchConfigFromSSH reports an unusable kubeconfig as a nil config without an error.
+		if config == nil {
+			continue
+		}
+		return config, nil
+	}
+	return nil, lastErr
 }
 
 // shouldFetchKubeConfig determines if kubeconfig should be fetched.

--- a/SaFE/resource-manager/pkg/resource/cluster_contoller_plane.go
+++ b/SaFE/resource-manager/pkg/resource/cluster_contoller_plane.go
@@ -11,6 +11,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -32,6 +33,7 @@ import (
 
 	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
 	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/common"
+	commonclient "github.com/AMD-AIG-AIMA/SAFE/common/pkg/k8sclient"
 	rmmetrics "github.com/AMD-AIG-AIMA/SAFE/resource-manager/pkg/metrics"
 	"github.com/AMD-AIG-AIMA/SAFE/resource-manager/pkg/utils"
 	"github.com/AMD-AIG-AIMA/SAFE/utils/pkg/secure"
@@ -42,6 +44,7 @@ const (
 	DefaultHttpServiePort = 443
 	// DefaultApiserverPort is the default port for Kubernetes API server
 	DefaultApiserverPort           = 6443
+	controlPlaneProbeBatchTimeout  = 15 * time.Second
 	deprecatedDefaultNginxTemplate = "nginx.22.3.2"
 	deprecatedDefaultNginxRelease  = "nginx"
 )
@@ -613,49 +616,110 @@ func (r *ClusterReconciler) guaranteeService(ctx context.Context, cluster *v1.Cl
 	return r.guaranteeServiceResource(ctx, cluster)
 }
 
-// guaranteeEndpoints creates the endpoints resource for the cluster.
-func (r *ClusterReconciler) guaranteeEndpoints(ctx context.Context, cluster *v1.Cluster, nodes []*v1.Node) error {
-	endpoint := new(corev1.Endpoints)
-	err := r.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: common.PrimusSafeNamespace}, endpoint)
+// filterHealthyControlPlaneAddresses keeps apiserver endpoints that respond to ServerVersion.
+func (r *ClusterReconciler) filterHealthyControlPlaneAddresses(ctx context.Context, cluster *v1.Cluster,
+	nodes []*v1.Node) []corev1.EndpointAddress {
+	all := make([]corev1.EndpointAddress, 0, len(nodes))
+	for _, node := range nodes {
+		all = append(all, corev1.EndpointAddress{IP: node.Spec.PrivateIP})
+	}
+	cps := cluster.Status.ControlPlaneStatus
+	if cps.CertData == "" || cps.KeyData == "" {
+		return all
+	}
 
+	healthy := make([]corev1.EndpointAddress, 0, len(nodes))
+	probeCtx, cancel := context.WithTimeout(ctx, controlPlaneProbeBatchTimeout)
+	defer cancel()
+
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for _, node := range nodes {
+		if probeCtx.Err() != nil {
+			break
+		}
+		wg.Add(1)
+		go func(node *v1.Node) {
+			defer wg.Done()
+			if probeCtx.Err() != nil {
+				return
+			}
+			endpoint := fmt.Sprintf("https://%s:%d", node.Spec.PrivateIP, DefaultApiserverPort)
+			_, restCfg, err := commonclient.NewClientSet(endpoint, cps.CertData, cps.KeyData, cps.CAData, true)
+			if err != nil {
+				return
+			}
+			if err = commonclient.ProbeRESTConfig(restCfg); err != nil {
+				klog.V(4).InfoS("control plane apiserver probe failed",
+					"cluster", cluster.Name, "node", node.Name, "err", err)
+				return
+			}
+			mu.Lock()
+			healthy = append(healthy, corev1.EndpointAddress{IP: node.Spec.PrivateIP})
+			mu.Unlock()
+		}(node)
+	}
+	wg.Wait()
+	if len(healthy) == 0 {
+		klog.Warningf("no healthy control plane endpoints for cluster %s, keeping all registered nodes", cluster.Name)
+		return all
+	}
+	return healthy
+}
+
+// guaranteeEndpoints creates or syncs the endpoints resource for the cluster.
+func (r *ClusterReconciler) guaranteeEndpoints(ctx context.Context, cluster *v1.Cluster, nodes []*v1.Node) error {
+	addresses := r.filterHealthyControlPlaneAddresses(ctx, cluster, nodes)
+	desiredPorts := []corev1.EndpointPort{{
+		Name:     "https",
+		Port:     DefaultApiserverPort,
+		Protocol: corev1.ProtocolTCP,
+	}}
+	desiredSubset := corev1.EndpointSubset{Addresses: addresses, Ports: desiredPorts}
+
+	existing := new(corev1.Endpoints)
+	err := r.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: common.PrimusSafeNamespace}, existing)
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}
-
-	if err == nil {
+	if errors.IsNotFound(err) {
+		endpoint := &corev1.Endpoints{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            cluster.Name,
+				Namespace:       common.PrimusSafeNamespace,
+				OwnerReferences: []metav1.OwnerReference{createKubernetesClusterOwnerReference(cluster)},
+			},
+			Subsets: []corev1.EndpointSubset{desiredSubset},
+		}
+		if err = r.Create(ctx, endpoint); err != nil {
+			return fmt.Errorf("create cluster endpoint failed %+v", err)
+		}
 		return nil
 	}
 
-	address := make([]corev1.EndpointAddress, 0, len(nodes))
-	for _, node := range nodes {
-		address = append(address, corev1.EndpointAddress{IP: node.Spec.PrivateIP})
+	isChanged := false
+	if len(existing.Subsets) != 1 {
+		existing.Subsets = []corev1.EndpointSubset{desiredSubset}
+		isChanged = true
+	} else {
+		cur := existing.Subsets[0]
+		if len(cur.Ports) != 1 || cur.Ports[0].Port != desiredPorts[0].Port {
+			existing.Subsets[0].Ports = desiredPorts
+			isChanged = true
+		}
+		if !endpointSubsetEqual(cur, desiredSubset) {
+			existing.Subsets[0].Addresses = addresses
+			isChanged = true
+		}
 	}
-
-	endpoint = &corev1.Endpoints{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            cluster.Name,
-			Namespace:       common.PrimusSafeNamespace,
-			OwnerReferences: []metav1.OwnerReference{createKubernetesClusterOwnerReference(cluster)},
-		},
-		Subsets: []corev1.EndpointSubset{
-			{
-				Addresses: address,
-				Ports: []corev1.EndpointPort{
-					{
-						Name:     "https",
-						Port:     DefaultApiserverPort,
-						Protocol: "TCP",
-					},
-				},
-			},
-		},
+	if !isChanged {
+		return nil
 	}
-
-	err = r.Create(ctx, endpoint)
-	if err != nil {
-		return fmt.Errorf("create cluster endpoint failed %+v", err)
+	if err = r.Update(ctx, existing); err != nil {
+		return fmt.Errorf("update cluster endpoint failed %+v", err)
 	}
-
+	klog.Infof("synced control plane endpoints for cluster %s, addresses: %d", cluster.Name, len(addresses))
+	r.markClusterClientFactoryStale(cluster.Name, "control plane endpoints changed")
 	return nil
 }
 

--- a/SaFE/resource-manager/pkg/resource/cluster_contoller_plane.go
+++ b/SaFE/resource-manager/pkg/resource/cluster_contoller_plane.go
@@ -628,9 +628,10 @@ func (r *ClusterReconciler) filterHealthyControlPlaneAddresses(ctx context.Conte
 	probeCtx, cancel := context.WithTimeout(ctx, controlPlaneProbeBatchTimeout)
 	defer cancel()
 
-	// Fan out over control plane nodes only, so concurrency is bounded by the etcd quorum size
-	// (typically 3 or 5) regardless of how many workers the cluster has. The whole batch is
-	// additionally capped by controlPlaneProbeBatchTimeout.
+	// Fan out over control plane nodes only, so per-cluster concurrency is bounded by the etcd
+	// quorum size (typically 3 or 5) rather than by how many workers the cluster has. Reconciles
+	// run at the manager's MaxConcurrentReconciles, keeping the aggregate in the tens, and each
+	// batch is additionally capped by controlPlaneProbeBatchTimeout.
 	var mu sync.Mutex
 	var wg sync.WaitGroup
 	for _, node := range nodes {

--- a/SaFE/resource-manager/pkg/resource/cluster_contoller_plane.go
+++ b/SaFE/resource-manager/pkg/resource/cluster_contoller_plane.go
@@ -628,6 +628,9 @@ func (r *ClusterReconciler) filterHealthyControlPlaneAddresses(ctx context.Conte
 	probeCtx, cancel := context.WithTimeout(ctx, controlPlaneProbeBatchTimeout)
 	defer cancel()
 
+	// Fan out over control plane nodes only, so concurrency is bounded by the etcd quorum size
+	// (typically 3 or 5) regardless of how many workers the cluster has. The whole batch is
+	// additionally capped by controlPlaneProbeBatchTimeout.
 	var mu sync.Mutex
 	var wg sync.WaitGroup
 	for _, node := range nodes {

--- a/SaFE/resource-manager/pkg/resource/cluster_contoller_plane.go
+++ b/SaFE/resource-manager/pkg/resource/cluster_contoller_plane.go
@@ -455,10 +455,6 @@ func (r *ClusterReconciler) updateClusterKubeConfig(ctx context.Context, cluster
 
 	cluster.Status.ControlPlaneStatus.Phase = v1.ReadyPhase
 
-	if err := r.guaranteeService(ctx, cluster); err != nil {
-		return err
-	}
-
 	if err := r.Status().Patch(ctx, cluster, originalCluster); err != nil {
 		return fmt.Errorf("failed load config %+v", err)
 	}

--- a/SaFE/resource-manager/pkg/resource/cluster_controller.go
+++ b/SaFE/resource-manager/pkg/resource/cluster_controller.go
@@ -46,6 +46,10 @@ import (
 
 const (
 	ClusterRoleBindingLabel = "app.kubernetes.io/role-ref"
+	// controlPlaneEndpointsSyncInterval requeues ready clusters to probe apiserver backends
+	// and sync admin-plane Endpoints. client-go dial defaults only apply per HTTP connection
+	// to the Service VIP; they do not remove dead backends from the Endpoints pool.
+	controlPlaneEndpointsSyncInterval = 15 * time.Second
 )
 
 // ClusterReconciler reconciles Cluster resources and manages their lifecycle.
@@ -343,7 +347,17 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrlruntime.Reque
 		rmmetrics.ClusterReconcileErrorsTotal.WithLabelValues("node_local_dns").Inc()
 		return ctrlruntime.Result{}, err
 	}
+	if shouldPeriodicSyncControlPlaneEndpoints(cluster) {
+		return ctrlruntime.Result{RequeueAfter: controlPlaneEndpointsSyncInterval}, nil
+	}
 	return ctrlruntime.Result{}, nil
+}
+
+// shouldPeriodicSyncControlPlaneEndpoints reports whether reconcile should requeue to
+// re-probe control-plane apiservers and sync Service Endpoints.
+func shouldPeriodicSyncControlPlaneEndpoints(cluster *v1.Cluster) bool {
+	return cluster != nil && cluster.GetDeletionTimestamp().IsZero() && cluster.IsReady() &&
+		len(cluster.Spec.ControlPlane.Nodes) > 0
 }
 
 // cleanupClusterResources removes all associated resources for a cluster including priority classes,
@@ -422,22 +436,50 @@ func (r *ClusterReconciler) resetNodesOfCluster(ctx context.Context, cluster *v1
 
 // guaranteeClientFactory ensures a Kubernetes client factory is available for the cluster.
 func (r *ClusterReconciler) guaranteeClientFactory(ctx context.Context, cluster *v1.Cluster) error {
-	if !cluster.IsReady() || r.clientManager.Has(cluster.Name) {
+	if !cluster.IsReady() {
 		return nil
+	}
+	if err := r.guaranteeService(ctx, cluster); err != nil {
+		return err
 	}
 	endpoint, err := commoncluster.GetEndpoint(ctx, r.Client, cluster)
 	if err != nil {
 		return err
 	}
-	controlPlane := &cluster.Status.ControlPlaneStatus
-	k8sClients, err := commonclient.NewClientFactory(ctx, cluster.Name, endpoint,
-		controlPlane.CertData, controlPlane.KeyData, controlPlane.CAData, commonclient.EnableInformer)
+	if obj, ok := r.clientManager.Get(cluster.Name); ok {
+		if factory, ok := obj.(*commonclient.ClientFactory); ok &&
+			!commoncluster.ClientFactoryNeedsRefresh(ctx, r.Client, cluster, factory) {
+			return nil
+		}
+	}
+	k8sClients, err := commoncluster.NewClientFactoryForCluster(ctx, r.Client, cluster, commonclient.EnableInformer)
 	if err != nil {
 		return err
 	}
+	recreated := r.clientManager.Has(cluster.Name)
 	r.clientManager.AddOrReplace(cluster.Name, k8sClients)
-	klog.Infof("add cluster %s informer, endpoint: %s", cluster.Name, endpoint)
+	klog.Infof("add cluster %s informer, endpoint: %s, selected: %s",
+		cluster.Name, endpoint, k8sClients.Endpoint())
+	if recreated {
+		tryRestartNodeInformer(ctx, cluster)
+	}
 	return nil
+}
+
+// markClusterClientFactoryStale invalidates the cached data-plane client after backend pool changes.
+func (r *ClusterReconciler) markClusterClientFactoryStale(clusterName, reason string) {
+	if r.clientManager == nil {
+		return
+	}
+	obj, ok := r.clientManager.Get(clusterName)
+	if !ok {
+		return
+	}
+	factory, ok := obj.(*commonclient.ClientFactory)
+	if !ok || !factory.IsValid() {
+		return
+	}
+	factory.SetValid(false, reason)
 }
 
 // guaranteePriorityClass ensures priority classes are created in the cluster.

--- a/SaFE/resource-manager/pkg/resource/cluster_controller.go
+++ b/SaFE/resource-manager/pkg/resource/cluster_controller.go
@@ -452,15 +452,20 @@ func (r *ClusterReconciler) guaranteeClientFactory(ctx context.Context, cluster 
 	if !cluster.IsReady() {
 		return nil
 	}
-	endpoint, err := commoncluster.GetEndpoint(ctx, r.Client, cluster)
-	if err != nil {
-		return err
-	}
 	if obj, ok := r.clientManager.Get(cluster.Name); ok {
 		if factory, ok := obj.(*commonclient.ClientFactory); ok &&
 			!commoncluster.ClientFactoryNeedsRefresh(ctx, r.Client, cluster, factory) {
 			return nil
 		}
+	}
+	endpoint, err := commoncluster.GetEndpoint(ctx, r.Client, cluster)
+	if err != nil {
+		if obj, ok := r.clientManager.Get(cluster.Name); ok {
+			if factory, ok := obj.(*commonclient.ClientFactory); ok && factory.IsValid() {
+				return nil
+			}
+		}
+		return err
 	}
 	k8sClients, err := commoncluster.NewClientFactoryForCluster(ctx, r.Client, cluster, commonclient.EnableInformer)
 	if err != nil {

--- a/SaFE/resource-manager/pkg/resource/cluster_controller.go
+++ b/SaFE/resource-manager/pkg/resource/cluster_controller.go
@@ -1067,7 +1067,7 @@ func (r *ClusterReconciler) guaranteeNodeLocalDNS(ctx context.Context, cluster *
 		return nil
 	}
 
-	controlPlaneIP, err := r.getControlPlaneIP(ctx)
+	controlPlaneIPs, err := r.getControlPlaneIPs(ctx)
 	if err != nil {
 		return err
 	}
@@ -1092,54 +1092,73 @@ func (r *ClusterReconciler) guaranteeNodeLocalDNS(ctx context.Context, cluster *
 		return fmt.Errorf("Corefile key not found in nodelocaldns ConfigMap in cluster %s", cluster.Name)
 	}
 
-	serverBlock := buildDNSServerBlock(dnsName, controlPlaneIP)
-	if strings.Contains(corefile, dnsName) {
-		klog.V(4).Infof("nodelocaldns Corefile in cluster %s already contains %s, skipping", cluster.Name, dnsName)
+	// Replace rather than append: the recorded addresses must follow the healthy control planes,
+	// otherwise data-plane nodes keep resolving the system host to an apiserver that is gone.
+	base := strings.TrimRight(stripDNSServerBlock(corefile, dnsName), " \t\n")
+	desired := base + "\n" + buildDNSServerBlock(dnsName, controlPlaneIPs)
+	if desired == corefile {
+		klog.V(4).Infof("nodelocaldns Corefile in cluster %s already targets %v, skipping",
+			cluster.Name, controlPlaneIPs)
 		return nil
 	}
 
-	cm.Data["Corefile"] = corefile + "\n" + serverBlock
+	cm.Data["Corefile"] = desired
 	if _, err = clientSet.CoreV1().ConfigMaps("kube-system").Update(ctx, cm, metav1.UpdateOptions{}); err != nil {
 		return fmt.Errorf("failed to update nodelocaldns ConfigMap in cluster %s: %w", cluster.Name, err)
 	}
-	klog.Infof("updated nodelocaldns Corefile in cluster %s with %s -> %s", cluster.Name, dnsName, controlPlaneIP)
+	klog.Infof("updated nodelocaldns Corefile in cluster %s with %s -> %v", cluster.Name, dnsName, controlPlaneIPs)
 	return nil
 }
 
-// getControlPlaneIP returns the IP address of the control-plane cluster's first endpoint.
-func (r *ClusterReconciler) getControlPlaneIP(ctx context.Context) (string, error) {
+// getControlPlaneIPs returns the admin-plane addresses that data-plane nodes should resolve the
+// system host to. It prefers the probed Endpoints pool so an apiserver that went down is left out,
+// and falls back to every address recorded on the cluster status when that pool is unavailable.
+func (r *ClusterReconciler) getControlPlaneIPs(ctx context.Context) ([]string, error) {
 	clusterList := &v1.ClusterList{}
 	if err := r.Client.List(ctx, clusterList, client.MatchingLabels{
 		v1.ClusterControlPlaneLabel: "",
 	}); err != nil {
-		return "", fmt.Errorf("failed to list clusters with control-plane label: %w", err)
+		return nil, fmt.Errorf("failed to list clusters with control-plane label: %w", err)
 	}
 	if len(clusterList.Items) == 0 {
-		return "", fmt.Errorf("no cluster with control-plane label found")
+		return nil, fmt.Errorf("no cluster with control-plane label found")
 	}
 
 	cp := &clusterList.Items[0]
-	if len(cp.Status.ControlPlaneStatus.Endpoints) == 0 {
-		return "", fmt.Errorf("control-plane cluster %s has no endpoints", cp.Name)
+	if ips, err := commoncluster.GetControlPlaneBackendIPs(ctx, r.Client, cp); err == nil && len(ips) > 0 {
+		return ips, nil
 	}
 
-	endpoint := cp.Status.ControlPlaneStatus.Endpoints[0]
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse control-plane endpoint %q: %w", endpoint, err)
+	hosts := make([]string, 0, len(cp.Status.ControlPlaneStatus.Endpoints))
+	for _, endpoint := range cp.Status.ControlPlaneStatus.Endpoints {
+		u, err := url.Parse(endpoint)
+		if err != nil {
+			klog.V(4).Infof("skip unparsable control-plane endpoint %q: %v", endpoint, err)
+			continue
+		}
+		if host := u.Hostname(); host != "" {
+			hosts = append(hosts, host)
+		}
 	}
-	host := u.Hostname()
-	if host == "" {
-		return "", fmt.Errorf("no host found in control-plane endpoint %q", endpoint)
+	if len(hosts) == 0 {
+		return nil, fmt.Errorf("control-plane cluster %s has no usable endpoint", cp.Name)
 	}
-	return host, nil
+	return hosts, nil
 }
 
-// buildDNSServerBlock generates a CoreDNS server block that resolves the given dnsName to the given IP.
-func buildDNSServerBlock(dnsName, ip string) string {
-	return fmt.Sprintf(`.:53 {
+// dnsServerBlockPrefix opens the CoreDNS server block that buildDNSServerBlock renders.
+const dnsServerBlockPrefix = ".:53 {"
+
+// buildDNSServerBlock generates a CoreDNS server block resolving dnsName to every given address.
+// One A record per control plane lets a resolver fall over when the first address stops answering.
+func buildDNSServerBlock(dnsName string, ips []string) string {
+	answers := make([]string, 0, len(ips))
+	for _, ip := range ips {
+		answers = append(answers, fmt.Sprintf(`        answer "{{ .Name }} 60 IN A %s"`, ip))
+	}
+	return fmt.Sprintf(`%s
     template IN A %s {
-        answer "{{ .Name }} 60 IN A %s"
+%s
         fallthrough
     }
     errors
@@ -1149,7 +1168,47 @@ func buildDNSServerBlock(dnsName, ip string) string {
     bind 169.254.25.10
     forward . /etc/resolv.conf
     prometheus :9253
-}`, dnsName, ip)
+}`, dnsServerBlockPrefix, dnsName, strings.Join(answers, "\n"))
+}
+
+// stripDNSServerBlock removes the server blocks templating dnsName so they can be replaced when the
+// control-plane address set changes. A block whose bounds cannot be determined is left untouched,
+// keeping a Corefile we do not fully understand intact.
+func stripDNSServerBlock(corefile, dnsName string) string {
+	marker := "template IN A " + dnsName
+	for {
+		pos := strings.Index(corefile, marker)
+		if pos < 0 {
+			return corefile
+		}
+		start := strings.LastIndex(corefile[:pos], dnsServerBlockPrefix)
+		if start < 0 {
+			return corefile
+		}
+		end := dnsServerBlockEnd(corefile, start)
+		if end < 0 {
+			return corefile
+		}
+		corefile = strings.TrimRight(corefile[:start], " \t\n") + corefile[end:]
+	}
+}
+
+// dnsServerBlockEnd returns the index just past the brace closing the block opened at start,
+// or -1 when the braces are unbalanced.
+func dnsServerBlockEnd(corefile string, start int) int {
+	depth := 0
+	for i := start; i < len(corefile); i++ {
+		switch corefile[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i + 1
+			}
+		}
+	}
+	return -1
 }
 
 // generateForwardName generates the name for forward resources by appending "-forward" to the cluster name.

--- a/SaFE/resource-manager/pkg/resource/cluster_controller.go
+++ b/SaFE/resource-manager/pkg/resource/cluster_controller.go
@@ -295,6 +295,11 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrlruntime.Reque
 		rmmetrics.ClusterReconcileErrorsTotal.WithLabelValues("cluster_control_plane").Inc()
 		return ctrlruntime.Result{}, err
 	}
+	if err = r.syncControlPlaneServiceEndpoints(ctx, cluster); err != nil {
+		klog.ErrorS(err, "failed to sync control plane endpoints", "cluster", cluster.Name)
+		rmmetrics.ClusterReconcileErrorsTotal.WithLabelValues("control_plane_endpoints").Inc()
+		return ctrlruntime.Result{}, err
+	}
 	if err = r.guaranteeClientFactory(ctx, cluster); err != nil {
 		klog.ErrorS(err, "failed to guarantee client factory", "cluster", cluster.Name)
 		rmmetrics.ClusterReconcileErrorsTotal.WithLabelValues("client_factory").Inc()
@@ -434,13 +439,18 @@ func (r *ClusterReconciler) resetNodesOfCluster(ctx context.Context, cluster *v1
 	return nil
 }
 
+// syncControlPlaneServiceEndpoints probes apiserver backends and syncs admin-plane Service/Endpoints once per reconcile.
+func (r *ClusterReconciler) syncControlPlaneServiceEndpoints(ctx context.Context, cluster *v1.Cluster) error {
+	if !shouldPeriodicSyncControlPlaneEndpoints(cluster) {
+		return nil
+	}
+	return r.guaranteeService(ctx, cluster)
+}
+
 // guaranteeClientFactory ensures a Kubernetes client factory is available for the cluster.
 func (r *ClusterReconciler) guaranteeClientFactory(ctx context.Context, cluster *v1.Cluster) error {
 	if !cluster.IsReady() {
 		return nil
-	}
-	if err := r.guaranteeService(ctx, cluster); err != nil {
-		return err
 	}
 	endpoint, err := commoncluster.GetEndpoint(ctx, r.Client, cluster)
 	if err != nil {
@@ -461,13 +471,16 @@ func (r *ClusterReconciler) guaranteeClientFactory(ctx context.Context, cluster 
 	klog.Infof("add cluster %s informer, endpoint: %s, selected: %s",
 		cluster.Name, endpoint, k8sClients.Endpoint())
 	if recreated {
-		tryRestartNodeInformer(ctx, cluster)
+		if restartErr := tryRestartNodeInformer(ctx, cluster); restartErr != nil {
+			klog.ErrorS(restartErr, "failed to restart node informer after client rebuild", "cluster", cluster.Name)
+		}
 	}
 	return nil
 }
 
 // markClusterClientFactoryStale invalidates the cached data-plane client after backend pool changes.
 func (r *ClusterReconciler) markClusterClientFactoryStale(clusterName, reason string) {
+	clearNodeInformerForCluster(clusterName)
 	if r.clientManager == nil {
 		return
 	}

--- a/SaFE/resource-manager/pkg/resource/cluster_controller_test.go
+++ b/SaFE/resource-manager/pkg/resource/cluster_controller_test.go
@@ -998,6 +998,30 @@ func TestGuaranteeEndpointsBackendSync(t *testing.T) {
 	testifyassert.False(t, factory.IsValid())
 }
 
+func TestGuaranteeClientFactoryKeepsValidFactoryWithoutEndpoint(t *testing.T) {
+	scheme, _ := genMockScheme()
+	cluster := readyCluster("c1")
+	cl := ctrlfake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster).Build()
+	cs := k8sfake.NewSimpleClientset()
+	mgr := commonutils.NewObjectManager()
+	factory := commonclient.NewClientFactoryWithOnlyClient(context.Background(), "c1", cs)
+	testifyassert.NoError(t, mgr.Add("c1", factory))
+	r := &ClusterReconciler{
+		ClusterBaseReconciler: &ClusterBaseReconciler{Client: cl},
+		clientManager:         mgr,
+	}
+	testifyassert.NoError(t, r.guaranteeClientFactory(context.Background(), cluster))
+	testifyassert.True(t, factory.IsValid())
+}
+
+func TestSyncControlPlaneServiceEndpointsSkipsWithoutCPNodes(t *testing.T) {
+	scheme, _ := genMockScheme()
+	cluster := readyCluster("c1")
+	cl := ctrlfake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster).Build()
+	r := &ClusterReconciler{ClusterBaseReconciler: &ClusterBaseReconciler{Client: cl}}
+	testifyassert.NoError(t, r.syncControlPlaneServiceEndpoints(context.Background(), cluster))
+}
+
 func TestFilterHealthyPreservesExistingBackends(t *testing.T) {
 	cluster := testCluster("c1")
 	existing := &corev1.Endpoints{

--- a/SaFE/resource-manager/pkg/resource/cluster_controller_test.go
+++ b/SaFE/resource-manager/pkg/resource/cluster_controller_test.go
@@ -933,3 +933,66 @@ func TestGuaranteeClientFactoryNotReady(t *testing.T) {
 	// Not ready -> no-op nil.
 	testifyassert.NoError(t, r.guaranteeClientFactory(context.Background(), testCluster("c1")))
 }
+
+func TestShouldPeriodicSyncControlPlaneEndpoints(t *testing.T) {
+	ready := testCluster("c1")
+	ready.Status.ControlPlaneStatus.Phase = v1.ReadyPhase
+	ready.Spec.ControlPlane.Nodes = []string{"cp1"}
+
+	notReady := testCluster("c2")
+	notReady.Spec.ControlPlane.Nodes = []string{"cp1"}
+
+	deleting := ready.DeepCopy()
+	now := metav1.Now()
+	deleting.DeletionTimestamp = &now
+
+	testifyassert.True(t, shouldPeriodicSyncControlPlaneEndpoints(ready))
+	testifyassert.False(t, shouldPeriodicSyncControlPlaneEndpoints(notReady))
+	testifyassert.False(t, shouldPeriodicSyncControlPlaneEndpoints(deleting))
+	testifyassert.False(t, shouldPeriodicSyncControlPlaneEndpoints(nil))
+}
+
+func TestFilterHealthyControlPlaneAddressesNoCredentials(t *testing.T) {
+	cluster := testCluster("c1")
+	r := newPlaneReconciler(t, cluster)
+	nodes := []*v1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "n1"}, Spec: v1.NodeSpec{PrivateIP: "10.0.0.1"}}}
+	addrs := r.filterHealthyControlPlaneAddresses(context.Background(), cluster, nodes)
+	testifyassert.Len(t, addrs, 1)
+	testifyassert.Equal(t, "10.0.0.1", addrs[0].IP)
+}
+
+func TestMarkClusterClientFactoryStale(t *testing.T) {
+	mgr := commonutils.NewObjectManager()
+	factory := commonclient.NewClientFactoryForTest("c1", "10.96.1.1:6443")
+	testifyassert.NoError(t, mgr.Add("c1", factory))
+	r := &ClusterReconciler{clientManager: mgr}
+	r.markClusterClientFactoryStale("c1", "control plane endpoints changed")
+	testifyassert.False(t, factory.IsValid())
+}
+
+func TestGuaranteeEndpointsBackendSync(t *testing.T) {
+	cluster := testCluster("c1")
+	existing := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: common.PrimusSafeNamespace},
+		Subsets: []corev1.EndpointSubset{{
+			Addresses: []corev1.EndpointAddress{{IP: "10.0.0.1"}, {IP: "10.0.0.2"}},
+		}},
+	}
+	r := newPlaneReconciler(t, cluster, existing)
+	mgr := commonutils.NewObjectManager()
+	factory := commonclient.NewClientFactoryForTest("c1", "10.96.1.1:6443")
+	factory.SetBackendFingerprint("10.0.0.1,10.0.0.2")
+	testifyassert.NoError(t, mgr.Add("c1", factory))
+	r.clientManager = mgr
+
+	nodes := []*v1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "n1"}, Spec: v1.NodeSpec{PrivateIP: "10.0.0.1"}}}
+	testifyassert.NoError(t, r.guaranteeEndpoints(context.Background(), cluster, nodes))
+
+	ep := &corev1.Endpoints{}
+	testifyassert.NoError(t, r.Get(context.Background(), client.ObjectKey{
+		Name: "c1", Namespace: common.PrimusSafeNamespace,
+	}, ep))
+	testifyassert.Len(t, ep.Subsets[0].Addresses, 1)
+	testifyassert.Equal(t, "10.0.0.1", ep.Subsets[0].Addresses[0].IP)
+	testifyassert.False(t, factory.IsValid())
+}

--- a/SaFE/resource-manager/pkg/resource/cluster_controller_test.go
+++ b/SaFE/resource-manager/pkg/resource/cluster_controller_test.go
@@ -7,6 +7,7 @@ package resource
 
 import (
 	"context"
+	"encoding/base64"
 	"testing"
 	"time"
 
@@ -995,4 +996,24 @@ func TestGuaranteeEndpointsBackendSync(t *testing.T) {
 	testifyassert.Len(t, ep.Subsets[0].Addresses, 1)
 	testifyassert.Equal(t, "10.0.0.1", ep.Subsets[0].Addresses[0].IP)
 	testifyassert.False(t, factory.IsValid())
+}
+
+func TestFilterHealthyPreservesExistingBackends(t *testing.T) {
+	cluster := testCluster("c1")
+	existing := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: common.PrimusSafeNamespace},
+		Subsets: []corev1.EndpointSubset{{
+			Addresses: []corev1.EndpointAddress{{IP: "10.0.0.1"}},
+		}},
+	}
+	r := newPlaneReconciler(t, cluster, existing)
+	cluster.Status.ControlPlaneStatus.CertData = base64.StdEncoding.EncodeToString([]byte("cert"))
+	cluster.Status.ControlPlaneStatus.KeyData = base64.StdEncoding.EncodeToString([]byte("key"))
+	nodes := []*v1.Node{
+		{ObjectMeta: metav1.ObjectMeta{Name: "n1"}, Spec: v1.NodeSpec{PrivateIP: "10.0.0.1"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "n2"}, Spec: v1.NodeSpec{PrivateIP: "10.0.0.2"}},
+	}
+	addrs := r.filterHealthyControlPlaneAddresses(context.Background(), cluster, nodes)
+	testifyassert.Len(t, addrs, 1)
+	testifyassert.Equal(t, "10.0.0.1", addrs[0].IP)
 }

--- a/SaFE/resource-manager/pkg/resource/cluster_controller_test.go
+++ b/SaFE/resource-manager/pkg/resource/cluster_controller_test.go
@@ -8,6 +8,7 @@ package resource
 import (
 	"context"
 	"encoding/base64"
+	"strings"
 	"testing"
 	"time"
 
@@ -447,6 +448,70 @@ func TestGuaranteeNodeLocalDNSUpdatesCorefile(t *testing.T) {
 	testifyassert.NoError(t, err)
 	updated, _ := cs.CoreV1().ConfigMaps("kube-system").Get(context.Background(), "nodelocaldns", metav1.GetOptions{})
 	testifyassert.Contains(t, updated.Data["Corefile"], "safe.local")
+}
+
+func readNodeLocalDNSCorefile(t *testing.T, cs *k8sfake.Clientset) string {
+	t.Helper()
+	cm, err := cs.CoreV1().ConfigMaps("kube-system").Get(
+		context.Background(), "nodelocaldns", metav1.GetOptions{})
+	testifyassert.NoError(t, err)
+	return cm.Data["Corefile"]
+}
+
+func TestGuaranteeNodeLocalDNSFollowsHealthyControlPlanes(t *testing.T) {
+	patches := gomonkey.ApplyFunc(commonconfig.GetSystemHost, func() string { return "safe.local" })
+	defer patches.Reset()
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "nodelocaldns", Namespace: "kube-system"},
+		Data:       map[string]string{"Corefile": "cluster.local:53 {\n    kubernetes\n}"},
+	}
+	cs := k8sfake.NewSimpleClientset(cm)
+
+	scheme, _ := genMockScheme()
+	dataCluster := readyCluster("c1")
+	cpCluster := readyCluster("ctrl")
+	cpCluster.Labels = map[string]string{v1.ClusterControlPlaneLabel: ""}
+	// The status lists every control plane, while probing currently reaches only two of them.
+	cpCluster.Status.ControlPlaneStatus.Endpoints = []string{
+		"https://10.0.0.1:6443", "https://10.0.0.2:6443", "https://10.0.0.3:6443",
+	}
+	endpoints := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{Name: "ctrl", Namespace: common.PrimusSafeNamespace},
+		Subsets: []corev1.EndpointSubset{{
+			Addresses: []corev1.EndpointAddress{{IP: "10.0.0.1"}, {IP: "10.0.0.3"}},
+		}},
+	}
+	cl := ctrlfake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(dataCluster, cpCluster, endpoints).Build()
+	mgr := commonutils.NewObjectManager()
+	testifyassert.NoError(t, mgr.Add("c1",
+		commonclient.NewClientFactoryWithOnlyClient(context.Background(), "c1", cs)))
+	r := &ClusterReconciler{ClusterBaseReconciler: &ClusterBaseReconciler{Client: cl}, clientManager: mgr}
+	ctx := context.Background()
+
+	testifyassert.NoError(t, r.guaranteeNodeLocalDNS(ctx, dataCluster))
+	corefile := readNodeLocalDNSCorefile(t, cs)
+	testifyassert.Contains(t, corefile, "IN A 10.0.0.1")
+	testifyassert.Contains(t, corefile, "IN A 10.0.0.3")
+	// 10.0.0.2 failed probing, so data-plane resolvers must not be pointed at it.
+	testifyassert.NotContains(t, corefile, "IN A 10.0.0.2")
+
+	// Reconciling again changes nothing.
+	testifyassert.NoError(t, r.guaranteeNodeLocalDNS(ctx, dataCluster))
+	testifyassert.Equal(t, corefile, readNodeLocalDNSCorefile(t, cs))
+
+	// 10.0.0.1 goes down: the Corefile follows the pool instead of keeping a dead address.
+	endpoints.Subsets[0].Addresses = []corev1.EndpointAddress{{IP: "10.0.0.3"}}
+	testifyassert.NoError(t, cl.Update(ctx, endpoints))
+	testifyassert.NoError(t, r.guaranteeNodeLocalDNS(ctx, dataCluster))
+
+	corefile = readNodeLocalDNSCorefile(t, cs)
+	testifyassert.NotContains(t, corefile, "IN A 10.0.0.1")
+	testifyassert.Contains(t, corefile, "IN A 10.0.0.3")
+	// The block is replaced rather than appended, and unrelated blocks survive.
+	testifyassert.Equal(t, 1, strings.Count(corefile, dnsServerBlockPrefix))
+	testifyassert.Contains(t, corefile, "cluster.local:53 {")
 }
 
 func TestGuaranteeDataPlaneClusterRoleEmptyName(t *testing.T) {

--- a/SaFE/resource-manager/pkg/resource/cluster_controller_test.go
+++ b/SaFE/resource-manager/pkg/resource/cluster_controller_test.go
@@ -8,6 +8,8 @@ package resource
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -448,6 +450,46 @@ func TestGuaranteeNodeLocalDNSUpdatesCorefile(t *testing.T) {
 	testifyassert.NoError(t, err)
 	updated, _ := cs.CoreV1().ConfigMaps("kube-system").Get(context.Background(), "nodelocaldns", metav1.GetOptions{})
 	testifyassert.Contains(t, updated.Data["Corefile"], "safe.local")
+}
+
+func TestFetchConfigFromControlPlaneFallsBackToNextNode(t *testing.T) {
+	var attempted []string
+	patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(&ClusterReconciler{}), "fetchConfigFromSSH",
+		func(_ *ClusterReconciler, _ context.Context, node *v1.Node) (*rest.Config, error) {
+			attempted = append(attempted, node.Name)
+			switch node.Name {
+			case "cp1":
+				return nil, fmt.Errorf("ssh dial failed")
+			case "cp2":
+				// An unusable kubeconfig is reported as a nil config without an error.
+				return nil, nil
+			default:
+				return &rest.Config{Host: "https://10.0.0.3:6443"}, nil
+			}
+		})
+	defer patches.Reset()
+
+	nodes := []*v1.Node{
+		{ObjectMeta: metav1.ObjectMeta{Name: "cp1"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "cp2"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "cp3"}},
+	}
+	config, err := (&ClusterReconciler{}).fetchConfigFromControlPlane(context.Background(), nodes)
+	testifyassert.NoError(t, err)
+	testifyassert.Equal(t, "https://10.0.0.3:6443", config.Host)
+	testifyassert.Equal(t, []string{"cp1", "cp2", "cp3"}, attempted)
+}
+
+func TestFetchConfigFromControlPlaneAllNodesFail(t *testing.T) {
+	patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(&ClusterReconciler{}), "fetchConfigFromSSH",
+		func(_ *ClusterReconciler, _ context.Context, _ *v1.Node) (*rest.Config, error) {
+			return nil, fmt.Errorf("ssh dial failed")
+		})
+	defer patches.Reset()
+
+	_, err := (&ClusterReconciler{}).fetchConfigFromControlPlane(context.Background(),
+		[]*v1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "cp1"}}})
+	testifyassert.Error(t, err)
 }
 
 func readNodeLocalDNSCorefile(t *testing.T, cs *k8sfake.Clientset) string {

--- a/SaFE/resource-manager/pkg/resource/node_informer_registry.go
+++ b/SaFE/resource-manager/pkg/resource/node_informer_registry.go
@@ -7,6 +7,7 @@ package resource
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
@@ -14,33 +15,45 @@ import (
 
 const nodeInformerRestartTimeout = 11 * time.Minute
 
+// The node informer lives in NodeK8sReconciler while the client factory it binds to is rebuilt by
+// ClusterReconciler. These callbacks bridge the two without a direct dependency. They are stored
+// atomically so registration is safe even if it ever moves off the startup path.
 var (
-	restartNodeInformer           func(context.Context, *v1.Cluster) error
-	clearNodeInformerRegistration func(string)
+	restartNodeInformer           atomic.Pointer[func(context.Context, *v1.Cluster) error]
+	clearNodeInformerRegistration atomic.Pointer[func(string)]
 )
 
 // RegisterNodeInformerRestarter registers a callback to (re)start the node informer after client rebuild.
 func RegisterNodeInformerRestarter(fn func(context.Context, *v1.Cluster) error) {
-	restartNodeInformer = fn
+	if fn == nil {
+		restartNodeInformer.Store(nil)
+		return
+	}
+	restartNodeInformer.Store(&fn)
 }
 
 // RegisterNodeInformerClearer registers a callback to drop cached node informer registrations.
 func RegisterNodeInformerClearer(fn func(string)) {
-	clearNodeInformerRegistration = fn
+	if fn == nil {
+		clearNodeInformerRegistration.Store(nil)
+		return
+	}
+	clearNodeInformerRegistration.Store(&fn)
 }
 
 func clearNodeInformerForCluster(clusterName string) {
-	if clearNodeInformerRegistration != nil {
-		clearNodeInformerRegistration(clusterName)
+	if clear := clearNodeInformerRegistration.Load(); clear != nil {
+		(*clear)(clusterName)
 	}
 }
 
 // tryRestartNodeInformer synchronously re-attaches the node informer to the rebuilt client factory.
 func tryRestartNodeInformer(ctx context.Context, cluster *v1.Cluster) error {
-	if restartNodeInformer == nil || cluster == nil {
+	restart := restartNodeInformer.Load()
+	if restart == nil || cluster == nil {
 		return nil
 	}
 	restartCtx, cancel := context.WithTimeout(ctx, nodeInformerRestartTimeout)
 	defer cancel()
-	return restartNodeInformer(restartCtx, cluster)
+	return (*restart)(restartCtx, cluster)
 }

--- a/SaFE/resource-manager/pkg/resource/node_informer_registry.go
+++ b/SaFE/resource-manager/pkg/resource/node_informer_registry.go
@@ -9,29 +9,38 @@ import (
 	"context"
 	"time"
 
-	"k8s.io/klog/v2"
-
 	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
 )
 
 const nodeInformerRestartTimeout = 11 * time.Minute
 
-var restartNodeInformer func(context.Context, *v1.Cluster) error
+var (
+	restartNodeInformer           func(context.Context, *v1.Cluster) error
+	clearNodeInformerRegistration func(string)
+)
 
 // RegisterNodeInformerRestarter registers a callback to (re)start the node informer after client rebuild.
 func RegisterNodeInformerRestarter(fn func(context.Context, *v1.Cluster) error) {
 	restartNodeInformer = fn
 }
 
-func tryRestartNodeInformer(_ context.Context, cluster *v1.Cluster) {
-	if restartNodeInformer == nil || cluster == nil {
-		return
+// RegisterNodeInformerClearer registers a callback to drop cached node informer registrations.
+func RegisterNodeInformerClearer(fn func(string)) {
+	clearNodeInformerRegistration = fn
+}
+
+func clearNodeInformerForCluster(clusterName string) {
+	if clearNodeInformerRegistration != nil {
+		clearNodeInformerRegistration(clusterName)
 	}
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), nodeInformerRestartTimeout)
-		defer cancel()
-		if err := restartNodeInformer(ctx, cluster); err != nil {
-			klog.ErrorS(err, "failed to restart node informer", "cluster", cluster.Name)
-		}
-	}()
+}
+
+// tryRestartNodeInformer synchronously re-attaches the node informer to the rebuilt client factory.
+func tryRestartNodeInformer(ctx context.Context, cluster *v1.Cluster) error {
+	if restartNodeInformer == nil || cluster == nil {
+		return nil
+	}
+	restartCtx, cancel := context.WithTimeout(ctx, nodeInformerRestartTimeout)
+	defer cancel()
+	return restartNodeInformer(restartCtx, cluster)
 }

--- a/SaFE/resource-manager/pkg/resource/node_informer_registry.go
+++ b/SaFE/resource-manager/pkg/resource/node_informer_registry.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+package resource
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/klog/v2"
+
+	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
+)
+
+const nodeInformerRestartTimeout = 11 * time.Minute
+
+var restartNodeInformer func(context.Context, *v1.Cluster) error
+
+// RegisterNodeInformerRestarter registers a callback to (re)start the node informer after client rebuild.
+func RegisterNodeInformerRestarter(fn func(context.Context, *v1.Cluster) error) {
+	restartNodeInformer = fn
+}
+
+func tryRestartNodeInformer(_ context.Context, cluster *v1.Cluster) {
+	if restartNodeInformer == nil || cluster == nil {
+		return
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), nodeInformerRestartTimeout)
+		defer cancel()
+		if err := restartNodeInformer(ctx, cluster); err != nil {
+			klog.ErrorS(err, "failed to restart node informer", "cluster", cluster.Name)
+		}
+	}()
+}

--- a/SaFE/resource-manager/pkg/resource/node_informer_registry_test.go
+++ b/SaFE/resource-manager/pkg/resource/node_informer_registry_test.go
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+package resource
+
+import (
+	"context"
+	"testing"
+
+	testifyassert "github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
+)
+
+func TestTryRestartNodeInformer(t *testing.T) {
+	called := false
+	RegisterNodeInformerRestarter(func(ctx context.Context, cluster *v1.Cluster) error {
+		called = cluster != nil && cluster.Name == "c1"
+		return nil
+	})
+	t.Cleanup(func() { RegisterNodeInformerRestarter(nil) })
+
+	err := tryRestartNodeInformer(context.Background(), &v1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1"},
+	})
+	testifyassert.NoError(t, err)
+	testifyassert.True(t, called)
+}
+
+func TestTryRestartNodeInformerNilCluster(t *testing.T) {
+	testifyassert.NoError(t, tryRestartNodeInformer(context.Background(), nil))
+}
+
+func TestClearNodeInformerForCluster(t *testing.T) {
+	cleared := ""
+	RegisterNodeInformerClearer(func(clusterName string) {
+		cleared = clusterName
+	})
+	t.Cleanup(func() { RegisterNodeInformerClearer(nil) })
+
+	clearNodeInformerForCluster("c1")
+	testifyassert.Equal(t, "c1", cleared)
+}

--- a/SaFE/resource-manager/pkg/resource/node_k8s_controller.go
+++ b/SaFE/resource-manager/pkg/resource/node_k8s_controller.go
@@ -100,8 +100,9 @@ func SetupNodeK8sController(ctx context.Context, mgr manager.Manager) error {
 		return err
 	}
 	RegisterNodeInformerRestarter(func(ctx context.Context, cluster *v1.Cluster) error {
-		return r.startNodeInformer(cluster)
+		return r.restartNodeInformerAfterClientRebuild(ctx, cluster)
 	})
+	RegisterNodeInformerClearer(r.clearNodeInformerRegistration)
 	err = ctrlruntime.NewControllerManagedBy(mgr).
 		For(&v1.Cluster{}, builder.WithPredicates(r.relevantChangePredicate())).
 		Complete(r)
@@ -156,45 +157,81 @@ func (r *NodeK8sReconciler) startNodeInformer(cluster *v1.Cluster) error {
 	return err
 }
 
+func (r *NodeK8sReconciler) clearNodeInformerRegistration(clusterName string) {
+	r.nodeInformerMu.Lock()
+	delete(r.startedNodeInformers, clusterName)
+	r.nodeInformerMu.Unlock()
+}
+
+// restartNodeInformerAfterClientRebuild re-attaches the node informer without blocking on cache sync.
+func (r *NodeK8sReconciler) restartNodeInformerAfterClientRebuild(ctx context.Context, cluster *v1.Cluster) error {
+	if cluster == nil {
+		return nil
+	}
+	_, err, _ := r.nodeInformerGroup.Do(cluster.Name, func() (interface{}, error) {
+		return nil, r.attachNodeInformer(ctx, cluster, false)
+	})
+	return err
+}
+
 func (r *NodeK8sReconciler) startNodeInformerOnce(cluster *v1.Cluster) error {
 	const maxRetry = 100
 	waitTime := time.Millisecond * 200
 	maxWaitTime := waitTime * maxRetry
 
-	err := backoff.Retry(func() error {
-		k8sClients, err := utils.GetK8sClientFactory(r.clientManager, cluster.Name)
-		if err != nil {
-			klog.ErrorS(err, "failed to get k8s client for data plane", "name", cluster.Name)
-			return err
-		}
-		r.nodeInformerMu.Lock()
-		if prev, ok := r.startedNodeInformers[cluster.Name]; ok && prev == k8sClients {
-			r.nodeInformerMu.Unlock()
-			return nil
-		}
-		r.nodeInformerMu.Unlock()
+	return backoff.Retry(func() error {
+		return r.attachNodeInformer(r.ctx, cluster, true)
+	}, maxWaitTime, waitTime)
+}
 
-		nodeInformer := k8sClients.SharedInformerFactory().Core().V1().Nodes().Informer()
-		if _, err = nodeInformer.AddEventHandler(r.nodeEventHandler(k8sClients)); err != nil {
-			klog.ErrorS(err, "failed to add event handler", "name", cluster.Name)
-			return err
-		}
-		if err = nodeInformer.SetWatchErrorHandler(commonclient.WatchErrorHandler(r.ctx, k8sClients)); err != nil {
-			klog.ErrorS(err, "failed to set error handler", "name", cluster.Name)
-			return err
-		}
-		k8sClients.StartInformer()
+// attachNodeInformer wires handlers and starts the node informer for the current client factory.
+func (r *NodeK8sReconciler) attachNodeInformer(ctx context.Context, cluster *v1.Cluster, waitSync bool) error {
+	k8sClients, err := utils.GetK8sClientFactory(r.clientManager, cluster.Name)
+	if err != nil {
+		klog.ErrorS(err, "failed to get k8s client for data plane", "name", cluster.Name)
+		return err
+	}
+	r.nodeInformerMu.Lock()
+	if prev, ok := r.startedNodeInformers[cluster.Name]; ok && prev == k8sClients {
+		r.nodeInformerMu.Unlock()
+		return nil
+	}
+	r.nodeInformerMu.Unlock()
+
+	nodeInformer := k8sClients.SharedInformerFactory().Core().V1().Nodes().Informer()
+	if _, err = nodeInformer.AddEventHandler(r.nodeEventHandler(k8sClients)); err != nil {
+		klog.ErrorS(err, "failed to add event handler", "name", cluster.Name)
+		return err
+	}
+	if err = nodeInformer.SetWatchErrorHandler(commonclient.WatchErrorHandler(r.ctx, k8sClients)); err != nil {
+		klog.ErrorS(err, "failed to set error handler", "name", cluster.Name)
+		return err
+	}
+	k8sClients.StartInformer()
+	r.nodeInformerMu.Lock()
+	r.startedNodeInformers[cluster.Name] = k8sClients
+	r.nodeInformerMu.Unlock()
+
+	if waitSync {
 		if k8sClients.WaitForCacheSync(time.Minute * 10) {
 			klog.Infof("add k8s node informer successfully. cluster: %s", cluster.Name)
 		} else {
 			klog.Errorf("failed to sync cache for k8s node informer. cluster: %s", cluster.Name)
 		}
-		r.nodeInformerMu.Lock()
-		r.startedNodeInformers[cluster.Name] = k8sClients
-		r.nodeInformerMu.Unlock()
 		return nil
-	}, maxWaitTime, waitTime)
-	return err
+	}
+
+	go func() {
+		if ctx.Err() != nil {
+			return
+		}
+		if k8sClients.WaitForCacheSync(time.Minute * 10) {
+			klog.Infof("node informer cache synced after client rebuild, cluster: %s", cluster.Name)
+		} else {
+			klog.Errorf("failed to sync node informer cache after client rebuild, cluster: %s", cluster.Name)
+		}
+	}()
+	return nil
 }
 
 // nodeEventHandler creates event handlers for Kubernetes node events (add, update, delete).

--- a/SaFE/resource-manager/pkg/resource/node_k8s_controller.go
+++ b/SaFE/resource-manager/pkg/resource/node_k8s_controller.go
@@ -199,11 +199,6 @@ func (r *NodeK8sReconciler) startNodeInformerOnce(cluster *v1.Cluster) error {
 
 // nodeEventHandler creates event handlers for Kubernetes node events (add, update, delete).
 func (r *NodeK8sReconciler) nodeEventHandler(k8sClients *commonclient.ClientFactory) cache.ResourceEventHandler {
-	check := func() {
-		if !k8sClients.IsValid() {
-			k8sClients.SetValid(true, "")
-		}
-	}
 	enqueue := func(oldNode, newNode *corev1.Node, action NodeAction) {
 		node := newNode
 		if action == NodeDelete || action == NodeUnmanaged {
@@ -224,7 +219,6 @@ func (r *NodeK8sReconciler) nodeEventHandler(k8sClients *commonclient.ClientFact
 	}
 	return cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			check()
 			node, ok := obj.(*corev1.Node)
 			if !ok || !node.GetDeletionTimestamp().IsZero() || v1.GetClusterId(node) != k8sClients.Name() {
 				return
@@ -234,7 +228,6 @@ func (r *NodeK8sReconciler) nodeEventHandler(k8sClients *commonclient.ClientFact
 			enqueue(nil, node, NodeAdd)
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
-			check()
 			oldNode, ok1 := oldObj.(*corev1.Node)
 			newNode, ok2 := newObj.(*corev1.Node)
 			if !ok1 || !ok2 || !newNode.GetDeletionTimestamp().IsZero() {
@@ -258,7 +251,6 @@ func (r *NodeK8sReconciler) nodeEventHandler(k8sClients *commonclient.ClientFact
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
-			check()
 			node, ok := obj.(*corev1.Node)
 			if !ok || v1.GetClusterId(node) != k8sClients.Name() {
 				return

--- a/SaFE/resource-manager/pkg/resource/node_k8s_controller.go
+++ b/SaFE/resource-manager/pkg/resource/node_k8s_controller.go
@@ -9,7 +9,10 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sync"
 	"time"
+
+	"golang.org/x/sync/singleflight"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -66,9 +69,12 @@ type nodeQueueMessage struct {
 type NodeK8sReconciler struct {
 	ctx context.Context
 	*ClusterBaseReconciler
-	clientManager *commonutils.ObjectManager
-	queue         NodeQueue
+	clientManager        *commonutils.ObjectManager
+	queue                NodeQueue
 	*commonctrl.Controller[*nodeQueueMessage]
+	nodeInformerMu       sync.Mutex
+	startedNodeInformers map[string]*commonclient.ClientFactory
+	nodeInformerGroup    singleflight.Group
 }
 
 // SetupNodeK8sController initializes and registers the NodeK8sReconciler with the controller manager.
@@ -81,6 +87,7 @@ func SetupNodeK8sController(ctx context.Context, mgr manager.Manager) error {
 		ctx:                   ctx,
 		ClusterBaseReconciler: baseReconciler,
 		clientManager:         commonutils.NewObjectManagerSingleton(),
+		startedNodeInformers:  make(map[string]*commonclient.ClientFactory),
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[*nodeQueueMessage](),
 			workqueue.TypedRateLimitingQueueConfig[*nodeQueueMessage]{Name: "node"}),
@@ -92,6 +99,9 @@ func SetupNodeK8sController(ctx context.Context, mgr manager.Manager) error {
 	if err = r.start(ctx); err != nil {
 		return err
 	}
+	RegisterNodeInformerRestarter(func(ctx context.Context, cluster *v1.Cluster) error {
+		return r.startNodeInformer(cluster)
+	})
 	err = ctrlruntime.NewControllerManagedBy(mgr).
 		For(&v1.Cluster{}, builder.WithPredicates(r.relevantChangePredicate())).
 		Complete(r)
@@ -137,6 +147,16 @@ func (r *NodeK8sReconciler) relevantChangePredicate() predicate.Predicate {
 
 // startNodeInformer initializes and starts a node informer for the given cluster with retry logic.
 func (r *NodeK8sReconciler) startNodeInformer(cluster *v1.Cluster) error {
+	if cluster == nil {
+		return nil
+	}
+	_, err, _ := r.nodeInformerGroup.Do(cluster.Name, func() (interface{}, error) {
+		return nil, r.startNodeInformerOnce(cluster)
+	})
+	return err
+}
+
+func (r *NodeK8sReconciler) startNodeInformerOnce(cluster *v1.Cluster) error {
 	const maxRetry = 100
 	waitTime := time.Millisecond * 200
 	maxWaitTime := waitTime * maxRetry
@@ -147,12 +167,19 @@ func (r *NodeK8sReconciler) startNodeInformer(cluster *v1.Cluster) error {
 			klog.ErrorS(err, "failed to get k8s client for data plane", "name", cluster.Name)
 			return err
 		}
+		r.nodeInformerMu.Lock()
+		if prev, ok := r.startedNodeInformers[cluster.Name]; ok && prev == k8sClients {
+			r.nodeInformerMu.Unlock()
+			return nil
+		}
+		r.nodeInformerMu.Unlock()
+
 		nodeInformer := k8sClients.SharedInformerFactory().Core().V1().Nodes().Informer()
 		if _, err = nodeInformer.AddEventHandler(r.nodeEventHandler(k8sClients)); err != nil {
 			klog.ErrorS(err, "failed to add event handler", "name", cluster.Name)
 			return err
 		}
-		if err = nodeInformer.SetWatchErrorHandler(watchErrorHandler(r.ctx, k8sClients)); err != nil {
+		if err = nodeInformer.SetWatchErrorHandler(commonclient.WatchErrorHandler(r.ctx, k8sClients)); err != nil {
 			klog.ErrorS(err, "failed to set error handler", "name", cluster.Name)
 			return err
 		}
@@ -162,6 +189,9 @@ func (r *NodeK8sReconciler) startNodeInformer(cluster *v1.Cluster) error {
 		} else {
 			klog.Errorf("failed to sync cache for k8s node informer. cluster: %s", cluster.Name)
 		}
+		r.nodeInformerMu.Lock()
+		r.startedNodeInformers[cluster.Name] = k8sClients
+		r.nodeInformerMu.Unlock()
 		return nil
 	}, maxWaitTime, waitTime)
 	return err
@@ -237,15 +267,6 @@ func (r *NodeK8sReconciler) nodeEventHandler(k8sClients *commonclient.ClientFact
 				k8sClients.Name(), node.Name, v1.GetWorkspaceId(node))
 			enqueue(node, nil, NodeDelete)
 		},
-	}
-}
-
-// watchErrorHandler handles errors from the Kubernetes watch connection and marks clients as invalid.
-func watchErrorHandler(ctx context.Context, k8sClients *commonclient.ClientFactory) cache.WatchErrorHandler {
-	return func(reflector *cache.Reflector, err error) {
-		cache.DefaultWatchErrorHandler(ctx, reflector, err)
-		klog.Warningf("set clients: %s invalid", k8sClients.Name())
-		k8sClients.SetValid(false, err.Error())
 	}
 }
 

--- a/SaFE/resource-manager/pkg/resource/node_k8s_controller_test.go
+++ b/SaFE/resource-manager/pkg/resource/node_k8s_controller_test.go
@@ -206,7 +206,7 @@ func TestWatchErrorHandlerFull(t *testing.T) {
 	cs := k8sfake.NewSimpleClientset()
 	factory := commonclient.NewClientFactoryWithOnlyClient(context.Background(), "c1", cs)
 	factory.SetValid(true, "")
-	h := watchErrorHandler(context.Background(), factory)
+	h := commonclient.WatchErrorHandler(context.Background(), factory)
 	h(&cache.Reflector{}, errors.New("boom"))
 	testifyassert.False(t, factory.IsValid())
 }

--- a/SaFE/resource-manager/pkg/resource/node_k8s_controller_test.go
+++ b/SaFE/resource-manager/pkg/resource/node_k8s_controller_test.go
@@ -42,7 +42,62 @@ func newNodeK8sReconciler(t *testing.T, objs ...client.Object) *NodeK8sReconcile
 		ctx:                   context.Background(),
 		ClusterBaseReconciler: &ClusterBaseReconciler{Client: cl},
 		clientManager:         commonutils.NewObjectManager(),
+		startedNodeInformers:  make(map[string]*commonclient.ClientFactory),
+		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[*nodeQueueMessage](),
+			workqueue.TypedRateLimitingQueueConfig[*nodeQueueMessage]{Name: "node-test"}),
 	}
+}
+
+// newInformerReconciler returns a reconciler whose cluster "c1" has a factory with a live
+// shared informer factory backed by a fake clientset.
+func newInformerReconciler(t *testing.T) (*NodeK8sReconciler, *commonclient.ClientFactory) {
+	t.Helper()
+	r := newNodeK8sReconciler(t)
+	factory := commonclient.NewClientFactoryForTestWithInformer("c1", k8sfake.NewSimpleClientset())
+	t.Cleanup(func() { _ = factory.Release() })
+	assert.NoError(t, r.clientManager.Add("c1", factory))
+	return r, factory
+}
+
+func TestAttachNodeInformer(t *testing.T) {
+	r, factory := newInformerReconciler(t)
+	cluster := &v1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c1"}}
+
+	testifyassert.NoError(t, r.attachNodeInformer(context.Background(), cluster, true))
+	testifyassert.Same(t, factory, r.startedNodeInformers["c1"])
+
+	// Re-attaching the same factory is skipped so node events are not handled twice.
+	testifyassert.NoError(t, r.attachNodeInformer(context.Background(), cluster, true))
+	testifyassert.Same(t, factory, r.startedNodeInformers["c1"])
+}
+
+func TestAttachNodeInformerWithoutFactory(t *testing.T) {
+	r := newNodeK8sReconciler(t)
+	err := r.attachNodeInformer(context.Background(), &v1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "missing"},
+	}, true)
+	testifyassert.Error(t, err)
+}
+
+func TestStartNodeInformer(t *testing.T) {
+	r, factory := newInformerReconciler(t)
+	testifyassert.NoError(t, r.startNodeInformer(nil))
+	testifyassert.NoError(t, r.startNodeInformer(&v1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c1"}}))
+	testifyassert.Same(t, factory, r.startedNodeInformers["c1"])
+}
+
+func TestRestartNodeInformerAfterClientRebuild(t *testing.T) {
+	r, factory := newInformerReconciler(t)
+	ctx := context.Background()
+	testifyassert.NoError(t, r.restartNodeInformerAfterClientRebuild(ctx, nil))
+	testifyassert.NoError(t, r.restartNodeInformerAfterClientRebuild(ctx,
+		&v1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c1"}}))
+	testifyassert.Same(t, factory, r.startedNodeInformers["c1"])
+
+	// Clearing the registration lets a rebuilt factory re-attach handlers.
+	r.clearNodeInformerRegistration("c1")
+	testifyassert.NotContains(t, r.startedNodeInformers, "c1")
 }
 
 func TestNodeK8sReconcileNoop(t *testing.T) {


### PR DESCRIPTION
## Summary

When a data-plane cluster runs multiple control plane nodes, a single CP apiserver going down or coming back should not leave SaFE components (resource-manager, job-manager, apiserver) stuck on a dead connection.

This PR implements HA in **Service mode** (default):

- **resource-manager** periodically probes CP nodes and maintains an admin-plane **Endpoints health pool** (same name as the Cluster)
- Data-plane clients connect to the **Service ClusterIP**; kube-proxy routes traffic using the Endpoints pool
- When Endpoints change or a Watch hits a non-recoverable error, **factory fingerprint / invalid state** triggers client and informer rebuild

## Architecture

```
RM probe CP → Update admin Endpoints
     ↓
kube-proxy routes Service ClusterIP → healthy backends
     ↓
RM / JM / apiserver: ClientFactory (ClusterIP) + fingerprint refresh + WatchErrorHandler
```

**Service mode**: factory uses ClusterIP; HA relies on the Endpoints pool and periodic refresh (not per-CP IP polling).

**Direct mode** (no admin Service): uses status endpoints plus `ServerVersion` probe failover.

## Changes

### common/pkg/cluster
- `GetEndpoint` / `UsesServiceEndpoint` / `GetControlPlaneBackendIPs`
- `NewClientFactoryForCluster`: unified Service / direct factory creation
- `ClientFactoryNeedsRefresh`: refresh on ClusterIP change, Endpoints fingerprint, direct-mode probe, etc.

### common/pkg/k8sclient
- `ProbeRESTConfig` / `NewClientSetWithProbe`: apiserver reachability and direct failover
- `WatchErrorHandler`: ignore expired RV; mark factory invalid on connection/TLS errors
- `ClientFactory`: `endpoint`, `backendFingerprint`, `IsValid` lifecycle

### resource-manager
- `filterHealthyControlPlaneAddresses` + `guaranteeEndpoints` create-or-update
- Preserve existing Endpoints when all probes fail (avoid re-adding dead IPs)
- `syncControlPlaneServiceEndpoints`: single Endpoints sync per reconcile
- `markClusterClientFactoryStale` + 15s periodic reconcile
- Node informer: synchronous re-attach after factory rebuild; clear stale registration

### job-manager
- `needsClientFactoryRefresh` / `recreateClientFactory`
- 15s maintainer reads Endpoints fingerprint and rebuilds workload informers
- Resource informers register `WatchErrorHandler`

### apiserver
- 15s periodic factory refresh for Ready clusters
- `GetK8sClientFactory` rejects invalid factories

### health reporter
- Cluster probe via `GetEndpoint` + probe (Service / direct)

## Test plan

- [x] `go test ./common/pkg/cluster/`
- [x] `go test ./common/pkg/k8sclient/`
- [x] `go test ./job-manager/pkg/syncer/`
- [x] `go test ./resource-manager/pkg/resource/` (HA-related cases)
- [x] `go test ./apiserver/pkg/controllers/ ./apiserver/pkg/utils/`
- [ ] Multi-CP env: stop one CP; confirm Endpoints shrink and workload sync recovers within ~15–30s
- [ ] CP recovery: Endpoints expand and factory/informers rebuild

## Notes

- RM and JM/apiserver are separate processes: RM writes Endpoints; JM/apiserver detect changes via periodic K8s API reads (~15s)
- Watch disconnect can trigger invalid → refresh faster than fingerprint-only detection
- Direct mode is fallback when no admin Service exists; production Ready clusters typically use Service mode