### PR TITLE
fix(resource-manager): stop managing the nodelocaldns Corefile

### DIFF
--- a/SaFE/node-agent/charts/node-agent/templates/config.yaml
+++ b/SaFE/node-agent/charts/node-agent/templates/config.yaml
@@ -55,12 +55,10 @@ data:
   net_oci_dcqcn_212: '{"script":"net_oci_dcqcn_212.sh","id":"212","cronjob":"@every 300s","timeoutSecond":250,"consecutiveCount":2,"chip":"amd","toggle":"on","arguments":["{{ .Values.node_agent.sub_domain }}"]}'
   net_resolved_kubespray_conf_213: '{"script":"net_resolved_kubespray_conf_213.sh","id":"213","cronjob":"@every 300s","timeoutSecond":250,"toggle":"on","arguments":["{{ .Values.node_agent.sub_domain }}"]}'
   # 214 mutates /etc/resolv.conf on the host every 5 min (appends a DNS
-  # search domain, chattr +i's the file, restarts systemd-resolved). DNS
-  # search domain propagation is now handled in-cluster by
-  # ClusterReconciler.guaranteeNodeLocalDNS which edits the nodelocaldns
-  # ConfigMap instead of poking /etc/resolv.conf on every node. Keep the
-  # script around for one release in case some site relies on it, then
-  # remove entirely.
+  # search domain, chattr +i's the file, restarts systemd-resolved). Name
+  # resolution is configured in CoreDNS instead, which nodelocaldns forwards
+  # to, so nothing has to be written on each node. Keep the script around for
+  # one release in case some site relies on it, then remove entirely.
   net_search_domain_214: '{"script":"net_search_domain_214.sh","id":"214","cronjob":"@every 300s","timeoutSecond":250,"toggle":"off","arguments":["{{ .Values.monitor.resolv_search_domain }}"]}'
   # 215 ensures same-node Pod -> host-IP routing: re-applies the high-priority
   # "ip rule to <pod_cidr> lookup main" when missing (e.g. after reboot). The

--- a/SaFE/resource-manager/pkg/resource/big_controllers_extra_test.go
+++ b/SaFE/resource-manager/pkg/resource/big_controllers_extra_test.go
@@ -7,7 +7,6 @@ package resource
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -94,36 +93,6 @@ func TestIsClusterSourceEndpoints(t *testing.T) {
 	assert.False(t, r.isClusterSourceEndpoints(other))
 }
 
-func TestBuildDNSServerBlock(t *testing.T) {
-	block := buildDNSServerBlock("foo.local", []string{"10.0.0.1", "10.0.0.3"})
-	assert.Contains(t, block, "foo.local")
-	// Every healthy control plane gets its own A record so resolvers can fall over.
-	assert.Contains(t, block, "IN A 10.0.0.1")
-	assert.Contains(t, block, "IN A 10.0.0.3")
-}
-
-func TestStripDNSServerBlockRoundTrip(t *testing.T) {
-	existing := "cluster.local:53 {\n    kubernetes\n}"
-	corefile := existing + "\n" + buildDNSServerBlock("foo.local", []string{"10.0.0.1"})
-
-	// Removing our block restores the untouched Corefile.
-	assert.Equal(t, existing, stripDNSServerBlock(corefile, "foo.local"))
-	// Unrelated names are left alone.
-	assert.Equal(t, corefile, stripDNSServerBlock(corefile, "bar.local"))
-	// Rebuilding with a new address set replaces rather than appends.
-	rebuilt := stripDNSServerBlock(corefile, "foo.local") + "\n" +
-		buildDNSServerBlock("foo.local", []string{"10.0.0.3"})
-	assert.Equal(t, 1, strings.Count(rebuilt, dnsServerBlockPrefix))
-	assert.Contains(t, rebuilt, "IN A 10.0.0.3")
-	assert.NotContains(t, rebuilt, "IN A 10.0.0.1")
-}
-
-func TestStripDNSServerBlockKeepsUnbalancedCorefile(t *testing.T) {
-	// A block we cannot delimit is preserved instead of being mangled.
-	broken := ".:53 {\n    template IN A foo.local {\n        answer \"x\""
-	assert.Equal(t, broken, stripDNSServerBlock(broken, "foo.local"))
-}
-
 func TestGenerateForwardName(t *testing.T) {
 	assert.Equal(t, "c1-forward", generateForwardName("c1"))
 }
