### PR TITLE
fix(database): stop the GORM pool serving a demoted replica forever

### DIFF
--- a/.github/workflows/block-sensitive-secrets.yml
+++ b/.github/workflows/block-sensitive-secrets.yml
@@ -84,6 +84,14 @@ jobs:
             # DSN builder: "password=%s" is a format placeholder filled from the
             # DBConfig at runtime, not a literal credential value.
             [[ "$path" == SaFE/common/pkg/database/utils/db.go ]] && return 0
+            # Same DSN builders, which now live beside the config they read:
+            # SourceName and GormSourceName both carry "password=%s" as a
+            # placeholder. Listed separately from db.go because the connection
+            # strings moved here to be testable as pure functions.
+            [[ "$path" == SaFE/common/pkg/database/utils/config.go ]] && return 0
+            # Those builders' tests: the expected DSNs contain "password=p", a
+            # single-character stand-in in an assertion, not a credential.
+            [[ "$path" == SaFE/common/pkg/database/utils/dsn_test.go ]] && return 0
             # applyconfiguration-gen output: schema / field names may match generic secret patterns
             [[ "$path" == SaFE/apis/pkg/client/applyconfiguration/* ]] && return 0
             # Frontend form field names and TypeScript type definitions, not credential values

--- a/SaFE/charts/primus-safe/templates/_helpers.tpl
+++ b/SaFE/charts/primus-safe/templates/_helpers.tpl
@@ -1,0 +1,25 @@
+{{/*
+The session a component's database driver must be given.
+
+"read-write" makes the driver check, at connect time, that the session it opened
+can write, and refuse it when it cannot -- so a connection reaching a replica
+fails there instead of failing every write later with "cannot execute INSERT in a
+read-only transaction". Every component reading this writes, so on is the right
+default.
+
+hasKey, not default: an explicitly empty value is how a deployment whose db host
+resolves to a replica turns this off, and `default` reads empty as unset and would
+put "read-write" back -- the escape hatch would render as the thing it escapes.
+The Go side honours the empty because getString tests viper.IsSet rather than the
+value.
+
+Shared rather than repeated in each component's config, because three copies of a
+condition this non-obvious drift apart.
+*/}}
+{{- define "primus-safe.dbTargetSessionAttrs" -}}
+{{- if hasKey (default dict .Values.db) "target_session_attrs" -}}
+{{ (default dict .Values.db).target_session_attrs | quote }}
+{{- else -}}
+"read-write"
+{{- end -}}
+{{- end -}}

--- a/SaFE/charts/primus-safe/templates/apiserver/config.yaml
+++ b/SaFE/charts/primus-safe/templates/apiserver/config.yaml
@@ -50,9 +50,7 @@ data:
       secret_path: {{ default "/etc/secrets/db" (default .Values.db).secret_path }}
       # The ssl mode of db
       ssl_mode: {{ default "require" (default .Values.db).ssl_mode }}
-      # hasKey, not default: an explicitly empty value is the way to turn this
-      # off, and `default` would read it as unset and put the default back.
-      target_session_attrs: {{ if hasKey (default dict .Values.db) "target_session_attrs" }}{{ (default dict .Values.db).target_session_attrs | quote }}{{ else }}"read-write"{{ end }}
+      target_session_attrs: {{ include "primus-safe.dbTargetSessionAttrs" . }}
     opensearch:
       # Whether to enable opensearch, it is used for log search.
       enable: {{ .Values.opensearch.enable }}

--- a/SaFE/charts/primus-safe/templates/apiserver/config.yaml
+++ b/SaFE/charts/primus-safe/templates/apiserver/config.yaml
@@ -50,6 +50,9 @@ data:
       secret_path: {{ default "/etc/secrets/db" (default .Values.db).secret_path }}
       # The ssl mode of db
       ssl_mode: {{ default "require" (default .Values.db).ssl_mode }}
+      # hasKey, not default: an explicitly empty value is the way to turn this
+      # off, and `default` would read it as unset and put the default back.
+      target_session_attrs: {{ if hasKey (default dict .Values.db) "target_session_attrs" }}{{ (default dict .Values.db).target_session_attrs | quote }}{{ else }}"read-write"{{ end }}
     opensearch:
       # Whether to enable opensearch, it is used for log search.
       enable: {{ .Values.opensearch.enable }}

--- a/SaFE/charts/primus-safe/templates/job-manager/config.yaml
+++ b/SaFE/charts/primus-safe/templates/job-manager/config.yaml
@@ -63,9 +63,7 @@ data:
       secret_path: {{ default "/etc/secrets/db" (default .Values.db).secret_path }}
       # The ssl mode of db
       ssl_mode: {{ default "require" (default .Values.db).ssl_mode }}
-      # hasKey, not default: an explicitly empty value is the way to turn this
-      # off, and `default` would read it as unset and put the default back.
-      target_session_attrs: {{ if hasKey (default dict .Values.db) "target_session_attrs" }}{{ (default dict .Values.db).target_session_attrs | quote }}{{ else }}"read-write"{{ end }}
+      target_session_attrs: {{ include "primus-safe.dbTargetSessionAttrs" . }}
     torchft:
       lighthouse: cGlwIGluc3RhbGwgInRvcmNoZnQtbmlnaHRseT09MjAyNS4xMi4xNiIgIm9wZW50ZWxlbWV0cnktc2RrPT0xLjM3LjAiICJvcGVudGVsZW1ldHJ5LWV4cG9ydGVyLW90bHAtcHJvdG8tY29tbW9uPT0xLjM3LjAiICJvcGVudGVsZW1ldHJ5LWV4cG9ydGVyLW90bHAtcHJvdG8taHR0cD09MS4zNy4wIiAmJiBSVVNUX0JBQ0tUUkFDRT0xIHRvcmNoZnRfbGlnaHRob3VzZSAtLXF1b3J1bV90aWNrX21zIDEwMCAtLWpvaW5fdGltZW91dF9tcyAxMDAwMDA=
 kind: ConfigMap

--- a/SaFE/charts/primus-safe/templates/job-manager/config.yaml
+++ b/SaFE/charts/primus-safe/templates/job-manager/config.yaml
@@ -63,6 +63,9 @@ data:
       secret_path: {{ default "/etc/secrets/db" (default .Values.db).secret_path }}
       # The ssl mode of db
       ssl_mode: {{ default "require" (default .Values.db).ssl_mode }}
+      # hasKey, not default: an explicitly empty value is the way to turn this
+      # off, and `default` would read it as unset and put the default back.
+      target_session_attrs: {{ if hasKey (default dict .Values.db) "target_session_attrs" }}{{ (default dict .Values.db).target_session_attrs | quote }}{{ else }}"read-write"{{ end }}
     torchft:
       lighthouse: cGlwIGluc3RhbGwgInRvcmNoZnQtbmlnaHRseT09MjAyNS4xMi4xNiIgIm9wZW50ZWxlbWV0cnktc2RrPT0xLjM3LjAiICJvcGVudGVsZW1ldHJ5LWV4cG9ydGVyLW90bHAtcHJvdG8tY29tbW9uPT0xLjM3LjAiICJvcGVudGVsZW1ldHJ5LWV4cG9ydGVyLW90bHAtcHJvdG8taHR0cD09MS4zNy4wIiAmJiBSVVNUX0JBQ0tUUkFDRT0xIHRvcmNoZnRfbGlnaHRob3VzZSAtLXF1b3J1bV90aWNrX21zIDEwMCAtLWpvaW5fdGltZW91dF9tcyAxMDAwMDA=
 kind: ConfigMap

--- a/SaFE/charts/primus-safe/templates/resource-manager/config.yaml
+++ b/SaFE/charts/primus-safe/templates/resource-manager/config.yaml
@@ -47,9 +47,7 @@ data:
       secret_path: {{ default "/etc/secrets/db" (default .Values.db).secret_path }}
       # The ssl mode of db
       ssl_mode: {{ default "require" (default .Values.db).ssl_mode }}
-      # hasKey, not default: an explicitly empty value is the way to turn this
-      # off, and `default` would read it as unset and put the default back.
-      target_session_attrs: {{ if hasKey (default dict .Values.db) "target_session_attrs" }}{{ (default dict .Values.db).target_session_attrs | quote }}{{ else }}"read-write"{{ end }}
+      target_session_attrs: {{ include "primus-safe.dbTargetSessionAttrs" . }}
     opensearch:
       # Whether to enable opensearch, it is used for log search.
       enable: {{ .Values.opensearch.enable }}

--- a/SaFE/charts/primus-safe/templates/resource-manager/config.yaml
+++ b/SaFE/charts/primus-safe/templates/resource-manager/config.yaml
@@ -47,6 +47,9 @@ data:
       secret_path: {{ default "/etc/secrets/db" (default .Values.db).secret_path }}
       # The ssl mode of db
       ssl_mode: {{ default "require" (default .Values.db).ssl_mode }}
+      # hasKey, not default: an explicitly empty value is the way to turn this
+      # off, and `default` would read it as unset and put the default back.
+      target_session_attrs: {{ if hasKey (default dict .Values.db) "target_session_attrs" }}{{ (default dict .Values.db).target_session_attrs | quote }}{{ else }}"read-write"{{ end }}
     opensearch:
       # Whether to enable opensearch, it is used for log search.
       enable: {{ .Values.opensearch.enable }}

--- a/SaFE/charts/primus-safe/values.yaml
+++ b/SaFE/charts/primus-safe/values.yaml
@@ -122,6 +122,14 @@ cicd:
 db:
   # Enable database for historical job queries, defaults to true
   enable: true
