### PR TITLE
feat(llm-gateway): attribute a proxied request to the caller's NTID

### DIFF
--- a/SaFE/apiserver/pkg/handlers/llm-gateway/handler.go
+++ b/SaFE/apiserver/pkg/handlers/llm-gateway/handler.go
@@ -672,9 +672,23 @@ func validateApimKey(apimKey string) error {
 // via AccessController.GetRequestUser (same pattern as resources/cd-handlers).
 // Falls back to userName if User CR lookup fails or email annotation is not set.
 func (h *Handler) getUserEmail(c *gin.Context) string {
+	email, _ := h.getUserIdentity(c)
+	return email
+}
+
+// getUserIdentity resolves the caller's email and NTID from one User CR read,
+// so the proxy path can stamp an upstream attribution header without a second
+// lookup per request.
+//
+// The two results do not share a fallback. Email keeps the old chain (userName,
+// then userId) because every caller uses it as a database key and needs
+// something. NTID is sent upstream as the identity APIM bills, so a userName
+// that merely looks like one would attribute the request to the wrong person:
+// unresolved stays empty, and the header is then removed rather than guessed.
+func (h *Handler) getUserIdentity(c *gin.Context) (email string, ntid string) {
 	userId := c.GetString(common.UserId)
 	if userId == "" {
-		return ""
+		return "", ""
 	}
 
 	// Look up User CR to get the real email
@@ -684,17 +698,35 @@ func (h *Handler) getUserEmail(c *gin.Context) string {
 			klog.V(4).InfoS("LLM Gateway: failed to get user, falling back to userName",
 				"userId", userId, "error", err)
 		} else {
-			if email := v1.GetUserEmail(user); email != "" {
-				return email
-			}
+			email = v1.GetUserEmail(user)
+			ntid = ntidFromPreferredName(v1.GetAnnotation(user, v1.UserPreferredNameAnnotation))
 		}
+	}
+	if email != "" {
+		return email, ntid
 	}
 
 	// Fallback: userName
 	if name := c.GetString(common.UserName); name != "" {
-		return name
+		return name, ntid
 	}
-	return userId
+	return userId, ntid
+}
+
+// ntidFromPreferredName takes the local part of a preferred name, which carries
+// the NTID ahead of a domain: "<ntid>@<domain>" yields the NTID. A value with no
+// domain is already one.
+//
+// Interior whitespace disqualifies it. An NTID has none, so what arrives with
+// any is a display name rather than the identifier -- and this value reaches an
+// outbound header, where a newline is a request-splitting vector.
+func ntidFromPreferredName(preferredName string) string {
+	ntid, _, _ := strings.Cut(preferredName, "@")
+	ntid = strings.TrimSpace(ntid)
+	if ntid == "" || strings.ContainsAny(ntid, " \t\r\n\v\f") {
+		return ""
+	}
+	return ntid
 }
 
 // maskKey returns a masked version of a key, showing the first 4 and last 4 characters.

--- a/SaFE/apiserver/pkg/handlers/llm-gateway/proxy.go
+++ b/SaFE/apiserver/pkg/handlers/llm-gateway/proxy.go
@@ -21,6 +21,10 @@ import (
 
 const llmProxyPrefix = "/api/v1/llm-proxy"
 
+// upstreamUserHeader carries the caller's NTID to APIM, which attributes the
+// request to it.
+const upstreamUserHeader = "USER-NTID"
+
 // newLLMProxy creates a reverse proxy targeting the LiteLLM endpoint.
 // It strips the /api/v1/llm-proxy prefix and prepends the target's base path, so that
 // /api/v1/llm-proxy/v1/chat/completions → <endpoint>/v1/chat/completions.
@@ -71,7 +75,7 @@ func newLLMProxy(endpoint string) (*httputil.ReverseProxy, error) {
 // It resolves the user's Virtual Key from the DB, replaces the Authorization
 // header, and reverse-proxies the request to LiteLLM.
 func (h *Handler) ProxyLLMRequest(c *gin.Context) {
-	email := h.getUserEmail(c)
+	email, ntid := h.getUserIdentity(c)
 	if email == "" {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "unable to identify user"})
 		c.Abort()
@@ -100,9 +104,24 @@ func (h *Handler) ProxyLLMRequest(c *gin.Context) {
 	}
 
 	applyProxyVirtualKeyHeader(c, virtualKey)
+	applyUpstreamUserHeader(c, ntid)
 
 	defer recoverReverseProxyAbort(c)
 	h.proxy.ServeHTTP(c.Writer, c.Request)
+}
+
+// applyUpstreamUserHeader stamps the caller's NTID for upstream APIM attribution.
+//
+// The delete is unconditional, and that is the point of the function: this is a
+// reverse proxy, so a client can send this header itself. Returning early
+// without it whenever the NTID is unresolved would forward the client's own
+// value upstream as though the gateway had established it.
+func applyUpstreamUserHeader(c *gin.Context, ntid string) {
+	c.Request.Header.Del(upstreamUserHeader)
+	if ntid == "" {
+		return
+	}
+	c.Request.Header.Set(upstreamUserHeader, ntid)
 }
 
 func recoverReverseProxyAbort(c *gin.Context) {


### PR DESCRIPTION
## What

APIM attributes a request to the identity in `USER-NTID`, and the LLM proxy sent none — so everything arriving through this gateway was unattributed.

`ProxyLLMRequest` now stamps the caller's NTID on the way out, taken from the `primus-safe.user.preferred.name` annotation on the User CR (its local part, ahead of the domain).

## How

- `getUserEmail` becomes a one-line wrapper over a new `getUserIdentity`, which returns email and NTID from **one** `GetRequestUser` call. The proxy path costs no additional lookup per request, and the 11 existing `getUserEmail` call sites are untouched.
- `applyUpstreamUserHeader` sets the header beside the existing `applyProxyVirtualKeyHeader`.

## Two decisions worth a reviewer's attention

**The delete is unconditional.** This is a reverse proxy, so a client can send `USER-NTID` itself. Returning early without the delete whenever the NTID is unresolved would forward the client's own value upstream as though the gateway had established it — so the header is removed first, and only then set when there is something to set.

**Email and NTID do not share a fallback.** Email keeps its existing chain (userName, then userId) because every caller uses it as a database key and needs a value. NTID is the identity billed upstream, so a userName that merely looks like one would attribute the request to the wrong person: unresolved stays empty. Interior whitespace also disqualifies a value — it rejects a display name, and keeps a newline out of an outbound header.

## Test plan

- [x] `go build` / `go vet` / `go test ./apiserver/pkg/handlers/llm-gateway/` pass
- [x] `gofmt` clean on both changed files
- [ ] Verify against a real APIM that the upstream sees the NTID it bills

Made with [Cursor](https://cursor.com)