@@ -131,12 +100,6 @@ func TestGenerateForwardName(t *testing.T) {
 func TestGenAllPriorityClass(t *testing.T) {
 	classes := genAllPriorityClass("c1")
 	assert.Len(t, classes, 3)
-}
-
-func TestGetControlPlaneIPsNoCluster(t *testing.T) {
-	r := newClusterReconciler(t)
-	_, err := r.getControlPlaneIPs(context.Background())
-	assert.Error(t, err)
 }
 
 // ---- cluster_contoller_plane pure functions ----

--- a/SaFE/resource-manager/pkg/resource/cluster_controller.go
+++ b/SaFE/resource-manager/pkg/resource/cluster_controller.go
@@ -8,7 +8,6 @@ package resource
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"strings"
 	"time"
 
@@ -345,11 +344,6 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrlruntime.Reque
 	if err = r.guaranteeForwardIngress(ctx, cluster); err != nil {
 		klog.ErrorS(err, "failed to guarantee ingress", "cluster", cluster.Name)
 		rmmetrics.ClusterReconcileErrorsTotal.WithLabelValues("forward_ingress").Inc()
-		return ctrlruntime.Result{}, err
-	}
-	if err = r.guaranteeNodeLocalDNS(ctx, cluster); err != nil {
-		klog.ErrorS(err, "failed to guarantee node local dns", "cluster", cluster.Name)
-		rmmetrics.ClusterReconcileErrorsTotal.WithLabelValues("node_local_dns").Inc()
 		return ctrlruntime.Result{}, err
 	}
 	if shouldPeriodicSyncControlPlaneEndpoints(cluster) {
@@ -1054,161 +1048,6 @@ func (r *ClusterReconciler) deleteDataPlaneClusterRole(ctx context.Context, clus
 	}
 	klog.Infof("delete ClusterRole %s from cluster %s", targetName, cluster.Name)
 	return nil
-}
-
-// guaranteeNodeLocalDNS ensures the nodelocaldns ConfigMap in each data-plane cluster
-// contains a Corefile server block that resolves the control-plane subdomain to its IP.
-func (r *ClusterReconciler) guaranteeNodeLocalDNS(ctx context.Context, cluster *v1.Cluster) error {
-	dnsName := commonconfig.GetSystemHost()
-	if dnsName == "" {
-		return nil
-	}
-	if !cluster.IsReady() {
-		return nil
-	}
-
-	controlPlaneIPs, err := r.getControlPlaneIPs(ctx)
-	if err != nil {
-		return err
-	}
-
-	k8sClients, err := utils.GetK8sClientFactory(r.clientManager, cluster.Name)
-	if err != nil {
-		return err
-	}
-	clientSet := k8sClients.ClientSet()
-
-	cm, err := clientSet.CoreV1().ConfigMaps("kube-system").Get(ctx, "nodelocaldns", metav1.GetOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			klog.V(4).Infof("nodelocaldns ConfigMap not found in cluster %s, skipping", cluster.Name)
-			return nil
-		}
-		return fmt.Errorf("failed to get nodelocaldns ConfigMap in cluster %s: %w", cluster.Name, err)
-	}
-
-	corefile, ok := cm.Data["Corefile"]
-	if !ok {
-		return fmt.Errorf("Corefile key not found in nodelocaldns ConfigMap in cluster %s", cluster.Name)
-	}
-
-	// Replace rather than append: the recorded addresses must follow the healthy control planes,
-	// otherwise data-plane nodes keep resolving the system host to an apiserver that is gone.
-	base := strings.TrimRight(stripDNSServerBlock(corefile, dnsName), " \t\n")
-	desired := base + "\n" + buildDNSServerBlock(dnsName, controlPlaneIPs)
-	if desired == corefile {
-		klog.V(4).Infof("nodelocaldns Corefile in cluster %s already targets %v, skipping",
-			cluster.Name, controlPlaneIPs)
-		return nil
-	}
-
-	cm.Data["Corefile"] = desired
-	if _, err = clientSet.CoreV1().ConfigMaps("kube-system").Update(ctx, cm, metav1.UpdateOptions{}); err != nil {
-		return fmt.Errorf("failed to update nodelocaldns ConfigMap in cluster %s: %w", cluster.Name, err)
-	}
-	klog.Infof("updated nodelocaldns Corefile in cluster %s with %s -> %v", cluster.Name, dnsName, controlPlaneIPs)
-	return nil
-}
-
-// getControlPlaneIPs returns the admin-plane addresses that data-plane nodes should resolve the
-// system host to. It prefers the probed Endpoints pool so an apiserver that went down is left out,
-// and falls back to every address recorded on the cluster status when that pool is unavailable.
-func (r *ClusterReconciler) getControlPlaneIPs(ctx context.Context) ([]string, error) {
-	clusterList := &v1.ClusterList{}
-	if err := r.Client.List(ctx, clusterList, client.MatchingLabels{
-		v1.ClusterControlPlaneLabel: "",
-	}); err != nil {
-		return nil, fmt.Errorf("failed to list clusters with control-plane label: %w", err)
-	}
-	if len(clusterList.Items) == 0 {
-		return nil, fmt.Errorf("no cluster with control-plane label found")
-	}
-
-	cp := &clusterList.Items[0]
-	if ips, err := commoncluster.GetControlPlaneBackendIPs(ctx, r.Client, cp); err == nil && len(ips) > 0 {
-		return ips, nil
-	}
-
-	hosts := make([]string, 0, len(cp.Status.ControlPlaneStatus.Endpoints))
-	for _, endpoint := range cp.Status.ControlPlaneStatus.Endpoints {
-		u, err := url.Parse(endpoint)
-		if err != nil {
-			klog.V(4).Infof("skip unparsable control-plane endpoint %q: %v", endpoint, err)
-			continue
-		}
-		if host := u.Hostname(); host != "" {
-			hosts = append(hosts, host)
-		}
-	}
-	if len(hosts) == 0 {
-		return nil, fmt.Errorf("control-plane cluster %s has no usable endpoint", cp.Name)
-	}
-	return hosts, nil
-}
-
-// dnsServerBlockPrefix opens the CoreDNS server block that buildDNSServerBlock renders.
-const dnsServerBlockPrefix = ".:53 {"
-
-// buildDNSServerBlock generates a CoreDNS server block resolving dnsName to every given address.
-// One A record per control plane lets a resolver fall over when the first address stops answering.
-func buildDNSServerBlock(dnsName string, ips []string) string {
-	answers := make([]string, 0, len(ips))
-	for _, ip := range ips {
-		answers = append(answers, fmt.Sprintf(`        answer "{{ .Name }} 60 IN A %s"`, ip))
-	}
-	return fmt.Sprintf(`%s
-    template IN A %s {
-%s
-        fallthrough
-    }
-    errors
-    cache 30
-    reload
-    loop
-    bind 169.254.25.10
-    forward . /etc/resolv.conf
-    prometheus :9253
-}`, dnsServerBlockPrefix, dnsName, strings.Join(answers, "\n"))
-}
-
-// stripDNSServerBlock removes the server blocks templating dnsName so they can be replaced when the
-// control-plane address set changes. A block whose bounds cannot be determined is left untouched,
-// keeping a Corefile we do not fully understand intact.
-func stripDNSServerBlock(corefile, dnsName string) string {
-	marker := "template IN A " + dnsName
-	for {
-		pos := strings.Index(corefile, marker)
-		if pos < 0 {
-			return corefile
-		}
-		start := strings.LastIndex(corefile[:pos], dnsServerBlockPrefix)
-		if start < 0 {
-			return corefile
-		}
-		end := dnsServerBlockEnd(corefile, start)
-		if end < 0 {
-			return corefile
-		}
-		corefile = strings.TrimRight(corefile[:start], " \t\n") + corefile[end:]
-	}
-}
-
-// dnsServerBlockEnd returns the index just past the brace closing the block opened at start,
-// or -1 when the braces are unbalanced.
-func dnsServerBlockEnd(corefile string, start int) int {
-	depth := 0
-	for i := start; i < len(corefile); i++ {
-		switch corefile[i] {
-		case '{':
-			depth++
-		case '}':
-			depth--
-			if depth == 0 {
-				return i + 1
-			}
-		}
-	}
-	return -1
 }
 
 // generateForwardName generates the name for forward resources by appending "-forward" to the cluster name.