+  # Session the driver must be given, checked when the connection is made.
+  # "read-write" refuses one that cannot write, so a connection reaching a
+  # demoted replica fails at connect instead of failing every write later with
+  # "cannot execute INSERT in a read-only transaction". Every component using
+  # this database writes, so that is the right default. Clear it only for a
+  # deployment whose db host deliberately resolves to a replica -- with it set,
+  # such a host cannot connect at all.
+  target_session_attrs: "read-write"
 opensearch:
   # Log search feature flag. When true, log search endpoints are available.
   # Queries are proxied through robust-api on data clusters (no direct OpenSearch connection).

--- a/SaFE/charts/primus-safe/values.yaml
+++ b/SaFE/charts/primus-safe/values.yaml
@@ -130,6 +130,12 @@ db:
   # deployment whose db host deliberately resolves to a replica -- with it set,
   # such a host cannot connect at all.
   target_session_attrs: "read-write"
+  # db.max_life_time_second is left unset on purpose. Its default of 600 is what
+  # retires a connection stranded on a demoted replica after a failover. If you
+  # do override it, do not set it to 0: database/sql reads 0 as "reusable for as
+  # long as the process lives", the unbounded reuse that kept a pool writing to a
+  # demoted replica for three days. Nothing reports that at runtime beyond one
+  # warning at startup, so a 0 is easy to miss.
 opensearch:
   # Log search feature flag. When true, log search endpoints are available.
   # Queries are proxied through robust-api on data clusters (no direct OpenSearch connection).

--- a/SaFE/common/pkg/config/config.go
+++ b/SaFE/common/pkg/config/config.go
@@ -245,6 +245,22 @@ func GetDBSslMode() string {
 	return getString(dbSslMode, "require")
 }
 
+// GetDBTargetSessionAttrs returns the session the driver must be given, or an
+// empty string to accept whichever it reaches.
+//
+// `read-write` makes the driver ask, at connect time, whether the session it
+// just opened can write, and refuse it when it cannot. Without that a connection
+// to a demoted replica is accepted and fails only later, on the first write, with
+// SQLSTATE 25006 -- and every component here writes, so a read-only session is
+// never one it can use.
+//
+// Configurable because it constrains what the address in the DB secret is allowed
+// to resolve to: a deployment that deliberately points at a replica has to clear
+// this, or every connection fails outright rather than serving reads.
+func GetDBTargetSessionAttrs() string {
+	return getString(dbTargetSessionAttrs, "read-write")
+}
+
 // GetDBMaxOpenConns returns the maximum number of open database connections.
 func GetDBMaxOpenConns() int {
 	return getInt(dbMaxOpenConns, 100)

--- a/SaFE/common/pkg/config/config_test.go
+++ b/SaFE/common/pkg/config/config_test.go
@@ -68,6 +68,7 @@ func TestGettersDefaults(t *testing.T) {
 	testifyassert.Equal(t, "", GetOpenSearchIndexPrefix())
 	testifyassert.False(t, IsDBEnable())
 	testifyassert.Equal(t, "require", GetDBSslMode())
+	testifyassert.Equal(t, "read-write", GetDBTargetSessionAttrs())
 	testifyassert.Equal(t, 100, GetDBMaxOpenConns())
 	testifyassert.Equal(t, 10, GetDBMaxIdleConns())
 	testifyassert.Equal(t, 600, GetDBMaxLifetimeSecond())
@@ -591,4 +592,27 @@ func TestOutboundTLSVerifyFromConfig(t *testing.T) {
 			assert.Equal(t, tt.want, IsOutboundTLSVerifyEnabled())
 		})
 	}
+}
+
+// TestDBTargetSessionAttrsHonoursAnExplicitEmpty covers the Go half of the way
+// out of this setting.
+//
+// Asking for a writable session is right for every component here, so it is on
+// by default -- but a deployment whose db host resolves to a replica has to be
+// able to clear it, or every connection it makes is refused outright. Clearing
+// it means an explicit empty value, and an empty value is exactly what a getter
+// is most likely to quietly replace with its default. getString tests
+// viper.IsSet rather than the value, which is what makes the escape hatch
+// reachable; nothing else states that, and reading the default back here would
+// mean a deployment could not turn this off at all.
+func TestDBTargetSessionAttrsHonoursAnExplicitEmpty(t *testing.T) {
+	viper.Reset()
+	testifyassert.Equal(t, "read-write", GetDBTargetSessionAttrs(), "unset must ask for a writable session")
+
+	viper.Set(dbTargetSessionAttrs, "")
+	testifyassert.Equal(t, "", GetDBTargetSessionAttrs(), "an explicit empty must survive, or the setting cannot be turned off")
+
+	viper.Set(dbTargetSessionAttrs, "any")
+	testifyassert.Equal(t, "any", GetDBTargetSessionAttrs())
+	viper.Reset()
 }

