### PR TITLE
fix(llm-gateway): use complete usage aggregation

### DIFF
--- a/SaFE/apiserver/pkg/handlers/llm-gateway/handler.go
+++ b/SaFE/apiserver/pkg/handlers/llm-gateway/handler.go
@@ -552,7 +552,7 @@ func (h *Handler) GetSummary(c *gin.Context) {
 	})
 }
 
-// GetUsage handles GET /api/v1/llm-gateway/usage?start_date=...&end_date=...&timezone=...
+// GetUsage handles GET /api/v1/llm-gateway/usage?start_date=...&end_date=...&timezone=...&timezone_offset=...
 func (h *Handler) GetUsage(c *gin.Context) {
 	email := h.getUserEmail(c)
 	if email == "" {
@@ -567,11 +567,12 @@ func (h *Handler) GetUsage(c *gin.Context) {
 		return
 	}
 
-	loc, err := resolveTimezone(c.Query("timezone"))
+	_, err := resolveTimezone(c.Query("timezone"))
 	if err != nil {
 		apiutils.AbortWithApiError(c, commonerrors.NewBadRequest(err.Error()))
 		return
 	}
+	timezoneOffset := c.DefaultQuery("timezone_offset", "0")
 
 	existing, err := h.dbClient.GetLLMBindingByEmail(c.Request.Context(), email)
 	if err != nil {
@@ -584,8 +585,13 @@ func (h *Handler) GetUsage(c *gin.Context) {
 		return
 	}
 
-	adjStart, adjEnd := expandDateRangeForTimezone(startDate, endDate, loc)
-	activity, err := h.litellmClient.GetUserDailyActivity(c.Request.Context(), email, adjStart, adjEnd)
+	activity, err := h.litellmClient.GetUserDailyActivity(
+		c.Request.Context(),
+		email,
+		startDate,
+		endDate,
+		timezoneOffset,
+	)
 	if err != nil {
 		klog.ErrorS(err, "GetUsage: LiteLLM query failed", "email", email)
 		c.JSON(http.StatusBadGateway, gin.H{"errorMessage": "usage data temporarily unavailable, please try again later"})

--- a/SaFE/apiserver/pkg/handlers/llm-gateway/handler_test.go
+++ b/SaFE/apiserver/pkg/handlers/llm-gateway/handler_test.go
@@ -1095,8 +1095,11 @@ func TestGetUsage_Success(t *testing.T) {
 	mockDB := mock_client.NewMockInterface(ctrl)
 
 	litellm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Contains(t, r.URL.Path, "/user/daily/activity")
+		assert.Equal(t, "/user/daily/activity/aggregated", r.URL.Path)
 		assert.Equal(t, "test@amd.com", r.URL.Query().Get("user_id"))
+		assert.Equal(t, "2026-03-17", r.URL.Query().Get("start_date"))
+		assert.Equal(t, "2026-03-17", r.URL.Query().Get("end_date"))
+		assert.Equal(t, "-480", r.URL.Query().Get("timezone"))
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(DailyActivityResponse{
 			Results: []DailyResult{
@@ -1135,7 +1138,7 @@ func TestGetUsage_Success(t *testing.T) {
 	})
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/usage?start_date=2026-03-17&end_date=2026-03-17", nil)
+	req, _ := http.NewRequest("GET", "/usage?start_date=2026-03-17&end_date=2026-03-17&timezone=Asia%2FShanghai&timezone_offset=-480", nil)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)

--- a/SaFE/apiserver/pkg/handlers/llm-gateway/litellm_client.go
+++ b/SaFE/apiserver/pkg/handlers/llm-gateway/litellm_client.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -459,10 +460,15 @@ func (c *LiteLLMClient) GetAllSpendLogs(ctx context.Context, userID, startDate, 
 	return allLogs, nil
 }
 
-// GetUserDailyActivity queries LiteLLM for a user's daily usage breakdown.
-func (c *LiteLLMClient) GetUserDailyActivity(ctx context.Context, userID, startDate, endDate string) (*DailyActivityResponse, error) {
-	reqURL := fmt.Sprintf("%s/user/daily/activity?user_id=%s&start_date=%s&end_date=%s",
-		c.endpoint, userID, startDate, endDate)
+// GetUserDailyActivity queries LiteLLM for a user's complete daily usage breakdown.
+func (c *LiteLLMClient) GetUserDailyActivity(ctx context.Context, userID, startDate, endDate, timezoneOffset string) (*DailyActivityResponse, error) {
+	query := url.Values{
+		"user_id":    []string{userID},
+		"start_date": []string{startDate},
+		"end_date":   []string{endDate},
+		"timezone":   []string{timezoneOffset},
+	}
+	reqURL := c.endpoint + "/user/daily/activity/aggregated?" + query.Encode()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {

--- a/SaFE/apiserver/pkg/handlers/llm-gateway/litellm_client_test.go
+++ b/SaFE/apiserver/pkg/handlers/llm-gateway/litellm_client_test.go
@@ -235,10 +235,11 @@ func TestDeleteKey_ServerError(t *testing.T) {
 
 func TestGetUserDailyActivity_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/user/daily/activity", r.URL.Path)
+		assert.Equal(t, "/user/daily/activity/aggregated", r.URL.Path)
 		assert.Equal(t, "test@amd.com", r.URL.Query().Get("user_id"))
 		assert.Equal(t, "2026-03-10", r.URL.Query().Get("start_date"))
 		assert.Equal(t, "2026-03-17", r.URL.Query().Get("end_date"))
+		assert.Equal(t, "-480", r.URL.Query().Get("timezone"))
 
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(DailyActivityResponse{
@@ -281,7 +282,7 @@ func TestGetUserDailyActivity_Success(t *testing.T) {
 	defer server.Close()
 
 	client := NewLiteLLMClient(server.URL, testAdminKey, "team-123")
-	resp, err := client.GetUserDailyActivity(context.Background(), "test@amd.com", "2026-03-10", "2026-03-17")
+	resp, err := client.GetUserDailyActivity(context.Background(), "test@amd.com", "2026-03-10", "2026-03-17", "-480")
 
 	assert.NoError(t, err)
 	assert.Len(t, resp.Results, 1)
@@ -300,7 +301,7 @@ func TestGetUserDailyActivity_Error(t *testing.T) {
 	defer server.Close()
 
 	client := NewLiteLLMClient(server.URL, testAdminKey, "team-123")
-	resp, err := client.GetUserDailyActivity(context.Background(), "test@amd.com", "2026-03-10", "2026-03-17")
+	resp, err := client.GetUserDailyActivity(context.Background(), "test@amd.com", "2026-03-10", "2026-03-17", "0")
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 }

--- a/Web/apps/safe/src/pages/LLMGateway/index.vue
+++ b/Web/apps/safe/src/pages/LLMGateway/index.vue
@@ -74,7 +74,7 @@
         <!-- Right: Summary Usage + Budget -->
         <div class="bound-col-right">
           <div class="budget-header">
-            <span class="budget-title">Summary Usage</span>
+            <span class="budget-title">All-time User Spend</span>
             <span class="budget-amount">${{ summary?.total_spend?.toFixed(5) ?? '0.00000' }}</span>
           </div>
 
@@ -865,6 +865,8 @@ const fetchUsage = async () => {
     usage.value = await getLLMGatewayUsage({
       start_date: dateRange.value[0],
       end_date: dateRange.value[1],
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      timezone_offset: new Date().getTimezoneOffset(),
     })
     await nextTick()
     renderChart()

--- a/Web/apps/safe/src/services/llm-gateway/type.ts
+++ b/Web/apps/safe/src/services/llm-gateway/type.ts
@@ -53,6 +53,8 @@ export interface LLMGatewayUsage {
 export interface LLMGatewayUsageParams {
   start_date: string
   end_date: string
+  timezone?: string
+  timezone_offset?: number
 }
 
 export interface LLMGatewaySummary {


### PR DESCRIPTION
## Summary
- use LiteLLM's aggregated daily activity endpoint so SaFE includes the complete date range instead of only the first page
- forward the browser timezone and UTC offset to keep daily usage boundaries aligned with the official LiteLLM UI
- clarify that the top summary is all-time user spend and add regression coverage for the upstream request contract

## Test plan
- [x] `go test ./pkg/handlers/llm-gateway -count=1`
- [x] `pnpm --filter ./apps/safe exec vue-tsc --noEmit`
- [x] `pnpm --filter ./apps/safe test`
- [x] `pnpm --filter ./apps/safe build-only`