--- a/SaFE/resource-manager/pkg/resource/cluster_controller_test.go
+++ b/SaFE/resource-manager/pkg/resource/cluster_controller_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
@@ -420,38 +419,6 @@ func TestGuaranteeDataPlaneClusterRole(t *testing.T) {
 	testifyassert.NoError(t, err)
 }
 
-func TestGuaranteeNodeLocalDNSNoHost(t *testing.T) {
-	r := newClusterReconcilerWithFactory(t, "c1", k8sfake.NewSimpleClientset())
-	// GetSystemHost default empty -> no-op.
-	testifyassert.NoError(t, r.guaranteeNodeLocalDNS(context.Background(), testCluster("c1")))
-}
-
-func TestGuaranteeNodeLocalDNSUpdatesCorefile(t *testing.T) {
-	patches := gomonkey.ApplyFunc(commonconfig.GetSystemHost, func() string { return "safe.local" })
-	defer patches.Reset()
-
-	cm := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Name: "nodelocaldns", Namespace: "kube-system"},
-		Data:       map[string]string{"Corefile": ".:53 {\n}"},
-	}
-	cs := k8sfake.NewSimpleClientset(cm)
-
-	scheme, _ := genMockScheme()
-	dataCluster := readyCluster("c1")
-	cpCluster := readyCluster("ctrl")
-	cpCluster.Labels = map[string]string{v1.ClusterControlPlaneLabel: ""}
-	cpCluster.Status.ControlPlaneStatus.Endpoints = []string{"https://10.0.0.9:6443"}
-	cl := ctrlfake.NewClientBuilder().WithScheme(scheme).WithObjects(dataCluster, cpCluster).Build()
-	mgr := commonutils.NewObjectManager()
-	_ = mgr.Add("c1", commonclient.NewClientFactoryWithOnlyClient(context.Background(), "c1", cs))
-	r := &ClusterReconciler{ClusterBaseReconciler: &ClusterBaseReconciler{Client: cl}, clientManager: mgr}
-
-	err := r.guaranteeNodeLocalDNS(context.Background(), dataCluster)
-	testifyassert.NoError(t, err)
-	updated, _ := cs.CoreV1().ConfigMaps("kube-system").Get(context.Background(), "nodelocaldns", metav1.GetOptions{})
-	testifyassert.Contains(t, updated.Data["Corefile"], "safe.local")
-}
-
 func TestFetchConfigFromControlPlaneFallsBackToNextNode(t *testing.T) {
 	var attempted []string
 	patches := gomonkey.ApplyPrivateMethod(reflect.TypeOf(&ClusterReconciler{}), "fetchConfigFromSSH",
@@ -490,70 +457,6 @@ func TestFetchConfigFromControlPlaneAllNodesFail(t *testing.T) {
 	_, err := (&ClusterReconciler{}).fetchConfigFromControlPlane(context.Background(),
 		[]*v1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "cp1"}}})
 	testifyassert.Error(t, err)