--- a/SaFE/common/pkg/config/define.go
+++ b/SaFE/common/pkg/config/define.go
@@ -74,6 +74,7 @@ const (
 	dbEnable               = dbPrefix + "enable"
 	dbSecretPath           = dbPrefix + "secret_path"
 	dbSslMode              = dbPrefix + "ssl_mode"
+	dbTargetSessionAttrs   = dbPrefix + "target_session_attrs"
 	dbMaxOpenConns         = dbPrefix + "max_open_conns"
 	dbMaxIdleConns         = dbPrefix + "max_idle_conns"
 	dbMaxLifetime          = dbPrefix + "max_life_time_second"

--- a/SaFE/common/pkg/database/client/client.go
+++ b/SaFE/common/pkg/database/client/client.go
@@ -23,8 +23,12 @@ import (
 )
 
 var (
-	once     sync.Once
-	instance *Client
+	// instanceMu guards instance. A mutex rather than sync.Once, because once is
+	// spent whether the body succeeded or not: a boot that could not reach the
+	// database left instance nil for the life of the process, with no second
+	// attempt and no way for a caller to tell "not ready" from "never will be".
+	instanceMu sync.Mutex
+	instance   *Client
 )
 
 // Client represents a database client that manages both sqlx and gorm database connections.
@@ -40,59 +44,97 @@ type Client struct {
 // validates the parameters, establishes connections using both sqlx and gorm
 // The initialization happens only once even if called multiple times.
 //
-// A failure here ends the process, because the alternative is worse than a
-// restart. `once` is spent whether the body succeeded or not, so returning on
-// failure left `instance` nil for the life of the process: no retry, and no way
-// for a caller to tell "not ready" from "never will be". What callers do with
-// that nil then varies, and the quiet one is the problem -- one logs a warning
-// and skips registering its controller, so a blip while the database was
-// electing a primary silently costs that deployment a controller until someone
-// notices it never ran.
+// A nil result means "no client right now", and callers decide what that costs
+// them -- the audit middleware degrades to a passthrough, the email relay
+// reports it. That contract is kept deliberately.
 //
-// Exiting hands the retry to the thing that is good at it. Kubernetes restarts
-// the pod with backoff, the next attempt reaches a database that has finished
-// failing over, and a boot that cannot reach its database is visible as a
-// restarting pod rather than as absent behaviour. Callers guard this with
-// IsDBEnable, so a deployment that runs without a database never arrives here.
+// What changed is that a failure no longer settles the question. Built under a
+// mutex rather than sync.Once, because once is spent whether the body succeeded
+// or not: a boot that could not reach the database used to leave the singleton
+// nil for the life of the process, so a blip while the cluster was electing a
+// primary cost a deployment its database client until someone restarted the pod.
+// Now the next caller tries again, and a database that has finished failing over
+// is picked up without one.
 //
 // Returns:
-//   - *Client: Singleton database client instance
+//   - *Client: Singleton database client instance, or nil when one cannot be
+//     built right now.
 func NewClient() *Client {
-	once.Do(func() {
-		cfg := &utils.DBConfig{
-			DBName:             commonconfig.GetDBName(),
-			Username:           commonconfig.GetDBUser(),
-			Password:           commonconfig.GetDBPassword(),
-			Host:               commonconfig.GetDBHost(),
-			Port:               commonconfig.GetDBPort(),
-			SSLMode:            commonconfig.GetDBSslMode(),
-			TargetSessionAttrs: commonconfig.GetDBTargetSessionAttrs(),
-			MaxOpenConns:       commonconfig.GetDBMaxOpenConns(),
-			MaxIdleConns:       commonconfig.GetDBMaxIdleConns(),
-			MaxLifetime:        time.Duration(commonconfig.GetDBMaxLifetimeSecond()) * time.Second,
-			MaxIdleTime:        time.Duration(commonconfig.GetDBMaxIdleTimeSecond()) * time.Second,
-			ConnectTimeout:     commonconfig.GetDBConnectTimeoutSecond(),
-			RequestTimeout:     time.Duration(commonconfig.GetDBRequestTimeoutSecond()) * time.Second,
-		}
-		if err := checkParams(cfg); err != nil {
-			klog.Fatalf("failed to check db params: %v", err)
-		}
-		db, err := utils.Connect(cfg, utils.PgDriver)
-		if err != nil {
-			klog.Fatalf("failed to connect db: %v", err)
-		}
-		if err = db.Ping(); err != nil {
-			klog.Fatalf("failed to ping db: %v", err)
-		}
-		gormDb, err := utils.ConnectGorm(cfg)
-		if err != nil {
-			klog.Fatalf("failed to connect gorm db: %v", err)
-		}
-		instance = &Client{db: db, DBConfig: cfg, gorm: gormDb}
-		klog.Infof("init db-client successfully! conn-timeout: %d(s), request-timeout: %d(s)",
-			cfg.ConnectTimeout, commonconfig.GetDBRequestTimeoutSecond())
-	})
+	instanceMu.Lock()
+	defer instanceMu.Unlock()
+	if instance != nil {
+		return instance
+	}
+	client, err := buildClient(configuredDB())
+	if err != nil {
+		klog.ErrorS(err, "failed to init db-client; a later call will try again")
+		return nil
+	}
+	instance = client
+	klog.Infof("init db-client successfully! conn-timeout: %d(s), request-timeout: %d(s)",
+		client.ConnectTimeout, commonconfig.GetDBRequestTimeoutSecond())
 	return instance
+}
+
+// configuredDB reads the database settings this process was started with.
+//
+// A variable so a test can count how often an init is attempted without standing
+// up viper state for settings it is not testing.
+var configuredDB = func() *utils.DBConfig {
+	return &utils.DBConfig{
+		DBName:             commonconfig.GetDBName(),
+		Username:           commonconfig.GetDBUser(),
+		Password:           commonconfig.GetDBPassword(),
+		Host:               commonconfig.GetDBHost(),
+		Port:               commonconfig.GetDBPort(),
+		SSLMode:            commonconfig.GetDBSslMode(),
+		TargetSessionAttrs: commonconfig.GetDBTargetSessionAttrs(),
+		MaxOpenConns:       commonconfig.GetDBMaxOpenConns(),
+		MaxIdleConns:       commonconfig.GetDBMaxIdleConns(),
+		MaxLifetime:        time.Duration(commonconfig.GetDBMaxLifetimeSecond()) * time.Second,
+		MaxIdleTime:        time.Duration(commonconfig.GetDBMaxIdleTimeSecond()) * time.Second,
+		ConnectTimeout:     commonconfig.GetDBConnectTimeoutSecond(),
+		RequestTimeout:     time.Duration(commonconfig.GetDBRequestTimeoutSecond()) * time.Second,
+	}
+}
+
+// buildClient opens both pools for cfg, or returns why it could not.
+//
+// Separate from NewClient so the failure paths can be exercised without a
+// database and without a singleton to reset between tests. Anything opened
+// before the failure is closed and stops reporting, so a retry does not leave a
+// pool behind each time it is attempted.
+func buildClient(cfg *utils.DBConfig) (*Client, error) {
+	if err := checkParams(cfg); err != nil {
+		return nil, fmt.Errorf("check db params: %w", err)
+	}
+	db, err := utils.Connect(cfg, utils.PgDriver)
+	if err != nil {
+		return nil, fmt.Errorf("connect db: %w", err)
+	}
+	if err = db.Ping(); err != nil {
+		discardPool(db, cfg)
+		return nil, fmt.Errorf("ping db: %w", err)
+	}
+	gormDb, err := utils.ConnectGorm(cfg)
+	if err != nil {
+		discardPool(db, cfg)
+		return nil, fmt.Errorf("connect gorm db: %w", err)
+	}
+	return &Client{db: db, DBConfig: cfg, gorm: gormDb}, nil
+}
+
+// discardPool closes a pool that will not be used and stops it reporting.
+//
+// Connect registers a metrics collector, and a closed pool that is still
+// registered publishes a frozen set of zeroes for the life of the process --
+// indistinguishable on a dashboard from a pool that is simply idle. Client.Close
+// pairs these for the same reason.
+func discardPool(db *sqlx.DB, cfg *utils.DBConfig) {
+	if err := db.Close(); err != nil {
+		klog.ErrorS(err, "failed to close db connection")
+	}
+	metrics.UnregisterDBPool(utils.SqlxPoolKey(cfg))
 }
 
 // NewClientWithConfig creates a new database Client instance with the provided configuration.
@@ -110,41 +152,13 @@ func NewClientWithConfig(cfg *utils.DBConfig) (*Client, error) {
 		return nil, fmt.Errorf("database config cannot be nil")
 	}
 
-	// Validate configuration parameters
-	if err := checkParams(cfg); err != nil {
-		klog.ErrorS(err, "failed to check db params")
-		return nil, err
-	}
-
-	// Connect using sqlx
-	db, err := utils.Connect(cfg, utils.PgDriver)
+	// Same build as the singleton takes, so the two cannot come to differ in
+	// which pools they open or what they clean up when one of them fails.
+	client, err := buildClient(cfg)
 	if err != nil {
-		klog.Errorf("failed to connect to database: %s", err.Error())
+		klog.ErrorS(err, "failed to create db-client")
 		return nil, err
 	}
-
-	// Verify connection
-	err = db.Ping()
-	if err != nil {
-		klog.ErrorS(err, "failed to ping db")
-		return nil, err
-	}
-
-	// Connect using GORM
-	gormDb, err := utils.ConnectGorm(cfg)
-	if err != nil {
-		klog.ErrorS(err, "failed to connect gorm db")
-		// Close sqlx connection before returning error, and stop it reporting.
-		// Connect registered its collector, and a closed pool that is still
-		// registered publishes a frozen set of zeroes for the life of the
-		// process -- indistinguishable on a dashboard from a pool that is simply
-		// idle. Client.Close pairs these for the same reason.
-		db.Close()
-		metrics.UnregisterDBPool(utils.SqlxPoolKey(cfg))
-		return nil, err
-	}
-
-	client := &Client{db: db, DBConfig: cfg, gorm: gormDb}
 	klog.Infof("created new db-client successfully! host: %s, dbname: %s, conn-timeout: %d(s), request-timeout: %d(s)",
 		cfg.Host, cfg.DBName, cfg.ConnectTimeout, int(cfg.RequestTimeout.Seconds()))
 

--- a/SaFE/common/pkg/database/client/client.go
+++ b/SaFE/common/pkg/database/client/client.go
@@ -45,18 +45,19 @@ type Client struct {
 func NewClient() *Client {
 	once.Do(func() {
 		cfg := &utils.DBConfig{
-			DBName:         commonconfig.GetDBName(),
-			Username:       commonconfig.GetDBUser(),
-			Password:       commonconfig.GetDBPassword(),
-			Host:           commonconfig.GetDBHost(),
-			Port:           commonconfig.GetDBPort(),
-			SSLMode:        commonconfig.GetDBSslMode(),
-			MaxOpenConns:   commonconfig.GetDBMaxOpenConns(),
-			MaxIdleConns:   commonconfig.GetDBMaxIdleConns(),
-			MaxLifetime:    time.Duration(commonconfig.GetDBMaxLifetimeSecond()) * time.Second,
-			MaxIdleTime:    time.Duration(commonconfig.GetDBMaxIdleTimeSecond()) * time.Second,
-			ConnectTimeout: commonconfig.GetDBConnectTimeoutSecond(),
-			RequestTimeout: time.Duration(commonconfig.GetDBRequestTimeoutSecond()) * time.Second,
+			DBName:             commonconfig.GetDBName(),
+			Username:           commonconfig.GetDBUser(),
+			Password:           commonconfig.GetDBPassword(),
+			Host:               commonconfig.GetDBHost(),
+			Port:               commonconfig.GetDBPort(),
+			SSLMode:            commonconfig.GetDBSslMode(),
+			TargetSessionAttrs: commonconfig.GetDBTargetSessionAttrs(),
+			MaxOpenConns:       commonconfig.GetDBMaxOpenConns(),
+			MaxIdleConns:       commonconfig.GetDBMaxIdleConns(),
+			MaxLifetime:        time.Duration(commonconfig.GetDBMaxLifetimeSecond()) * time.Second,
+			MaxIdleTime:        time.Duration(commonconfig.GetDBMaxIdleTimeSecond()) * time.Second,
+			ConnectTimeout:     commonconfig.GetDBConnectTimeoutSecond(),
+			RequestTimeout:     time.Duration(commonconfig.GetDBRequestTimeoutSecond()) * time.Second,
 		}
 		if err := checkParams(cfg); err != nil {
 			klog.ErrorS(err, "failed to check db params")

--- a/SaFE/common/pkg/database/client/client.go
+++ b/SaFE/common/pkg/database/client/client.go
@@ -73,6 +73,14 @@ func NewClient() *Client {
 			return
 		}
 		gormDb, err := utils.ConnectGorm(cfg)
+		if err != nil {
+			// Left unchecked, a failed GORM init still produced a client, with a
+			// nil handle every later query would fault on -- far from the boot
+			// that caused it. NewClientWithConfig has always checked this.
+			klog.ErrorS(err, "failed to connect gorm db")
+			db.Close()
+			return
+		}
 		instance = &Client{db: db, DBConfig: cfg, gorm: gormDb}
 		klog.Infof("init db-client successfully! conn-timeout: %d(s), request-timeout: %d(s)",
 			cfg.ConnectTimeout, commonconfig.GetDBRequestTimeoutSecond())

--- a/SaFE/common/pkg/database/client/client.go
+++ b/SaFE/common/pkg/database/client/client.go
@@ -40,6 +40,21 @@ type Client struct {
 // validates the parameters, establishes connections using both sqlx and gorm
 // The initialization happens only once even if called multiple times.
 //
+// A failure here ends the process, because the alternative is worse than a
+// restart. `once` is spent whether the body succeeded or not, so returning on
+// failure left `instance` nil for the life of the process: no retry, and no way
+// for a caller to tell "not ready" from "never will be". What callers do with
+// that nil then varies, and the quiet one is the problem -- one logs a warning
+// and skips registering its controller, so a blip while the database was
+// electing a primary silently costs that deployment a controller until someone
+// notices it never ran.
+//
+// Exiting hands the retry to the thing that is good at it. Kubernetes restarts
+// the pod with backoff, the next attempt reaches a database that has finished
+// failing over, and a boot that cannot reach its database is visible as a
+// restarting pod rather than as absent behaviour. Callers guard this with
+// IsDBEnable, so a deployment that runs without a database never arrives here.
+//
 // Returns:
 //   - *Client: Singleton database client instance
 func NewClient() *Client {
@@ -60,27 +75,18 @@ func NewClient() *Client {
 			RequestTimeout:     time.Duration(commonconfig.GetDBRequestTimeoutSecond()) * time.Second,
 		}
 		if err := checkParams(cfg); err != nil {
-			klog.ErrorS(err, "failed to check db params")
-			return
+			klog.Fatalf("failed to check db params: %v", err)
 		}
 		db, err := utils.Connect(cfg, utils.PgDriver)
 		if err != nil {
-			klog.Errorf("%s", err.Error())
-			return
+			klog.Fatalf("failed to connect db: %v", err)
 		}
-		err = db.Ping()
-		if err != nil {
-			klog.ErrorS(err, "failed to ping db")
-			return
+		if err = db.Ping(); err != nil {
+			klog.Fatalf("failed to ping db: %v", err)
 		}
 		gormDb, err := utils.ConnectGorm(cfg)
 		if err != nil {
-			// Left unchecked, a failed GORM init still produced a client, with a
-			// nil handle every later query would fault on -- far from the boot
-			// that caused it. NewClientWithConfig has always checked this.
-			klog.ErrorS(err, "failed to connect gorm db")
-			db.Close()
-			return
+			klog.Fatalf("failed to connect gorm db: %v", err)
 		}
 		instance = &Client{db: db, DBConfig: cfg, gorm: gormDb}
 		klog.Infof("init db-client successfully! conn-timeout: %d(s), request-timeout: %d(s)",
@@ -128,8 +134,13 @@ func NewClientWithConfig(cfg *utils.DBConfig) (*Client, error) {
 	gormDb, err := utils.ConnectGorm(cfg)
 	if err != nil {
 		klog.ErrorS(err, "failed to connect gorm db")
-		// Close sqlx connection before returning error
+		// Close sqlx connection before returning error, and stop it reporting.
+		// Connect registered its collector, and a closed pool that is still
+		// registered publishes a frozen set of zeroes for the life of the
+		// process -- indistinguishable on a dashboard from a pool that is simply
+		// idle. Client.Close pairs these for the same reason.
 		db.Close()
+		metrics.UnregisterDBPool(utils.SqlxPoolKey(cfg))
 		return nil, err
 	}
 

--- a/SaFE/common/pkg/database/client/client.go
+++ b/SaFE/common/pkg/database/client/client.go
@@ -29,7 +29,28 @@ var (
 	// attempt and no way for a caller to tell "not ready" from "never will be".
 	instanceMu sync.Mutex
 	instance   *Client
+	// lastAttempt is when a build was last tried and failed. Zero means never.
+	lastAttempt time.Time
 )
+
+// initRetryCooldown is how long a failed build stands before another is tried.
+//
+// Retrying is what stops one bad boot costing a process its database client for
+// good, but retrying on every call is its own fault: a build dials the server,
+// waits up to ConnectTimeout, and holds instanceMu while it does. Callers are on
+// periodic and reconcile paths -- the self-health reporter asks every 30s,
+// dispatch asks per user lookup -- so an outage would turn each of them into a
+// repeated dial against a database that is already struggling, with every other
+// caller queued behind the one holding the lock.
+//
+// Timed from when an attempt starts rather than when it fails, so a dial that
+// hangs for its whole timeout does not then earn a further cooldown on top: the
+// rate is one attempt per cooldown however slowly the server is failing.
+//
+// A variable so a test can take it out of the way; not a config key, because the
+// number that matters to an operator is ConnectTimeout, and this only has to be
+// longer than one attempt.
+var initRetryCooldown = 30 * time.Second
 
 // Client represents a database client that manages both sqlx and gorm database connections.
 // It encapsulates the database configuration and provides methods to interact with the database.
@@ -54,7 +75,8 @@ type Client struct {
 // nil for the life of the process, so a blip while the cluster was electing a
 // primary cost a deployment its database client until someone restarted the pod.
 // Now the next caller tries again, and a database that has finished failing over
-// is picked up without one.
+// is picked up without one -- though not the very next caller, since a failure
+// stands for initRetryCooldown before another dial is spent on it.
 //
 // Returns:
 //   - *Client: Singleton database client instance, or nil when one cannot be
@@ -65,11 +87,18 @@ func NewClient() *Client {
 	if instance != nil {
 		return instance
 	}
-	client, err := buildClient(configuredDB())
-	if err != nil {
-		klog.ErrorS(err, "failed to init db-client; a later call will try again")
+	if since := time.Since(lastAttempt); !lastAttempt.IsZero() && since < initRetryCooldown {
+		klog.V(4).Infof("db-client init failed %v ago; holding off until %v has passed", since, initRetryCooldown)
 		return nil
 	}
+	lastAttempt = time.Now()
+	client, err := buildClient(configuredDB())
+	if err != nil {
+		klog.ErrorS(err, "failed to init db-client; a call after the retry cooldown will try again",
+			"cooldown", initRetryCooldown)
+		return nil
+	}
+	lastAttempt = time.Time{}
 	instance = client
 	klog.Infof("init db-client successfully! conn-timeout: %d(s), request-timeout: %d(s)",
 		client.ConnectTimeout, commonconfig.GetDBRequestTimeoutSecond())

--- a/SaFE/common/pkg/database/client/client_init_test.go
+++ b/SaFE/common/pkg/database/client/client_init_test.go
@@ -6,12 +6,19 @@
 package client
 
 import (
+	"net"
 	"testing"
+	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/jmoiron/sqlx"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	commonconfig "github.com/AMD-AIG-AIMA/SAFE/common/pkg/config"
 	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/database/utils"
+	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/metrics"
 )
 
 // TestBuildClientReportsWhyItCouldNotBuild covers the failure path a caller acts
@@ -92,4 +99,85 @@ func TestNewClientCachesASuccess(t *testing.T) {
 	require.NotNil(t, NewClient())
 	assert.Equal(t, "already-built", NewClient().DBName)
 	assert.Zero(t, calls, "an existing client must be returned, not rebuilt")
+}
+
+// TestDiscardPoolStopsItReporting covers the half of a failed init that is
+// invisible at runtime.
+//
+// Connect registers a metrics collector against the pool it opened. Closing the
+// pool without unregistering leaves the collector reading a closed handle, which
+// publishes a frozen set of zeroes for the life of the process -- on a dashboard
+// that is indistinguishable from a pool that is simply idle, so the one signal
+// that would say "this client never came up" reads as healthy.
+func TestDiscardPoolStopsItReporting(t *testing.T) {
+	sqldb, _, err := sqlmock.New()
+	require.NoError(t, err)
+	db := sqlx.NewDb(sqldb, "postgres")
+
+	cfg := &utils.DBConfig{Host: "discard-test", Port: 5432, DBName: "safe"}
+	labels := map[string]string{"pool": "discard-test:5432/safe", "driver": "sqlx", "state": "open"}
+	metrics.RegisterDBPool(utils.SqlxPoolKey(cfg), db.Stats)
+	t.Cleanup(func() { metrics.UnregisterDBPool(utils.SqlxPoolKey(cfg)) })
+	require.NotNil(t, findMetric(t, "safe_db_pool_connections", labels),
+		"precondition: the pool should be reporting before it is discarded")
+
+	discardPool(db, cfg)
+
+	assert.Nil(t, findMetric(t, "safe_db_pool_connections", labels),
+		"a discarded pool must stop reporting, or its zeroes look like an idle pool")
+	assert.Error(t, db.Ping(), "the pool should be closed as well as unregistered")
+}
+
+// TestConfiguredDBReadsEachSettingIntoItsOwnField guards a mapping that nothing
+// else would catch. Thirteen settings are copied into one struct, and the two
+// durations are the pair worth pinning: swapping the lifetime and the idle time
+// would compile, pass every other test, and quietly restore the unbounded reuse
+// this branch exists to end.
+func TestConfiguredDBReadsEachSettingIntoItsOwnField(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	commonconfig.SetValue("db.max_life_time_second", "111")
+	commonconfig.SetValue("db.max_idle_time_second", "222")
+	commonconfig.SetValue("db.ssl_mode", "disable")
+	commonconfig.SetValue("db.target_session_attrs", "")
+
+	cfg := configuredDB()
+
+	assert.Equal(t, 111*time.Second, cfg.MaxLifetime)
+	assert.Equal(t, 222*time.Second, cfg.MaxIdleTime)
+	assert.Equal(t, "disable", cfg.SSLMode)
+	assert.Equal(t, "", cfg.TargetSessionAttrs, "an explicit empty must reach the DSN builder")
+}
+
+// TestBuildClientReportsAnUnreachableServer covers the connect path without a
+// server: a config that passes validation but points at a closed port fails in
+// utils.Connect, which is the branch a database that is down takes.
+func TestBuildClientReportsAnUnreachableServer(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := listener.Addr().(*net.TCPAddr).Port
+	require.NoError(t, listener.Close()) // nothing is listening there now
+
+	client, err := buildClient(&utils.DBConfig{
+		DBName: "safe", Username: "u", Password: "p", Host: "127.0.0.1",
+		Port: port, SSLMode: "disable", ConnectTimeout: 1,
+	})
+
+	assert.Nil(t, client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connect db")
+}
+
+// TestNewClientWithConfigRefusesAConfigItCannotUse keeps the non-singleton
+// constructor's contract: it reports rather than exits, and it reports the same
+// reason the singleton logs, because both now take one build path.
+func TestNewClientWithConfigRefusesAConfigItCannotUse(t *testing.T) {
+	client, err := NewClientWithConfig(nil)
+	assert.Nil(t, client)
+	require.Error(t, err)
+
+	client, err = NewClientWithConfig(&utils.DBConfig{})
+	assert.Nil(t, client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "check db params")
 }

--- a/SaFE/common/pkg/database/client/client_init_test.go
+++ b/SaFE/common/pkg/database/client/client_init_test.go
@@ -6,48 +6,90 @@
 package client
 
 import (
-	"os"
-	"os/exec"
 	"testing"
 
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/database/utils"
 )
 
-// childEnv marks the re-executed copy of this test that is expected to die.
-const childEnv = "SAFE_DB_CLIENT_FATAL_CHILD"
+// TestBuildClientReportsWhyItCouldNotBuild covers the failure path a caller acts
+// on. A nil client is a contract here -- the audit middleware degrades to a
+// passthrough on one, the email relay reports it -- so what matters is that the
+// reason reaches the log rather than being swallowed on the way out.
+func TestBuildClientReportsWhyItCouldNotBuild(t *testing.T) {
+	client, err := buildClient(&utils.DBConfig{})
 
-// TestNewClientExitsWhenItCannotBeBuilt pins the one thing that cannot be
-// asserted in-process, because the behaviour under test is the process ending.
+	assert.Nil(t, client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "check db params")
+	for _, missing := range []string{"dbname", "username", "host"} {
+		assert.Contains(t, err.Error(), missing,
+			"the error has to name what is missing, or a nil client explains nothing")
+	}
+}
+
+// TestNewClientRetriesAfterAFailure is the regression this rewrite exists for.
 //
-// The alternative it replaced is why this is worth a subprocess. `once` is spent
-// whether the body succeeded or not, so returning on failure left a nil
-// singleton for the life of the process -- no retry, and callers that could not
-// tell "not ready" from "never will be". One of them logs a warning and skips
-// registering its controller, so the failure was both permanent and quiet.
+// The singleton was built with sync.Once, which is spent whether the body
+// succeeded or not: one failed attempt left the instance nil for the life of the
+// process, so a blip while the cluster elected a primary cost a deployment its
+// database client until somebody restarted the pod. A second call has to be a
+// second attempt.
 //
-// Run as a child rather than mocked: klog.Fatalf calls os.Exit, so a test that
-// reached it in-process would take the test binary with it, and stubbing the exit
-// would test the stub rather than what a pod does.
-func TestNewClientExitsWhenItCannotBeBuilt(t *testing.T) {
-	if os.Getenv(childEnv) == "1" {
-		// No config, so checkParams finds no dbname, user, password or host.
-		viper.Reset()
-		NewClient()
-		// Reached only if the failure path returned instead of exiting, which is
-		// the regression this test exists for. The parent reads the zero status.
-		return
+// Asserted through the failure path because the success path needs a database.
+// Reaching buildClient twice is the property under test; that both attempts fail
+// here is incidental.
+func TestNewClientRetriesAfterAFailure(t *testing.T) {
+	instanceMu.Lock()
+	instance = nil
+	instanceMu.Unlock()
+
+	attempts := 0
+	t.Cleanup(func() {
+		instanceMu.Lock()
+		instance = nil
+		instanceMu.Unlock()
+	})
+
+	// Stand in for the config reader so the test does not depend on viper state,
+	// and count how many times a call reaches it.
+	restore := configuredDB
+	t.Cleanup(func() { configuredDB = restore })
+	configuredDB = func() *utils.DBConfig {
+		attempts++
+		return &utils.DBConfig{}
 	}
 
-	cmd := exec.Command(os.Args[0], "-test.run=TestNewClientExitsWhenItCannotBeBuilt")
-	cmd.Env = append(os.Environ(), childEnv+"=1")
-	out, err := cmd.CombinedOutput()
+	assert.Nil(t, NewClient())
+	assert.Nil(t, NewClient())
+	assert.Equal(t, 2, attempts,
+		"a failed init must not settle the question: the next call has to try again")
+}
 
-	require.Error(t, err, "a db client that cannot be built must end the process, not return nil:\n%s", out)
-	exitErr, ok := err.(*exec.ExitError)
-	require.True(t, ok, "expected an exit status, got %v", err)
-	assert.NotEqual(t, 0, exitErr.ExitCode())
-	assert.Contains(t, string(out), "failed to check db params",
-		"the exit has to say which check failed, or a restarting pod explains nothing")
+// TestNewClientCachesASuccess keeps the other half of the contract. Retrying is
+// only correct while there is nothing to return; once a client exists it is the
+// singleton, and rebuilding it would open a second pair of pools.
+func TestNewClientCachesASuccess(t *testing.T) {
+	instanceMu.Lock()
+	instance = &Client{DBConfig: &utils.DBConfig{DBName: "already-built"}}
+	instanceMu.Unlock()
+	t.Cleanup(func() {
+		instanceMu.Lock()
+		instance = nil
+		instanceMu.Unlock()
+	})
+
+	calls := 0
+	restore := configuredDB
+	t.Cleanup(func() { configuredDB = restore })
+	configuredDB = func() *utils.DBConfig {
+		calls++
+		return &utils.DBConfig{}
+	}
+
+	require.NotNil(t, NewClient())
+	assert.Equal(t, "already-built", NewClient().DBName)
+	assert.Zero(t, calls, "an existing client must be returned, not rebuilt")
 }

--- a/SaFE/common/pkg/database/client/client_init_test.go
+++ b/SaFE/common/pkg/database/client/client_init_test.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+package client
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// childEnv marks the re-executed copy of this test that is expected to die.
+const childEnv = "SAFE_DB_CLIENT_FATAL_CHILD"
+
+// TestNewClientExitsWhenItCannotBeBuilt pins the one thing that cannot be
+// asserted in-process, because the behaviour under test is the process ending.
+//
+// The alternative it replaced is why this is worth a subprocess. `once` is spent
+// whether the body succeeded or not, so returning on failure left a nil
+// singleton for the life of the process -- no retry, and callers that could not
+// tell "not ready" from "never will be". One of them logs a warning and skips
+// registering its controller, so the failure was both permanent and quiet.
+//
+// Run as a child rather than mocked: klog.Fatalf calls os.Exit, so a test that
+// reached it in-process would take the test binary with it, and stubbing the exit
+// would test the stub rather than what a pod does.
+func TestNewClientExitsWhenItCannotBeBuilt(t *testing.T) {
+	if os.Getenv(childEnv) == "1" {
+		// No config, so checkParams finds no dbname, user, password or host.
+		viper.Reset()
+		NewClient()
+		// Reached only if the failure path returned instead of exiting, which is
+		// the regression this test exists for. The parent reads the zero status.
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestNewClientExitsWhenItCannotBeBuilt")
+	cmd.Env = append(os.Environ(), childEnv+"=1")
+	out, err := cmd.CombinedOutput()
+
+	require.Error(t, err, "a db client that cannot be built must end the process, not return nil:\n%s", out)
+	exitErr, ok := err.(*exec.ExitError)
+	require.True(t, ok, "expected an exit status, got %v", err)
+	assert.NotEqual(t, 0, exitErr.ExitCode())
+	assert.Contains(t, string(out), "failed to check db params",
+		"the exit has to say which check failed, or a restarting pod explains nothing")
+}

--- a/SaFE/common/pkg/database/client/client_init_test.go
+++ b/SaFE/common/pkg/database/client/client_init_test.go
@@ -37,6 +37,21 @@ func TestBuildClientReportsWhyItCouldNotBuild(t *testing.T) {
 	}
 }
 
+// resetSingleton puts the package back to "never built" and restores it after the
+// test, so cases that drive NewClient do not inherit each other's instance or
+// retry cooldown.
+func resetSingleton(t *testing.T) {
+	t.Helper()
+	clear := func() {
+		instanceMu.Lock()
+		defer instanceMu.Unlock()
+		instance = nil
+		lastAttempt = time.Time{}
+	}
+	clear()
+	t.Cleanup(clear)
+}
+
 // TestNewClientRetriesAfterAFailure is the regression this rewrite exists for.
 //
 // The singleton was built with sync.Once, which is spent whether the body
@@ -47,58 +62,85 @@ func TestBuildClientReportsWhyItCouldNotBuild(t *testing.T) {
 //
 // Asserted through the failure path because the success path needs a database.
 // Reaching buildClient twice is the property under test; that both attempts fail
-// here is incidental.
+// here is incidental. The cooldown is taken out of the way so this case stays
+// about whether a retry happens at all -- when it happens is the case below.
 func TestNewClientRetriesAfterAFailure(t *testing.T) {
+	resetSingleton(t)
+	attempts := countedFailingConfig(t)
+	withCooldown(t, 0)
+
+	assert.Nil(t, NewClient())
+	assert.Nil(t, NewClient())
+	assert.Equal(t, 2, *attempts,
+		"a failed init must not settle the question: a later call has to try again")
+}
+
+// TestNewClientHoldsOffAfterAFailure is the other side of that retry, and the
+// cost of having added it.
+//
+// An attempt is not cheap: it dials the server, waits up to connect_timeout, and
+// holds instanceMu while it does. The callers are periodic or per-request -- the
+// self-health reporter asks every 30s, dispatch asks per user lookup -- so
+// retrying on every call would point a steady stream of connection attempts at a
+// database that is already down, each one parking the other callers behind the
+// lock. sync.Once was at least free once it was spent; a retry has to buy its
+// own bound.
+func TestNewClientHoldsOffAfterAFailure(t *testing.T) {
+	resetSingleton(t)
+	attempts := countedFailingConfig(t)
+	withCooldown(t, time.Hour)
+
+	assert.Nil(t, NewClient())
+	assert.Nil(t, NewClient())
+	assert.Nil(t, NewClient())
+	assert.Equal(t, 1, *attempts, "calls inside the cooldown must not dial again")
+
+	// Age the failure past the cooldown: the hold-off has to expire, or it is
+	// sync.Once with extra steps.
 	instanceMu.Lock()
-	instance = nil
+	lastAttempt = time.Now().Add(-2 * time.Hour)
 	instanceMu.Unlock()
 
-	attempts := 0
-	t.Cleanup(func() {
-		instanceMu.Lock()
-		instance = nil
-		instanceMu.Unlock()
-	})
+	assert.Nil(t, NewClient())
+	assert.Equal(t, 2, *attempts, "once the cooldown has passed, a call must try again")
+}
 
-	// Stand in for the config reader so the test does not depend on viper state,
-	// and count how many times a call reaches it.
+// countedFailingConfig replaces the config reader with one that always yields an
+// unusable config, and returns a count of how many times a build reached it.
+// Standing in here keeps these cases off viper state for settings they are not
+// testing, and makes "did it attempt" observable without a database.
+func countedFailingConfig(t *testing.T) *int {
+	t.Helper()
+	attempts := 0
 	restore := configuredDB
 	t.Cleanup(func() { configuredDB = restore })
 	configuredDB = func() *utils.DBConfig {
 		attempts++
 		return &utils.DBConfig{}
 	}
+	return &attempts
+}
 
-	assert.Nil(t, NewClient())
-	assert.Nil(t, NewClient())
-	assert.Equal(t, 2, attempts,
-		"a failed init must not settle the question: the next call has to try again")
+func withCooldown(t *testing.T, d time.Duration) {
+	t.Helper()
+	restore := initRetryCooldown
+	t.Cleanup(func() { initRetryCooldown = restore })
+	initRetryCooldown = d
 }
 
 // TestNewClientCachesASuccess keeps the other half of the contract. Retrying is
 // only correct while there is nothing to return; once a client exists it is the
 // singleton, and rebuilding it would open a second pair of pools.
 func TestNewClientCachesASuccess(t *testing.T) {
+	resetSingleton(t)
 	instanceMu.Lock()
 	instance = &Client{DBConfig: &utils.DBConfig{DBName: "already-built"}}
 	instanceMu.Unlock()
-	t.Cleanup(func() {
-		instanceMu.Lock()
-		instance = nil
-		instanceMu.Unlock()
-	})
-
-	calls := 0
-	restore := configuredDB
-	t.Cleanup(func() { configuredDB = restore })
-	configuredDB = func() *utils.DBConfig {
-		calls++
-		return &utils.DBConfig{}
-	}
+	calls := countedFailingConfig(t)
 
 	require.NotNil(t, NewClient())
 	assert.Equal(t, "already-built", NewClient().DBName)
-	assert.Zero(t, calls, "an existing client must be returned, not rebuilt")
+	assert.Zero(t, *calls, "an existing client must be returned, not rebuilt")
 }
 
 // TestDiscardPoolStopsItReporting covers the half of a failed init that is

--- a/SaFE/common/pkg/database/utils/config.go
+++ b/SaFE/common/pkg/database/utils/config.go
@@ -13,18 +13,21 @@ import (
 // DBConfig represents the database configuration parameters for connecting to a database.
 // It contains all necessary connection details and connection pool settings.
 type DBConfig struct {
-	DBName         string        // Database name to connect to
-	Username       string        // Database username
-	Password       string        // Database user password
-	Host           string        // Database host address
-	SSLMode        string        // SSL mode for the connection
-	Port           int           // Database port
-	MaxIdleConns   int           // Maximum number of idle connections in the pool
-	MaxOpenConns   int           // Maximum number of open connections to the database
-	MaxIdleTime    time.Duration // Maximum amount of time a connection may be idle
-	MaxLifetime    time.Duration // Maximum amount of time a connection may be reused
-	ConnectTimeout int           // Connection timeout in seconds
-	RequestTimeout time.Duration // Request timeout for database operations
+	DBName   string // Database name to connect to
+	Username string // Database username
+	Password string // Database user password
+	Host     string // Database host address
+	SSLMode  string // SSL mode for the connection
+	// TargetSessionAttrs constrains the session the driver will accept, e.g.
+	// "read-write" to refuse one that cannot write. Empty accepts any.
+	TargetSessionAttrs string
+	Port               int           // Database port
+	MaxIdleConns       int           // Maximum number of idle connections in the pool
+	MaxOpenConns       int           // Maximum number of open connections to the database
+	MaxIdleTime        time.Duration // Maximum amount of time a connection may be idle
+	MaxLifetime        time.Duration // Maximum amount of time a connection may be reused
+	ConnectTimeout     int           // Connection timeout in seconds
+	RequestTimeout     time.Duration // Request timeout for database operations
 }
 
 // SourceName generates a PostgreSQL connection string based on the database configuration.
@@ -32,6 +35,19 @@ type DBConfig struct {
 // Returns:
 //   - string: Formatted connection string containing user, password, dbname, host, port, sslmode and connect_timeout
 func (c *DBConfig) SourceName() string {
-	return fmt.Sprintf("user=%s password=%s dbname=%s host=%s port=%d sslmode=%s connect_timeout=%d",
-		c.Username, c.Password, c.DBName, c.Host, c.Port, c.SSLMode, c.ConnectTimeout)
+	return fmt.Sprintf("user=%s password=%s dbname=%s host=%s port=%d sslmode=%s connect_timeout=%d%s",
+		c.Username, c.Password, c.DBName, c.Host, c.Port, c.SSLMode, c.ConnectTimeout,
+		targetSessionAttrsParam(c.TargetSessionAttrs))
+}
+
+// targetSessionAttrsParam renders the parameter, or nothing when unset.
+//
+// Omitted rather than passed empty: both drivers read an explicit empty value as
+// a setting, and libpq rejects it, so an unset field has to leave the keyword out
+// of the string entirely.
+func targetSessionAttrsParam(attrs string) string {
+	if attrs == "" {
+		return ""
+	}
+	return " target_session_attrs=" + attrs
 }

--- a/SaFE/common/pkg/database/utils/config.go
+++ b/SaFE/common/pkg/database/utils/config.go
@@ -48,9 +48,14 @@ func (c *DBConfig) SourceName() string {
 // how the pool limits came to differ between the two pools. The keyword order
 // differs from SourceName's because that is what each was written with and the
 // drivers do not care; what has to agree is which parameters appear.
+//
+// connect_timeout is among them. It was missing here while SourceName had it,
+// which left a GORM dial to an unreachable host waiting on the OS rather than on
+// a number this config sets -- the same shape of asymmetry as the pool limits,
+// and it bounds how long an init attempt can hold the client mutex.
 func (c *DBConfig) GormSourceName() string {
-	return fmt.Sprintf("host=%s port=%v user=%s dbname=%s password=%s sslmode=%s%s",
-		c.Host, c.Port, c.Username, c.DBName, c.Password, c.SSLMode,
+	return fmt.Sprintf("host=%s port=%v user=%s dbname=%s password=%s sslmode=%s connect_timeout=%d%s",
+		c.Host, c.Port, c.Username, c.DBName, c.Password, c.SSLMode, c.ConnectTimeout,
 		targetSessionAttrsParam(c.TargetSessionAttrs))
 }
 

--- a/SaFE/common/pkg/database/utils/config.go
+++ b/SaFE/common/pkg/database/utils/config.go
@@ -40,6 +40,20 @@ func (c *DBConfig) SourceName() string {
 		targetSessionAttrsParam(c.TargetSessionAttrs))
 }
 
+// GormSourceName generates the connection string GORM's postgres dialector is
+// opened with.
+//
+// Beside SourceName rather than inline at the call site, and for the reason this
+// file's own history gives: two things built from one config, in two places, is
+// how the pool limits came to differ between the two pools. The keyword order
+// differs from SourceName's because that is what each was written with and the
+// drivers do not care; what has to agree is which parameters appear.
+func (c *DBConfig) GormSourceName() string {
+	return fmt.Sprintf("host=%s port=%v user=%s dbname=%s password=%s sslmode=%s%s",
+		c.Host, c.Port, c.Username, c.DBName, c.Password, c.SSLMode,
+		targetSessionAttrsParam(c.TargetSessionAttrs))
+}
+
 // targetSessionAttrsParam renders the parameter, or nothing when unset.
 //
 // Omitted rather than passed empty: both drivers read an explicit empty value as

--- a/SaFE/common/pkg/database/utils/db.go
+++ b/SaFE/common/pkg/database/utils/db.go
@@ -48,14 +48,7 @@ func Connect(cfg *DBConfig, driverName DBDriver) (*sqlx.DB, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect db %s, err: %v", cfg.DBName, err)
 	}
-	if cfg.MaxOpenConns > 0 {
-		db.SetMaxOpenConns(cfg.MaxOpenConns)
-	}
-	if cfg.MaxIdleConns > 0 {
-		db.SetMaxIdleConns(cfg.MaxIdleConns)
-	}
-	db.SetConnMaxIdleTime(cfg.MaxIdleTime)
-	db.SetConnMaxLifetime(cfg.MaxLifetime)
+	applyPoolLimits(db.DB, cfg)
 	metrics.RegisterDBPool(SqlxPoolKey(cfg), db.Stats)
 	return db, nil
 }
@@ -114,14 +107,41 @@ func ConnectGorm(cfg *DBConfig) (*gorm.DB, error) {
 	if err = gormDB.Use(gormMetricsPlugin{}); err != nil {
 		return nil, err
 	}
-	// GORM opens a pool of its own rather than sharing the sqlx one, and it is
-	// left on the database/sql defaults, so it needs its own pool metrics.
+	// GORM opens a pool of its own rather than sharing the sqlx one, so it needs
+	// both the same limits and its own metrics.
 	sqlDB, err := gormDB.DB()
 	if err != nil {
 		return nil, err
 	}
+	applyPoolLimits(sqlDB, cfg)
 	metrics.RegisterDBPool(GormPoolKey(cfg), sqlDB.Stats)
 	return gormDB, nil
+}
+
+// applyPoolLimits bounds how long a pooled connection may be reused.
+//
+// The lifetime is the part that matters beyond tuning. A connection is bound to
+// the backend it was dialled to, and on a Postgres cluster that backend can stop
+// being the primary while the connection stays open: the address the pool
+// resolves now points elsewhere, but an established connection does not move.
+// Reusing one then fails every write with SQLSTATE 25006, "cannot execute INSERT
+// in a read-only transaction", on a pool that reports itself healthy.
+//
+// database/sql leaves both timers at zero, meaning a connection is reusable for
+// as long as the process lives. That is how a pool kept serving a demoted
+// replica for three days after a failover, while the sqlx pool in the same
+// process -- which has always set these -- rotated onto the new primary within
+// its lifetime. Applied here rather than at each call site so a second pool
+// cannot be opened without them.
+func applyPoolLimits(sqlDB *sql.DB, cfg *DBConfig) {
+	if cfg.MaxOpenConns > 0 {
+		sqlDB.SetMaxOpenConns(cfg.MaxOpenConns)
+	}
+	if cfg.MaxIdleConns > 0 {
+		sqlDB.SetMaxIdleConns(cfg.MaxIdleConns)
+	}
+	sqlDB.SetConnMaxIdleTime(cfg.MaxIdleTime)
+	sqlDB.SetConnMaxLifetime(cfg.MaxLifetime)
 }
 
 // ParseNullString parses the input data.

--- a/SaFE/common/pkg/database/utils/db.go
+++ b/SaFE/common/pkg/database/utils/db.go
@@ -81,8 +81,9 @@ func GormPoolKey(cfg *DBConfig) metrics.PoolKey {
 //   - error: Connection error if any
 func ConnectGorm(cfg *DBConfig) (*gorm.DB, error) {
 	// init gorm
-	dsn := fmt.Sprintf("host=%s port=%v user=%s dbname=%s password=%s sslmode=%s",
-		cfg.Host, cfg.Port, cfg.Username, cfg.DBName, cfg.Password, cfg.SSLMode)
+	dsn := fmt.Sprintf("host=%s port=%v user=%s dbname=%s password=%s sslmode=%s%s",
+		cfg.Host, cfg.Port, cfg.Username, cfg.DBName, cfg.Password, cfg.SSLMode,
+		targetSessionAttrsParam(cfg.TargetSessionAttrs))
 	dialector := postgres.Dialector{
 		Config: &postgres.Config{
 			DSN: dsn,

--- a/SaFE/common/pkg/database/utils/db.go
+++ b/SaFE/common/pkg/database/utils/db.go
@@ -81,12 +81,9 @@ func GormPoolKey(cfg *DBConfig) metrics.PoolKey {
 //   - error: Connection error if any
 func ConnectGorm(cfg *DBConfig) (*gorm.DB, error) {
 	// init gorm
-	dsn := fmt.Sprintf("host=%s port=%v user=%s dbname=%s password=%s sslmode=%s%s",
-		cfg.Host, cfg.Port, cfg.Username, cfg.DBName, cfg.Password, cfg.SSLMode,
-		targetSessionAttrsParam(cfg.TargetSessionAttrs))
 	dialector := postgres.Dialector{
 		Config: &postgres.Config{
-			DSN: dsn,
+			DSN: cfg.GormSourceName(),
 		},
 	}
 	gormDB, err := gorm.Open(dialector, &gorm.Config{
@@ -140,6 +137,15 @@ func applyPoolLimits(sqlDB *sql.DB, cfg *DBConfig) {
 	}
 	if cfg.MaxIdleConns > 0 {
 		sqlDB.SetMaxIdleConns(cfg.MaxIdleConns)
+	}
+	if cfg.MaxLifetime <= 0 {
+		// Passed through rather than overridden, because a caller may mean it.
+		// Said out loud because the meaning is not the one the zero suggests: it
+		// is not "no limit configured", it is the unbounded reuse that let a pool
+		// serve a demoted replica for three days, and nothing else reports it.
+		klog.Warningf("db pool %s has no connection lifetime: a connection may be "+
+			"reused for the life of the process, so one to a demoted replica is "+
+			"never retired", poolName(cfg))
 	}
 	sqlDB.SetConnMaxIdleTime(cfg.MaxIdleTime)
 	sqlDB.SetConnMaxLifetime(cfg.MaxLifetime)

--- a/SaFE/common/pkg/database/utils/db_pool_test.go
+++ b/SaFE/common/pkg/database/utils/db_pool_test.go
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+package utils
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// retiredByLifetime waits for the pool to close a connection because its
+// lifetime elapsed, and reports whether it did.
+//
+// Polled rather than asserted once: database/sql retires an expired connection
+// either when the next caller takes it out of the free list or when the cleaner
+// goroutine comes round, so which of the two gets there first is not something a
+// test should depend on.
+//
+// The ping's own error is discarded on purpose. It is what asks for a connection
+// and so provokes the check, but the mock driver hands out one connection only --
+// once the expired one is gone the next ping has nothing to take, and failing on
+// that would fail the test for the very thing it is here to observe.
+func retiredByLifetime(t *testing.T, db *sql.DB) bool {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if db.Stats().MaxLifetimeClosed > 0 {
+			return true
+		}
+		_ = db.Ping()
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
+}
+
+// TestPoolLimitsRetireAConnectionOnItsLifetime is the regression this file
+// exists for.
+//
+// A connection is bound to the backend it was dialled to, and that backend can
+// stop being the primary while the connection stays open. Reusing one then fails
+// every write with SQLSTATE 25006 on a pool that reports itself healthy, and
+// with no lifetime there is nothing that ever ends it: one such connection
+// served a demoted replica for three days.
+//
+// Both directions are checked, because a test that only sets a lifetime would
+// pass against a pool that ignores it.
+func TestPoolLimitsRetireAConnectionOnItsLifetime(t *testing.T) {
+	t.Run("a configured lifetime ends a connection", func(t *testing.T) {
+		db, _, err := sqlmock.New()
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = db.Close() })
+
+		applyPoolLimits(db, &DBConfig{MaxLifetime: time.Millisecond, MaxIdleTime: time.Minute})
+		require.NoError(t, db.Ping())
+
+		assert.True(t, retiredByLifetime(t, db),
+			"a pooled connection outlived MaxLifetime, so a failover leaves it serving the old backend")
+	})
+
+	t.Run("no lifetime keeps it forever, which is what was wrong", func(t *testing.T) {
+		db, _, err := sqlmock.New()
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = db.Close() })
+
+		// The database/sql default, and what the GORM pool was left on.
+		applyPoolLimits(db, &DBConfig{})
+		require.NoError(t, db.Ping())
+		time.Sleep(50 * time.Millisecond)
+		require.NoError(t, db.Ping())
+
+		assert.Zero(t, db.Stats().MaxLifetimeClosed,
+			"nothing should retire a connection when no lifetime is configured")
+	})
+}
+
+// TestPoolLimitsCarryTheConfiguredCeilings pins that the ceilings reach the
+// pool, and that a zero is read as "leave the default" rather than as a limit of
+// none -- MaxOpenConns of 0 means unlimited to database/sql, so passing it
+// through would uncap a pool the caller meant to leave alone.
+func TestPoolLimitsCarryTheConfiguredCeilings(t *testing.T) {
+	db, _, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	applyPoolLimits(db, &DBConfig{MaxOpenConns: 7, MaxIdleConns: 3})
+	assert.Equal(t, 7, db.Stats().MaxOpenConnections)
+
+	applyPoolLimits(db, &DBConfig{})
+	assert.Equal(t, 7, db.Stats().MaxOpenConnections,
+		"a zero must not be forwarded as a limit")
+}

--- a/SaFE/common/pkg/database/utils/dsn_test.go
+++ b/SaFE/common/pkg/database/utils/dsn_test.go
@@ -31,6 +31,36 @@ func TestSourceNameAsksForAWritableSession(t *testing.T) {
 	assert.Contains(t, dsnConfig("read-write").SourceName(), "target_session_attrs=read-write")
 }
 
+// TestBothDSNsCarryTheSameSessionAttr is the one that guards against a repeat of
+// the bug this branch fixes.
+//
+// That bug was two things built from one config, in two places, which came to
+// disagree -- the sqlx pool had a connection lifetime and the GORM pool did not.
+// The two DSNs are the same shape of risk, so the parameter is asserted on both
+// rather than on the one that happens to be a method.
+func TestBothDSNsCarryTheSameSessionAttr(t *testing.T) {
+	cfg := dsnConfig("read-write")
+	assert.Contains(t, cfg.SourceName(), "target_session_attrs=read-write")
+	assert.Contains(t, cfg.GormSourceName(), "target_session_attrs=read-write")
+
+	unset := dsnConfig("")
+	assert.NotContains(t, unset.SourceName(), "target_session_attrs")
+	assert.NotContains(t, unset.GormSourceName(), "target_session_attrs")
+}
+
+// TestGormSourceNameCarriesTheConnectionItNeeds pins the parameters, not their
+// order: the two DSNs were written with different keyword orders and the drivers
+// do not care, but a parameter going missing from one of them is the asymmetry
+// that has already cost a three-day outage once.
+func TestGormSourceNameCarriesTheConnectionItNeeds(t *testing.T) {
+	dsn := dsnConfig("read-write").GormSourceName()
+	for _, want := range []string{
+		"host=h", "port=5432", "user=u", "dbname=d", "password=p", "sslmode=require",
+	} {
+		assert.Contains(t, dsn, want)
+	}
+}
+
 // TestSourceNameOmitsAnUnsetSessionAttr is the half that matters for the escape
 // hatch. Both drivers read an explicit empty value as a setting and libpq
 // rejects it, so clearing the config has to leave the keyword out rather than

--- a/SaFE/common/pkg/database/utils/dsn_test.go
+++ b/SaFE/common/pkg/database/utils/dsn_test.go
@@ -6,9 +6,12 @@
 package utils
 
 import (
+	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func dsnConfig(attrs string) *DBConfig {
@@ -72,4 +75,48 @@ func TestSourceNameOmitsAnUnsetSessionAttr(t *testing.T) {
 	assert.Equal(t,
 		"user=u password=p dbname=d host=h port=5432 sslmode=require connect_timeout=5",
 		dsn, "an unset attr must leave the string exactly as it was before")
+}
+
+// closedPort returns a port nothing is listening on, so a dial fails at once
+// rather than waiting out a timeout against an unroutable address.
+func closedPort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := listener.Addr().(*net.TCPAddr).Port
+	require.NoError(t, listener.Close())
+	return port
+}
+
+func unreachableConfig(t *testing.T) *DBConfig {
+	t.Helper()
+	return &DBConfig{
+		DBName: "safe", Username: "u", Password: "p", Host: "127.0.0.1",
+		Port: closedPort(t), SSLMode: "disable", ConnectTimeout: 1,
+		MaxOpenConns: 5, MaxIdleConns: 2,
+		MaxIdleTime: time.Minute, MaxLifetime: 10 * time.Minute,
+	}
+}
+
+// TestConnectReportsAnUnreachableServer covers the path a database that is down
+// takes, and names the database in the error: both pools are opened from one
+// config, so a failure that does not say which one it was leaves the reader
+// guessing between them.
+func TestConnectReportsAnUnreachableServer(t *testing.T) {
+	db, err := Connect(unreachableConfig(t), PgDriver)
+
+	assert.Nil(t, db)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "safe", "the error should name the database it could not reach")
+}
+
+// TestConnectGormReportsAnUnreachableServer is the same path on the other pool.
+// Worth its own case rather than trusting the first: these two are separate
+// implementations over separate drivers, and this branch exists because they had
+// come to differ.
+func TestConnectGormReportsAnUnreachableServer(t *testing.T) {
+	db, err := ConnectGorm(unreachableConfig(t))
+
+	assert.Nil(t, db)
+	assert.Error(t, err)
 }

--- a/SaFE/common/pkg/database/utils/dsn_test.go
+++ b/SaFE/common/pkg/database/utils/dsn_test.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func dsnConfig(attrs string) *DBConfig {
+	return &DBConfig{
+		Username: "u", Password: "p", DBName: "d", Host: "h", Port: 5432,
+		SSLMode: "require", ConnectTimeout: 5, TargetSessionAttrs: attrs,
+	}
+}
+
+// TestSourceNameAsksForAWritableSession pins the parameter that keeps a
+// connection off a demoted replica.
+//
+// The address in the DB secret follows the primary, so a new connection normally
+// reaches it -- but "normally" is doing the work there. Between a failover and
+// the address catching up, a connection lands on a node that answers, accepts the
+// session, and then refuses every write with SQLSTATE 25006. Asking for a
+// writable session moves that from a 500 the caller sees to a connect the driver
+// declines and the pool retries.
+func TestSourceNameAsksForAWritableSession(t *testing.T) {
+	assert.Contains(t, dsnConfig("read-write").SourceName(), "target_session_attrs=read-write")
+}
+
+// TestSourceNameOmitsAnUnsetSessionAttr is the half that matters for the escape
+// hatch. Both drivers read an explicit empty value as a setting and libpq
+// rejects it, so clearing the config has to leave the keyword out rather than
+// pass nothing to it -- otherwise the way out of this constraint is itself a
+// connection failure.
+func TestSourceNameOmitsAnUnsetSessionAttr(t *testing.T) {
+	dsn := dsnConfig("").SourceName()
+	assert.NotContains(t, dsn, "target_session_attrs")
+	assert.Equal(t,
+		"user=u password=p dbname=d host=h port=5432 sslmode=require connect_timeout=5",
+		dsn, "an unset attr must leave the string exactly as it was before")
+}

--- a/SaFE/common/pkg/database/utils/dsn_test.go
+++ b/SaFE/common/pkg/database/utils/dsn_test.go
@@ -49,6 +49,12 @@ func TestBothDSNsCarryTheSameSessionAttr(t *testing.T) {
 	unset := dsnConfig("")
 	assert.NotContains(t, unset.SourceName(), "target_session_attrs")
 	assert.NotContains(t, unset.GormSourceName(), "target_session_attrs")
+
+	// connect_timeout for the same reason. It was the parameter that had already
+	// gone missing from one of the two, so it is asserted on both here rather
+	// than only where it was added.
+	assert.Contains(t, cfg.SourceName(), "connect_timeout=5")
+	assert.Contains(t, cfg.GormSourceName(), "connect_timeout=5")
 }
 
 // TestGormSourceNameCarriesTheConnectionItNeeds pins the parameters, not their
@@ -59,6 +65,7 @@ func TestGormSourceNameCarriesTheConnectionItNeeds(t *testing.T) {
 	dsn := dsnConfig("read-write").GormSourceName()
 	for _, want := range []string{
 		"host=h", "port=5432", "user=u", "dbname=d", "password=p", "sslmode=require",
+		"connect_timeout=5",
 	} {
 		assert.Contains(t, dsn, want)
 	}


### PR DESCRIPTION
## Background

A pooled connection is bound to the backend it was dialled to. On a Postgres cluster that backend can stop being the primary while the connection stays open: the address resolves somewhere else now, but an established connection does not move. Every write on one then fails with `SQLSTATE 25006`, "cannot execute INSERT in a read-only transaction", from a pool that reports itself healthy.

`ConnectGorm` never applied the limits it was handed. GORM opens a pool of its own and this one was left on the `database/sql` defaults, where both `ConnMaxLifetime` and `ConnMaxIdleTime` are zero and a connection is reusable for as long as the process lives. The existing comment observed exactly this and drew only the conclusion that the pool needed its own metrics.

What that produced, on the cluster:

| Time (UTC) | Event |
|---|---|
| 08-13 22:39:00 | `nvsf-0` becomes primary |
| 08-13 22:39:02 | apiserver's GORM pool connects to it — correctly, it is the primary |
| 08-13 22:49:26 | `mtgv-0` takes over as primary; `nvsf` is demoted to a read-only replica |
| 08-13 → 08-17 | two GORM connections stay open on `nvsf`, idle, for 3 days 6 hours |
| 08-17 04:52 | three consecutive `PUT` bindings all draw one of them → 500 |

Requests were served correctly or with a 25006 depending on which connection they drew, which is why it read as intermittent. Every write path on GORM was affected — llm-gateway bindings, image upserts (`image.go:51 "failed to upsert image"`), optimization tasks, models, notifications.

The sqlx pool in the same process, built from the same `DBConfig`, rotated onto the new primary inside its 600s lifetime. That asymmetry — one pool self-healing and the other not, from one config — is what this fixes.

## Changes

**Bound how long a connection may be reused.** Both pools now go through one `applyPoolLimits`, so a second pool cannot be opened without the limits and the two cannot drift again. This takes the exposure from unbounded to one `MaxLifetime`, 600s by default.

A zero still means "leave the default" for the two counts: `database/sql` reads a zero `MaxOpenConns` as unlimited, so forwarding it would uncap a pool the caller meant to leave alone.

**Refuse a session that cannot write.** The lifetime bounds how long a connection to a demoted replica survives; it does not stop one being made. Between a failover and the address catching up, a connection lands on a node that answers, accepts the session, and then refuses every write. `target_session_attrs=read-write` moves that to connect time — the driver asks and declines, so the pool retries rather than handing a caller a connection that will 500. Both drivers support it: `lib/pq` for sqlx, `pgx/v5` under gorm's postgres driver, and both DSNs are built through one helper so they cannot disagree.

Defaulted on, because every component sharing this config writes. Configurable, because it constrains what the secret's address may resolve to.

**Gave that switch a way into a Helm deployment.** It existed only as a config key no template rendered, so the one deployment that must turn it off could not. Read with `hasKey` rather than `default`: an explicitly empty value is how it is turned off, and `default` treats empty as unset and would put `read-write` back — the escape hatch would have rendered as the thing it escapes.

**Checked the error `NewClient` dropped.** A failed GORM init still produced a client, with a nil handle every later query would fault on, arbitrarily far from the boot that caused it. `NewClientWithConfig` has always checked it.

## Verification

- `go build ./common/...`, `go vet`, `gofmt` clean; `common/pkg/database/...` and `common/pkg/config/...` tests pass
- New tests cover both directions, which is what makes them regression tests rather than restatements: a configured lifetime retires a connection and no lifetime never does; a set attr reaches the DSN and an unset one leaves the string byte-identical to before
- Chart rendered three ways: the default asks for `read-write`, `--set db.target_session_attrs=""` forwards the empty, and the Go side honours it because `getString` tests `viper.IsSet` rather than the value

Not covered: that `ConnectGorm` calls the limits. `gorm.Open` pings on open and this repo has no pattern for a test against a live Postgres, so the single shared function is what guards it instead.

`apiserver` does not build in my environment for an unrelated reason — `containers/storage` needs `btrfs/version.h`, which is missing here. `--set db=null` fails to render on `resource-manager/deployment.yaml:62`, which predates this branch and is untouched.

## Deployment

Nothing to do beyond deploying: both defaults are the safe ones. A deployment whose `db` host deliberately resolves to a replica must set `db.target_session_attrs: ""`, or its connections will be refused outright rather than serving reads.
