### PR TITLE
fix(web): scope homepage workload query to the current workspace

### DIFF
--- a/Web/apps/safe/src/pages/Homepage/index.vue
+++ b/Web/apps/safe/src/pages/Homepage/index.vue
@@ -297,10 +297,20 @@ const quickActions = computed(() =>
   quickActionDefs.filter((a) => (store.currentScopes ?? []).includes(a.scope)),
 )
 const goToCreate = (path: string) => router.push({ path, query: { action: 'create' } })
+// The list API grants regular users the "list" verb only as the workspace
+// member, so the query must carry a workspaceId; an unscoped request is
+// rejected with 403 for anyone who is not an admin.
 const fetchMyWorkloads = async () => {
+  const workspaceId = store.currentWorkspaceId
+  if (!workspaceId || !userStore.userId) {
+    myWorkloads.value = []
+    myWlTotal.value = 0
+    return
+  }
   try {
     myWlLoading.value = true
     const res: any = await getWorkloadsList({
+      workspaceId,
       userId: userStore.userId,
       phase: ['Running', 'Pending'],
       offset: 0,
@@ -317,7 +327,6 @@ const fetchMyWorkloads = async () => {
     myWlLoading.value = false
   }
 }
-onMounted(fetchMyWorkloads)
 
 const detailData = ref<any>(null)
 const RES_KEYS = ['amd.com/gpu', 'rdma/hca', 'cpu', 'memory'] as const
@@ -657,6 +666,10 @@ watch(
   },
   { immediate: true },
 )
+
+watch([() => store.currentWorkspaceId, () => userStore.userId], fetchMyWorkloads, {
+  immediate: true,
+})
 
 watch(
   () => clusterStore.currentClusterId,


### PR DESCRIPTION
## Summary

Reported from the backend side: every user hits
`GET /api/workloads?userId=<self>&phase=Running,Pending&offset=0&limit=50&sortBy=createdAt&order=desc&src=console`
right after login, and non-admin users get a 403 plus an error toast on the homepage.

Root cause is the workspace scope, not the user filter:

- The homepage right rail (`My Workloads`) fires `fetchMyWorkloads` in `onMounted`
  with only `userId`, no `workspaceId`.
- `listWorkload` authorizes with `generateWorkloadForAuth("", "", query.WorkspaceId, query.ClusterId)`,
  so `ResourceOwner` is empty and `Workspaces` is empty. The query-string `userId`
  never reaches the authorizer, it is only a SQL filter.
- The `default` role grants `list` on `workload` to `owner` or `workspace-user`
  only, so both checks miss and the request is forbidden.
- The axios response interceptor shows an `ElMessage` for any non-401 failure,
  so the page-level `try/catch` cannot keep it silent.

Fix: send the current `workspaceId` so a regular user is authorized as a
workspace member, skip the request until the workspace and user id are known,
and refetch when either changes (previously the call only ran once on mount and
did not follow workspace switches).

Behavior notes: the rail now lists the user's running/pending workloads in the
current workspace instead of across all workspaces, and a user with no workspace
sees the empty state rather than an error toast. The backend still filters by
`userId`, so no additional data is exposed.

## Test plan

- [x] `pnpm type-check` in `Web/apps/safe`
- [x] `pnpm test` in `Web/apps/safe` (113 tests)
- [ ] Log in as a regular workspace member: homepage loads with no error toast and the rail lists own running/pending workloads
- [ ] Log in as an admin: rail still shows the teaser list plus `View all`
- [ ] Switch workspace on the homepage: the rail refetches for the new workspace