-}
-
-func readNodeLocalDNSCorefile(t *testing.T, cs *k8sfake.Clientset) string {
-	t.Helper()
-	cm, err := cs.CoreV1().ConfigMaps("kube-system").Get(
-		context.Background(), "nodelocaldns", metav1.GetOptions{})
-	testifyassert.NoError(t, err)
-	return cm.Data["Corefile"]
-}
-
-func TestGuaranteeNodeLocalDNSFollowsHealthyControlPlanes(t *testing.T) {
-	patches := gomonkey.ApplyFunc(commonconfig.GetSystemHost, func() string { return "safe.local" })
-	defer patches.Reset()
-
-	cm := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Name: "nodelocaldns", Namespace: "kube-system"},
-		Data:       map[string]string{"Corefile": "cluster.local:53 {\n    kubernetes\n}"},
-	}
-	cs := k8sfake.NewSimpleClientset(cm)
-
-	scheme, _ := genMockScheme()
-	dataCluster := readyCluster("c1")
-	cpCluster := readyCluster("ctrl")
-	cpCluster.Labels = map[string]string{v1.ClusterControlPlaneLabel: ""}
-	// The status lists every control plane, while probing currently reaches only two of them.
-	cpCluster.Status.ControlPlaneStatus.Endpoints = []string{
-		"https://10.0.0.1:6443", "https://10.0.0.2:6443", "https://10.0.0.3:6443",
-	}
-	endpoints := &corev1.Endpoints{
-		ObjectMeta: metav1.ObjectMeta{Name: "ctrl", Namespace: common.PrimusSafeNamespace},
-		Subsets: []corev1.EndpointSubset{{
-			Addresses: []corev1.EndpointAddress{{IP: "10.0.0.1"}, {IP: "10.0.0.3"}},
-		}},
-	}
-	cl := ctrlfake.NewClientBuilder().WithScheme(scheme).
-		WithObjects(dataCluster, cpCluster, endpoints).Build()
-	mgr := commonutils.NewObjectManager()
-	testifyassert.NoError(t, mgr.Add("c1",
-		commonclient.NewClientFactoryWithOnlyClient(context.Background(), "c1", cs)))
-	r := &ClusterReconciler{ClusterBaseReconciler: &ClusterBaseReconciler{Client: cl}, clientManager: mgr}
-	ctx := context.Background()
-
-	testifyassert.NoError(t, r.guaranteeNodeLocalDNS(ctx, dataCluster))
-	corefile := readNodeLocalDNSCorefile(t, cs)
-	testifyassert.Contains(t, corefile, "IN A 10.0.0.1")
-	testifyassert.Contains(t, corefile, "IN A 10.0.0.3")
-	// 10.0.0.2 failed probing, so data-plane resolvers must not be pointed at it.
-	testifyassert.NotContains(t, corefile, "IN A 10.0.0.2")
-
-	// Reconciling again changes nothing.
-	testifyassert.NoError(t, r.guaranteeNodeLocalDNS(ctx, dataCluster))
-	testifyassert.Equal(t, corefile, readNodeLocalDNSCorefile(t, cs))
-
-	// 10.0.0.1 goes down: the Corefile follows the pool instead of keeping a dead address.
-	endpoints.Subsets[0].Addresses = []corev1.EndpointAddress{{IP: "10.0.0.3"}}
-	testifyassert.NoError(t, cl.Update(ctx, endpoints))
-	testifyassert.NoError(t, r.guaranteeNodeLocalDNS(ctx, dataCluster))
-
-	corefile = readNodeLocalDNSCorefile(t, cs)
-	testifyassert.NotContains(t, corefile, "IN A 10.0.0.1")
-	testifyassert.Contains(t, corefile, "IN A 10.0.0.3")
-	// The block is replaced rather than appended, and unrelated blocks survive.
-	testifyassert.Equal(t, 1, strings.Count(corefile, dnsServerBlockPrefix))
-	testifyassert.Contains(t, corefile, "cluster.local:53 {")
 }
 
 func TestGuaranteeDataPlaneClusterRoleEmptyName(t *testing.T) {


### PR DESCRIPTION
## What was wrong

`guaranteeNodeLocalDNS` rewrote the `kube-system/nodelocaldns` ConfigMap on every reconcile. It replaced the whole `.:53` server block, so any host entry a site had added there was removed, and the sync runs often enough that restoring one by hand did not hold.

On the crusoe cluster that block now carries only the `template` this code writes. Comparing it with the ConfigMap's own `last-applied-configuration` shows five entries gone:

```
10.245.146.28 harbor.crusoe.primus-safe.amd.com
10.245.146.28 s3.crusoe.primus-safe.amd.com
10.214.150.4  llm-api.amd.com
10.255.36.101 global.primus-safe.amd.com
10.245.149.59 crs-m2m-cpu-spur-005.crusoe.amd.com
```

## Change

The sync is removed, along with the Corefile editing it did and the control-plane address lookup only it used. `resource-manager` no longer reads or writes that ConfigMap.

Where these records belong is a site decision rather than a reconcile loop: a converged site keeps them in CoreDNS, which nodelocaldns forwards to and caches; a site that has not converged keeps them in nodelocaldns's own `hosts` entries. The ConfigMap carries `addonmanager.kubernetes.io/mode: EnsureExists`, so once this controller stops writing, nothing else overwrites what an operator puts there.

## What this gives up

Since #710 the sync wrote one A record per healthy control plane and refreshed them from the probe pool, so `<sub_domain>.<domain>` followed apiserver failover. After this change the name resolves to whatever the site has configured and no longer tracks that pool. Control-plane failover itself is unaffected: `syncControlPlaneServiceEndpoints` still probes the backends and syncs the admin-plane Service and Endpoints, which is the Service path rather than this DNS one.

## Restoring an existing cluster

Stopping the reconcile does not restore entries it already removed. Check which case applies first — `kubectl -n kube-system get cm nodelocaldns -o yaml` — and read what the `.:53` block forwards to.

**Converged, `.:53` forwards to CoreDNS.** Add the records to the CoreDNS ConfigMap; they take effect on its hot reload, and nodelocaldns does not need rolling.

**Not converged, `.:53` forwards to `/etc/resolv.conf`.** Put the entries back in the `hosts` block of the nodelocaldns ConfigMap, then `kubectl -n kube-system rollout restart ds nodelocaldns`. The `last-applied-configuration` annotation holds what was there before.

## Scope

`nodelocaldns_ip` is still passed to kubespray at install time and still validated on the Cluster spec; only the ConfigMap editing is gone.

The `set-localdns` addon is unchanged. It routes the system domain to nodelocaldns, which either forwards it to CoreDNS or answers it from its own `hosts` entries, depending on the site.

A stale comment in the node-agent chart pointed at the removed function and now describes where these entries live.

## Tests

`go build` and `go vet` pass. The tests covering the removed sync are gone with it. `TestGuaranteeCICDClusterRoleBindingFull` and `TestGuaranteeForwardIngressFull` fail on `main` as well and are unrelated.
