### PR TITLE
fix(job-manager): read pod specs at the path the writer used

### DIFF
--- a/SaFE/apis/pkg/apis/amd/v1/resource_template_types.go
+++ b/SaFE/apis/pkg/apis/amd/v1/resource_template_types.go
@@ -67,11 +67,16 @@ type ResourceSpec struct {
 }
 
 // TemplatePath returns the path components for locating the resource template.
+// The result is a fresh slice: appending onto PrePaths directly would write
+// through its backing array whenever it has spare capacity, corrupting the
+// ResourceTemplate for later reads.
 func (t *ResourceSpec) TemplatePath() []string {
 	if t == nil {
 		return nil
 	}
-	path := append(t.PrePaths, t.TemplatePaths...)
+	path := make([]string, 0, len(t.PrePaths)+len(t.TemplatePaths))
+	path = append(path, t.PrePaths...)
+	path = append(path, t.TemplatePaths...)
 	return path
 }
 

--- a/SaFE/apis/pkg/apis/amd/v1/resource_template_types.go
+++ b/SaFE/apis/pkg/apis/amd/v1/resource_template_types.go
@@ -85,6 +85,16 @@ func (t *ResourceSpec) joinPrePaths(rel []string) []string {
 	return path
 }
 
+// Path returns the path components for locating a field that sits directly
+// under prePaths and has no dedicated path field of its own. Each call returns
+// a fresh slice, so the result is safe to append to.
+func (t *ResourceSpec) Path(fields ...string) []string {
+	if t == nil {
+		return nil
+	}
+	return t.joinPrePaths(fields)
+}
+
 // TemplatePath returns the path components for locating the resource template.
 func (t *ResourceSpec) TemplatePath() []string {
 	if t == nil {

--- a/SaFE/apis/pkg/apis/amd/v1/resource_template_types.go
+++ b/SaFE/apis/pkg/apis/amd/v1/resource_template_types.go
@@ -56,6 +56,15 @@ type ResourceSpec struct {
 	PrePaths []string `json:"prePaths,omitempty"`
 	// The relative path of pod template
 	TemplatePaths []string `json:"templatePaths,omitempty"`
+	// The relative path of the core/v1 PodSpec, where containers, volumes,
+	// priorityClassName and the other pod-level fields live. Like the other
+	// path fields it is relative to prePaths, not to templatePaths: a kind that
+	// wraps its pod in a PodTemplateSpec repeats the template segment and adds
+	// "spec" (template, spec), while a kind whose slot embeds a PodSpec inline
+	// names that field alone (extraPodSpec).
+	//
+	// Empty means the path is derived from templatePaths and the kind instead.
+	PodSpecPaths []string `json:"podSpecPaths,omitempty"`
 	// The relative path of pod replica
 	ReplicasPaths []string `json:"replicasPaths,omitempty"`
 	// Fits scenarios without a defined replica path but with actual replica values, such as ray-job.
@@ -82,6 +91,15 @@ func (t *ResourceSpec) TemplatePath() []string {
 		return nil
 	}
 	return t.joinPrePaths(t.TemplatePaths)
+}
+
+// PodSpecPath returns the path components for locating the pod spec, or nil
+// when the resource spec does not declare podSpecPaths.
+func (t *ResourceSpec) PodSpecPath() []string {
+	if t == nil || len(t.PodSpecPaths) == 0 {
+		return nil
+	}
+	return t.joinPrePaths(t.PodSpecPaths)
 }
 
 // ReplicasPath returns the path components for locating the replica count.

--- a/SaFE/apis/pkg/apis/amd/v1/resource_template_types.go
+++ b/SaFE/apis/pkg/apis/amd/v1/resource_template_types.go
@@ -66,18 +66,46 @@ type ResourceSpec struct {
 	MinReplicasPaths []string `json:"minReplicasPaths,omitempty"`
 }
 
+// joinPrePaths returns PrePaths followed by rel as a fresh slice, leaving
+// PrePaths' backing array untouched even when callers append to the result.
+// The path accessors below all build on it.
+func (t *ResourceSpec) joinPrePaths(rel []string) []string {
+	path := make([]string, 0, len(t.PrePaths)+len(rel))
+	path = append(path, t.PrePaths...)
+	path = append(path, rel...)
+	return path
+}
+
 // TemplatePath returns the path components for locating the resource template.
-// The result is a fresh slice: appending onto PrePaths directly would write
-// through its backing array whenever it has spare capacity, corrupting the
-// ResourceTemplate for later reads.
 func (t *ResourceSpec) TemplatePath() []string {
 	if t == nil {
 		return nil
 	}
-	path := make([]string, 0, len(t.PrePaths)+len(t.TemplatePaths))
-	path = append(path, t.PrePaths...)
-	path = append(path, t.TemplatePaths...)
-	return path
+	return t.joinPrePaths(t.TemplatePaths)
+}
+
+// ReplicasPath returns the path components for locating the replica count.
+func (t *ResourceSpec) ReplicasPath() []string {
+	if t == nil {
+		return nil
+	}
+	return t.joinPrePaths(t.ReplicasPaths)
+}
+
+// MaxReplicasPath returns the path components for locating the max replica count.
+func (t *ResourceSpec) MaxReplicasPath() []string {
+	if t == nil {
+		return nil
+	}
+	return t.joinPrePaths(t.MaxReplicasPaths)
+}
+
+// MinReplicasPath returns the path components for locating the min replica count.
+func (t *ResourceSpec) MinReplicasPath() []string {
+	if t == nil {
+		return nil
+	}
+	return t.joinPrePaths(t.MinReplicasPaths)
 }
 
 type ResourceStatus struct {

--- a/SaFE/apis/pkg/apis/amd/v1/zz_generated.deepcopy.go
+++ b/SaFE/apis/pkg/apis/amd/v1/zz_generated.deepcopy.go
@@ -1712,6 +1712,11 @@ func (in *ResourceSpec) DeepCopyInto(out *ResourceSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.PodSpecPaths != nil {
+		in, out := &in.PodSpecPaths, &out.PodSpecPaths
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.ReplicasPaths != nil {
 		in, out := &in.ReplicasPaths, &out.ReplicasPaths
 		*out = make([]string, len(*in))

--- a/SaFE/apis/pkg/client/applyconfiguration/amd/v1/resourcespec.go
+++ b/SaFE/apis/pkg/client/applyconfiguration/amd/v1/resourcespec.go
@@ -13,6 +13,15 @@ type ResourceSpecApplyConfiguration struct {
 	PrePaths []string `json:"prePaths,omitempty"`
 	// The relative path of pod template
 	TemplatePaths []string `json:"templatePaths,omitempty"`
+	// The relative path of the core/v1 PodSpec, where containers, volumes,
+	// priorityClassName and the other pod-level fields live. Like the other
+	// path fields it is relative to prePaths, not to templatePaths: a kind that
+	// wraps its pod in a PodTemplateSpec repeats the template segment and adds
+	// "spec" (template, spec), while a kind whose slot embeds a PodSpec inline
+	// names that field alone (extraPodSpec).
+	//
+	// Empty means the path is derived from templatePaths and the kind instead.
+	PodSpecPaths []string `json:"podSpecPaths,omitempty"`
 	// The relative path of pod replica
 	ReplicasPaths []string `json:"replicasPaths,omitempty"`
 	// Fits scenarios without a defined replica path but with actual replica values, such as ray-job.
@@ -45,6 +54,16 @@ func (b *ResourceSpecApplyConfiguration) WithPrePaths(values ...string) *Resourc
 func (b *ResourceSpecApplyConfiguration) WithTemplatePaths(values ...string) *ResourceSpecApplyConfiguration {
 	for i := range values {
 		b.TemplatePaths = append(b.TemplatePaths, values[i])
+	}
+	return b
+}
+
+// WithPodSpecPaths adds the given value to the PodSpecPaths field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the PodSpecPaths field.
+func (b *ResourceSpecApplyConfiguration) WithPodSpecPaths(values ...string) *ResourceSpecApplyConfiguration {
+	for i := range values {
+		b.PodSpecPaths = append(b.PodSpecPaths, values[i])
 	}
 	return b
 }

--- a/SaFE/charts/primus-safe-cr/templates/resource_template/resource_template.yaml
+++ b/SaFE/charts/primus-safe-cr/templates/resource_template/resource_template.yaml
@@ -26,6 +26,9 @@ spec:
         - Master
       templatePaths:
         - template
+      podSpecPaths:
+        - template
+        - spec
       replicasPaths:
         - replicas
     - prePaths:
@@ -34,6 +37,9 @@ spec:
         - Worker
       templatePaths:
         - template
+      podSpecPaths:
+        - template
+        - spec
       replicasPaths:
         - replicas
   resourceStatus:
@@ -86,6 +92,8 @@ spec:
   resourceSpecs:
     - prePaths:
         - spec
+      podSpecPaths:
+        - podTemplate
       replicasPaths:
         - replicas
   resourceStatus:
@@ -153,6 +161,9 @@ spec:
         - Master
       templatePaths:
         - template
+      podSpecPaths:
+        - template
+        - spec
       replicasPaths:
         - replicas
   resourceStatus:
@@ -222,6 +233,9 @@ spec:
         - spec
       templatePaths:
         - template
+      podSpecPaths:
+        - template
+        - spec
       replicasPaths:
         - replicas
   resourceStatus:
@@ -272,6 +286,9 @@ spec:
         - spec
       templatePaths:
         - template
+      podSpecPaths:
+        - template
+        - spec
       replicasPaths:
         - replicas
   resourceStatus:
@@ -308,6 +325,9 @@ spec:
         - spec
       templatePaths:
         - template
+      podSpecPaths:
+        - template
+        - spec
       replicasPaths:
         - parallelism
       minReplicasPaths:
@@ -355,6 +375,9 @@ spec:
         - spec
       templatePaths:
         - template
+      podSpecPaths:
+        - template
+        - spec
 ---
 apiVersion: amd.com/v1
 kind: ResourceTemplate
@@ -374,6 +397,8 @@ spec:
     kind: EphemeralRunner
   resourceSpecs:
     - prePaths:
+        - spec
+      podSpecPaths:
         - spec
   resourceStatus:
     prePaths:
@@ -417,6 +442,9 @@ spec:
         - spec
       templatePaths:
         - submitterPodTemplate
+      podSpecPaths:
+        - submitterPodTemplate
+        - spec
     - prePaths:
         - spec
         - rayClusterSpec
@@ -424,6 +452,9 @@ spec:
       defaultReplica: 1
       templatePaths:
         - template
+      podSpecPaths:
+        - template
+        - spec
     - prePaths:
         - spec
         - rayClusterSpec
@@ -431,6 +462,9 @@ spec:
         - "0"
       templatePaths:
         - template
+      podSpecPaths:
+        - template
+        - spec
       replicasPaths:
         - replicas
       maxReplicasPaths:
@@ -444,6 +478,9 @@ spec:
         - "1"
       templatePaths:
         - template
+      podSpecPaths:
+        - template
+        - spec
       replicasPaths:
         - replicas
       maxReplicasPaths:
@@ -527,6 +564,8 @@ spec:
         - role0
       templatePaths:
         - extraPodSpec
+      podSpecPaths:
+        - extraPodSpec
       replicasPaths:
         - replicas
     - prePaths:
@@ -534,6 +573,8 @@ spec:
         - services
         - role1
       templatePaths:
+        - extraPodSpec
+      podSpecPaths:
         - extraPodSpec
       replicasPaths:
         - replicas
@@ -543,6 +584,8 @@ spec:
         - role2
       templatePaths:
         - extraPodSpec
+      podSpecPaths:
+        - extraPodSpec
       replicasPaths:
         - replicas
     - prePaths:
@@ -551,6 +594,8 @@ spec:
         - role3
       templatePaths:
         - extraPodSpec
+      podSpecPaths:
+        - extraPodSpec
       replicasPaths:
         - replicas
     - prePaths:
@@ -558,6 +603,8 @@ spec:
         - services
         - role4
       templatePaths:
+        - extraPodSpec
+      podSpecPaths:
         - extraPodSpec
       replicasPaths:
         - replicas
@@ -618,6 +665,8 @@ spec:
         - role0
       templatePaths:
         - extraPodSpec
+      podSpecPaths:
+        - extraPodSpec
       replicasPaths:
         - replicas
     - prePaths:
@@ -625,6 +674,8 @@ spec:
         - services
         - role1
       templatePaths:
+        - extraPodSpec
+      podSpecPaths:
         - extraPodSpec
       replicasPaths:
         - replicas
@@ -634,6 +685,8 @@ spec:
         - role2
       templatePaths:
         - extraPodSpec
+      podSpecPaths:
+        - extraPodSpec
       replicasPaths:
         - replicas
     - prePaths:
@@ -642,6 +695,8 @@ spec:
         - role3
       templatePaths:
         - extraPodSpec
+      podSpecPaths:
+        - extraPodSpec
       replicasPaths:
         - replicas
     - prePaths:
@@ -649,6 +704,8 @@ spec:
         - services
         - role4
       templatePaths:
+        - extraPodSpec
+      podSpecPaths:
         - extraPodSpec
       replicasPaths:
         - replicas
@@ -694,6 +751,9 @@ spec:
         - spec
       templatePaths:
         - podTemplate
+      podSpecPaths:
+        - podTemplate
+        - spec
   resourceStatus:
     prePaths:
       - status

--- a/SaFE/charts/primus-safe/crds/amd.com_resourcetemplates.yaml
+++ b/SaFE/charts/primus-safe/crds/amd.com_resourcetemplates.yaml
@@ -86,6 +86,19 @@ spec:
                       items:
                         type: string
                       type: array
+                    podSpecPaths:
+                      description: |-
+                        The relative path of the core/v1 PodSpec, where containers, volumes,
+                        priorityClassName and the other pod-level fields live. Like the other
+                        path fields it is relative to prePaths, not to templatePaths: a kind that
+                        wraps its pod in a PodTemplateSpec repeats the template segment and adds
+                        "spec" (template, spec), while a kind whose slot embeds a PodSpec inline
+                        names that field alone (extraPodSpec).
+
+                        Empty means the path is derived from templatePaths and the kind instead.
+                      items:
+                        type: string
+                      type: array
                     prePaths:
                       description: Pre-path to k8s object's spec
                       items:

--- a/SaFE/common/pkg/workload/workload.go
+++ b/SaFE/common/pkg/workload/workload.go
@@ -170,9 +170,28 @@ func GetMainContainerByPod(obj metav1.Object, kind, podName string) string {
 	return v1.GetMainContainer(obj)
 }
 
+// ResolvePodSpecPath returns the absolute path to a resource spec's pod spec,
+// followed by fields. The pod spec location is declared data: it comes from the
+// ResourceTemplate's podSpecPaths, which both the write path (dispatcher) and
+// the read path (jobutils) resolve from the same ResourceSpec.
+//
+// ResourceTemplates rendered by charts that predate podSpecPaths carry no
+// value, so kind supplies the built-in default from PodSpecSegment.
+func ResolvePodSpecPath(t *v1.ResourceSpec, kind string, fields ...string) []string {
+	base := t.PodSpecPath()
+	if base == nil {
+		return BuildPodSpecPath(t.TemplatePath(), PodSpecSegment(kind), fields...)
+	}
+	out := make([]string, 0, len(base)+len(fields))
+	out = append(out, base...)
+	out = append(out, fields...)
+	return out
+}
+
 // PodSpecSegment returns the path segment that sits between a
 // ResourceTemplate's templatePaths and the pod spec fields (containers,
-// volumes, ...), for the given workload kind.
+// volumes, ...), for the given workload kind. It is the default that
+// ResolvePodSpecPath applies to a ResourceTemplate with no podSpecPaths.
 //
 // PyTorchJob / Deployment / RayJob and friends wrap pods in a
 // PodTemplateSpec, so the pod spec is one "spec" level down. DynamoDeployment

--- a/SaFE/common/pkg/workload/workload.go
+++ b/SaFE/common/pkg/workload/workload.go
@@ -185,11 +185,17 @@ func GetMainContainerByPod(obj metav1.Object, kind, podName string) string {
 // Read and write paths must agree here: when they disagree, the readers report
 // "not found", drift detection concludes nothing changed, and spec updates are
 // silently dropped.
+//
+// kind is a SaFE Workload kind on the write path (Workload.SpecKind) and the
+// rendered CR kind on the read path (ResourceTemplate.SpecKind). The two
+// namespaces hold different strings for some kinds — a SaFE DynamoDeployment
+// renders a DynamoGraphDeployment — so each non-"spec" case lists every
+// spelling that reaches it.
 func PodSpecSegment(kind string) string {
 	switch kind {
 	case common.MonarchMesh:
 		return "podTemplate"
-	case common.DynamoDeploymentKind, common.InferaDeploymentKind:
+	case common.DynamoDeploymentKind, common.DynamoGraphDeploymentKind, common.InferaDeploymentKind:
 		return ""
 	default:
 		return "spec"

--- a/SaFE/common/pkg/workload/workload.go
+++ b/SaFE/common/pkg/workload/workload.go
@@ -170,6 +170,48 @@ func GetMainContainerByPod(obj metav1.Object, kind, podName string) string {
 	return v1.GetMainContainer(obj)
 }
 
+// PodSpecSegment returns the path segment that sits between a
+// ResourceTemplate's templatePaths and the pod spec fields (containers,
+// volumes, ...), for the given workload kind.
+//
+// PyTorchJob / Deployment / RayJob and friends wrap pods in a
+// PodTemplateSpec, so the pod spec is one "spec" level down. DynamoDeployment
+// and InferaDeployment slots instead embed a core/v1 PodSpec inline in
+// extraPodSpec (see dynamo operator/api/v1alpha1/common.go::ExtraPodSpec and
+// Infera's ServiceSpec.ExtraPodSpec), so their templatePaths already point at
+// the pod spec and there is no segment to traverse. MonarchMesh nests its pod
+// under podTemplate.
+//
+// Read and write paths must agree here: when they disagree, the readers report
+// "not found", drift detection concludes nothing changed, and spec updates are
+// silently dropped.
+func PodSpecSegment(kind string) string {
+	switch kind {
+	case common.MonarchMesh:
+		return "podTemplate"
+	case common.DynamoDeploymentKind, common.InferaDeploymentKind:
+		return ""
+	default:
+		return "spec"
+	}
+}
+
+// BuildPodSpecPath joins templatePath, the pod spec segment and fields into a
+// fresh slice, skipping an empty segment.
+//
+// Emitting "" as a path segment would look up or write a map key named "",
+// which surfaces as CRD schema warnings and path-not-found failures. The
+// result never aliases templatePath's backing array.
+func BuildPodSpecPath(templatePath []string, podSpec string, fields ...string) []string {
+	out := make([]string, 0, len(templatePath)+1+len(fields))
+	out = append(out, templatePath...)
+	if podSpec != "" {
+		out = append(out, podSpec)
+	}
+	out = append(out, fields...)
+	return out
+}
+
 // GetWorkloadResourceUsage retrieves active resources based on the input workload.
 // It filters out terminated pods and applies node filtering criteria.
 func GetWorkloadResourceUsage(workload *v1.Workload, filterNode func(nodeName string) bool) (

--- a/SaFE/common/pkg/workload/workload_test.go
+++ b/SaFE/common/pkg/workload/workload_test.go
@@ -586,3 +586,96 @@ func TestBuildPodSpecPathOmitsEmptySegment(t *testing.T) {
 	assert.Equal(t, len(base), 2)
 	assert.DeepEqual(t, base[:2], []string{"spec", "template"})
 }
+
+// TestResolvePodSpecPathUsesDeclaredPaths pins the declared-data path: when the
+// ResourceTemplate carries podSpecPaths, that is where the pod spec is, for
+// every kind.
+func TestResolvePodSpecPathUsesDeclaredPaths(t *testing.T) {
+	cases := []struct {
+		name string
+		spec v1.ResourceSpec
+		kind string
+		want []string
+	}{
+		{
+			name: "inline pod spec",
+			spec: v1.ResourceSpec{
+				PrePaths:      []string{"spec", "services", "role0"},
+				TemplatePaths: []string{"extraPodSpec"},
+				PodSpecPaths:  []string{"extraPodSpec"},
+			},
+			kind: common.InferaDeploymentKind,
+			want: []string{"spec", "services", "role0", "extraPodSpec", "containers"},
+		},
+		{
+			name: "pod template wrapper",
+			spec: v1.ResourceSpec{
+				PrePaths:      []string{"spec"},
+				TemplatePaths: []string{"template"},
+				PodSpecPaths:  []string{"template", "spec"},
+			},
+			kind: common.DeploymentKind,
+			want: []string{"spec", "template", "spec", "containers"},
+		},
+		{
+			name: "no pod template",
+			spec: v1.ResourceSpec{
+				PrePaths:     []string{"spec"},
+				PodSpecPaths: []string{"podTemplate"},
+			},
+			kind: common.MonarchMesh,
+			want: []string{"spec", "podTemplate", "containers"},
+		},
+		{
+			// The declared path wins over the kind default, which is what lets a
+			// new kind ship without a code change.
+			name: "declared path overrides the kind default",
+			spec: v1.ResourceSpec{
+				PrePaths:      []string{"spec"},
+				TemplatePaths: []string{"template"},
+				PodSpecPaths:  []string{"somewhereElse"},
+			},
+			kind: common.DeploymentKind,
+			want: []string{"spec", "somewhereElse", "containers"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.DeepEqual(t, ResolvePodSpecPath(&c.spec, c.kind, "containers"), c.want)
+		})
+	}
+}
+
+// TestResolvePodSpecPathFallsBackToKind covers ResourceTemplates rendered by
+// charts that predate podSpecPaths: the path comes from templatePaths plus the
+// kind's built-in segment.
+func TestResolvePodSpecPathFallsBackToKind(t *testing.T) {
+	wrapped := v1.ResourceSpec{
+		PrePaths:      []string{"spec"},
+		TemplatePaths: []string{"template"},
+	}
+	assert.DeepEqual(t, ResolvePodSpecPath(&wrapped, common.DeploymentKind, "containers"),
+		[]string{"spec", "template", "spec", "containers"})
+
+	inline := v1.ResourceSpec{
+		PrePaths:      []string{"spec", "services", "role0"},
+		TemplatePaths: []string{"extraPodSpec"},
+	}
+	assert.DeepEqual(t, ResolvePodSpecPath(&inline, common.InferaDeploymentKind, "containers"),
+		[]string{"spec", "services", "role0", "extraPodSpec", "containers"})
+}
+
+// TestResolvePodSpecPathDoesNotAlias pins that repeated calls cannot write
+// through each other's backing array.
+func TestResolvePodSpecPathDoesNotAlias(t *testing.T) {
+	spec := v1.ResourceSpec{
+		PrePaths:     []string{"spec"},
+		PodSpecPaths: []string{"template", "spec"},
+	}
+	volumes := ResolvePodSpecPath(&spec, common.DeploymentKind, "volumes")
+	containers := ResolvePodSpecPath(&spec, common.DeploymentKind, "containers")
+	assert.DeepEqual(t, volumes, []string{"spec", "template", "spec", "volumes"})
+	assert.DeepEqual(t, containers, []string{"spec", "template", "spec", "containers"})
+	assert.DeepEqual(t, spec.PodSpecPaths, []string{"template", "spec"})
+}

--- a/SaFE/common/pkg/workload/workload_test.go
+++ b/SaFE/common/pkg/workload/workload_test.go
@@ -525,3 +525,64 @@ func TestGeneratePriorityAndReason(t *testing.T) {
 	assert.Equal(t, GeneratePriority(-100), common.LowPriority)
 	assert.Assert(t, GeneratePriorityClass(wlKind(common.JobKind)) != "")
 }
+
+// TestPodSpecSegmentAgreesAcrossKindNamespaces is the regression guard for the
+// asymmetry PodSpecSegment exists to prevent.
+//
+// The writers resolve the segment from the SaFE Workload kind; the readers
+// resolve it from the rendered CR kind on the ResourceTemplate's GVK. Those are
+// different strings whenever SaFE's abstraction is named differently from the
+// object it renders (DynamoDeployment -> DynamoGraphDeployment). If only one
+// spelling is listed in the switch, the other falls through to "spec", the
+// readers look somewhere the writers never wrote, drift detection concludes
+// "unchanged", and spec updates are dropped without an error.
+func TestPodSpecSegmentAgreesAcrossKindNamespaces(t *testing.T) {
+	// workloadKind -> CR kind rendered from it, as declared by the shipped
+	// ResourceTemplates (spec.groupVersionKind.kind).
+	pairs := []struct {
+		workloadKind string
+		crKind       string
+		want         string
+	}{
+		{common.DynamoDeploymentKind, common.DynamoGraphDeploymentKind, ""},
+		{common.InferaDeploymentKind, common.InferaDeploymentKind, ""},
+		{common.MonarchMesh, common.MonarchMesh, "podTemplate"},
+		{common.DeploymentKind, common.DeploymentKind, "spec"},
+		{common.StatefulSetKind, common.StatefulSetKind, "spec"},
+		{common.AuthoringKind, common.PytorchJobKind, "spec"},
+		{common.UnifiedJobKind, common.PytorchJobKind, "spec"},
+		{common.RayJobKind, common.RayJobKind, "spec"},
+	}
+
+	for _, p := range pairs {
+		t.Run(p.workloadKind+"->"+p.crKind, func(t *testing.T) {
+			fromWriter := PodSpecSegment(p.workloadKind)
+			fromReader := PodSpecSegment(p.crKind)
+			assert.Equal(t, fromWriter, p.want)
+			assert.Equal(t, fromReader, p.want)
+			assert.Equal(t, fromWriter, fromReader)
+		})
+	}
+}
+
+// TestBuildPodSpecPathOmitsEmptySegment pins the inline-PodSpec shape: an empty
+// segment must vanish rather than become a "" map key, and the result must not
+// alias the caller's slice.
+func TestBuildPodSpecPathOmitsEmptySegment(t *testing.T) {
+	tmpl := []string{"spec", "services", "role0", "extraPodSpec"}
+
+	inline := BuildPodSpecPath(tmpl, PodSpecSegment(common.DynamoGraphDeploymentKind), "containers")
+	assert.DeepEqual(t, inline,
+		[]string{"spec", "services", "role0", "extraPodSpec", "containers"})
+
+	wrapped := BuildPodSpecPath([]string{"spec", "template"},
+		PodSpecSegment(common.DeploymentKind), "containers")
+	assert.DeepEqual(t, wrapped, []string{"spec", "template", "spec", "containers"})
+
+	// The caller's slice is untouched even though it has spare capacity.
+	base := make([]string, 2, 8)
+	base[0], base[1] = "spec", "template"
+	_ = BuildPodSpecPath(base, "spec", "containers")
+	assert.Equal(t, len(base), 2)
+	assert.DeepEqual(t, base[:2], []string{"spec", "template"})
+}

--- a/SaFE/common/pkg/workload/workload_test.go
+++ b/SaFE/common/pkg/workload/workload_test.go
@@ -7,7 +7,11 @@ package workload
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"reflect"
+	"regexp"
+	"strings"
 	"testing"
 
 	"gotest.tools/assert"
@@ -17,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/yaml"
 
 	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
 	"github.com/AMD-AIG-AIMA/SAFE/apis/pkg/client/clientset/versioned/scheme"
@@ -678,4 +683,79 @@ func TestResolvePodSpecPathDoesNotAlias(t *testing.T) {
 	assert.DeepEqual(t, volumes, []string{"spec", "template", "spec", "volumes"})
 	assert.DeepEqual(t, containers, []string{"spec", "template", "spec", "containers"})
 	assert.DeepEqual(t, spec.PodSpecPaths, []string{"template", "spec"})
+}
+
+// chartResourceTemplatePath is the shipped ResourceTemplate data, relative to
+// this package. It is production input to ResolvePodSpecPath, not a fixture.
+const chartResourceTemplatePath = "../../../charts/primus-safe-cr/templates/resource_template/resource_template.yaml"
+
+// helmActionRE matches the Helm actions in the chart. Only metadata
+// annotations use them, so replacing each with a literal leaves parseable YAML.
+var helmActionRE = regexp.MustCompile(`{{[^}]*}}`)
+
+// loadChartResourceTemplates parses the shipped ResourceTemplates.
+func loadChartResourceTemplates(t *testing.T) []v1.ResourceTemplate {
+	t.Helper()
+	raw, err := os.ReadFile(chartResourceTemplatePath)
+	assert.NilError(t, err)
+	rendered := helmActionRE.ReplaceAllString(string(raw), "placeholder")
+
+	var templates []v1.ResourceTemplate
+	for _, doc := range strings.Split(rendered, "\n---\n") {
+		if strings.TrimSpace(doc) == "" {
+			continue
+		}
+		var rt v1.ResourceTemplate
+		assert.NilError(t, yaml.Unmarshal([]byte(doc), &rt))
+		if rt.Kind != "ResourceTemplate" {
+			continue
+		}
+		templates = append(templates, rt)
+	}
+	assert.Assert(t, len(templates) > 0)
+	return templates
+}
+
+// TestShippedResourceTemplatesDeclarePodSpecPaths validates the chart, which is
+// the production copy of the pod spec locations and is not otherwise covered:
+// job-manager's fixtures are a hand-maintained parallel copy, so nothing stops
+// the two from drifting.
+//
+// Every resourceSpec must declare podSpecPaths - a template added without them
+// falls back to PodSpecSegment silently - and the declaration must resolve to
+// the same path as that fallback, for the CR kind the readers pass and for
+// every SaFE workload kind the writers pass. A disagreement is the failure this
+// whole path exists to prevent: readers look where writers never wrote, drift
+// detection reports "unchanged", and spec updates are dropped without an error.
+func TestShippedResourceTemplatesDeclarePodSpecPaths(t *testing.T) {
+	checked := 0
+	for _, rt := range loadChartResourceTemplates(t) {
+		if len(rt.Spec.ResourceSpecs) == 0 {
+			// Pod and Event carry no pod spec of their own.
+			continue
+		}
+		kinds := []string{rt.Spec.GroupVersionKind.Kind}
+		if annotation := rt.Annotations[v1.WorkloadKindLabel]; annotation != "" {
+			for _, k := range strings.Split(annotation, ",") {
+				if k = strings.TrimSpace(k); k != "" {
+					kinds = append(kinds, k)
+				}
+			}
+		}
+
+		for i := range rt.Spec.ResourceSpecs {
+			spec := &rt.Spec.ResourceSpecs[i]
+			t.Run(fmt.Sprintf("%s/%d", rt.Name, i), func(t *testing.T) {
+				assert.Assert(t, len(spec.PodSpecPaths) > 0, "resourceSpec declares no podSpecPaths")
+				for _, kind := range kinds {
+					assert.DeepEqual(t, ResolvePodSpecPath(spec, kind, "containers"),
+						BuildPodSpecPath(spec.TemplatePath(), PodSpecSegment(kind), "containers"))
+				}
+				checked++
+			})
+		}
+	}
+	// The chart ships more than a couple of templates; a parse that quietly
+	// produced nothing must not read as a pass.
+	assert.Assert(t, checked > 10)
 }

--- a/SaFE/docs/apis/cicd-quickstart.md
+++ b/SaFE/docs/apis/cicd-quickstart.md
@@ -11,7 +11,7 @@ The build context directory must include this Dockerfile. The `setup-certs` step
 ```dockerfile
 FROM ubuntu:22.04
 
-ARG RUNNER_VERSION=2.333.1
+ARG RUNNER_VERSION=2.336.0
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/SaFE/job-manager/pkg/dispatcher/dispatcher.go
+++ b/SaFE/job-manager/pkg/dispatcher/dispatcher.go
@@ -562,6 +562,19 @@ func (r *DispatcherReconciler) syncWorkloadToObject(ctx context.Context, adminWo
 		return nil
 	}
 
+	// InferaDeployment is handed off to the Infera Operator the same way, and
+	// its create path adds flags that exist only on the IDEP: normalizeInferaIDEP
+	// appends the sglang disaggregation and multi-node args to each slot's
+	// launcher payload without writing them back to Workload.Spec.EntryPoints.
+	// Re-deriving the command from the Workload would strip
+	// --disaggregation-mode / --disaggregation-transfer-backend /
+	// --disaggregation-bootstrap-port and silently degrade a PD deployment to
+	// aggregated. Until the injected flags round-trip into the Workload, skip
+	// the sync instead of rewriting a command we cannot reproduce.
+	if commonworkload.IsInferaDeployment(adminWorkload) {
+		return nil
+	}
+
 	functions := []func(adminWorkload *v1.Workload, obj *unstructured.Unstructured, rt *v1.ResourceTemplate) bool{
 		isResourceChanged, isImagesChanged, isEntrypointChanged, isSharedMemoryChanged,
 		isEnvChanged, isPriorityClassChanged, isGithubSecretChanged,

--- a/SaFE/job-manager/pkg/dispatcher/dispatcher.go
+++ b/SaFE/job-manager/pkg/dispatcher/dispatcher.go
@@ -562,18 +562,9 @@ func (r *DispatcherReconciler) syncWorkloadToObject(ctx context.Context, adminWo
 		return nil
 	}
 
-	// InferaDeployment is handed off to the Infera Operator the same way, and
-	// its create path adds flags that exist only on the IDEP: normalizeInferaIDEP
-	// appends the sglang disaggregation and multi-node args to each slot's
-	// launcher payload without writing them back to Workload.Spec.EntryPoints.
-	// Re-deriving the command from the Workload would strip
-	// --disaggregation-mode / --disaggregation-transfer-backend /
-	// --disaggregation-bootstrap-port and silently degrade a PD deployment to
-	// aggregated. Until the injected flags round-trip into the Workload, skip
-	// the sync instead of rewriting a command we cannot reproduce.
-	if commonworkload.IsInferaDeployment(adminWorkload) {
-		return nil
-	}
+	// InferaDeployment syncs image, env, resources, shared memory and replicas
+	// through the generic flow below. Its launcher command is excluded, in
+	// isEntrypointChanged and updateContainers.
 
 	functions := []func(adminWorkload *v1.Workload, obj *unstructured.Unstructured, rt *v1.ResourceTemplate) bool{
 		isResourceChanged, isImagesChanged, isEntrypointChanged, isSharedMemoryChanged,
@@ -625,7 +616,10 @@ func isResourceChanged(adminWorkload *v1.Workload, obj *unstructured.Unstructure
 	}
 	if len(replicaList) == len(adminWorkload.Spec.Resources) {
 		for i := range replicaList {
-			if replicaList[i] != int64(adminWorkload.Spec.Resources[i].Replica) {
+			// expectedReplica yields the value updateReplica writes for this
+			// resource, which for an Infera multi-node role is 1 rather than
+			// Resources[i].Replica.
+			if replicaList[i] != expectedReplica(adminWorkload, i) {
 				return true
 			}
 		}
@@ -658,6 +652,13 @@ func isImagesChanged(adminWorkload *v1.Workload, obj *unstructured.Unstructured,
 
 // isEntrypointChanged checks if the entry point/command of the workload has changed.
 func isEntrypointChanged(adminWorkload *v1.Workload, obj *unstructured.Unstructured, rt *v1.ResourceTemplate) bool {
+	// Entrypoint is not a synced field for InferaDeployment. Its rendered
+	// command is a superset of buildEntryPoint's output: normalizeInferaIDEP
+	// injects the sglang disaggregation and multi-node flags the Workload does
+	// not already carry, and those additions live only on the object.
+	if commonworkload.IsInferaDeployment(adminWorkload) {
+		return false
+	}
 	commands, err := jobutils.GetCommands(obj, rt, len(adminWorkload.Spec.Resources))
 	if err != nil {
 		klog.ErrorS(err, "failed to get command", "obj", obj.GetName())

--- a/SaFE/job-manager/pkg/dispatcher/dispatcher.go
+++ b/SaFE/job-manager/pkg/dispatcher/dispatcher.go
@@ -562,8 +562,9 @@ func (r *DispatcherReconciler) syncWorkloadToObject(ctx context.Context, adminWo
 		return nil
 	}
 
-	// InferaDeployment syncs image, env, resources, shared memory and replicas
-	// through the generic flow below. Its launcher command is excluded, in
+	// InferaDeployment syncs image, env, resources, shared memory, replicas and
+	// the launcher command through the generic flow below. The command is
+	// rebuilt with the role's injected sglang flags re-grafted, in
 	// isEntrypointChanged and updateContainers.
 
 	functions := []func(adminWorkload *v1.Workload, obj *unstructured.Unstructured, rt *v1.ResourceTemplate) bool{
@@ -652,13 +653,6 @@ func isImagesChanged(adminWorkload *v1.Workload, obj *unstructured.Unstructured,
 
 // isEntrypointChanged checks if the entry point/command of the workload has changed.
 func isEntrypointChanged(adminWorkload *v1.Workload, obj *unstructured.Unstructured, rt *v1.ResourceTemplate) bool {
-	// Entrypoint is not a synced field for InferaDeployment. Its rendered
-	// command is a superset of buildEntryPoint's output: normalizeInferaIDEP
-	// injects the sglang disaggregation and multi-node flags the Workload does
-	// not already carry, and those additions live only on the object.
-	if commonworkload.IsInferaDeployment(adminWorkload) {
-		return false
-	}
 	commands, err := jobutils.GetCommands(obj, rt, len(adminWorkload.Spec.Resources))
 	if err != nil {
 		klog.ErrorS(err, "failed to get command", "obj", obj.GetName())
@@ -671,7 +665,13 @@ func isEntrypointChanged(adminWorkload *v1.Workload, obj *unstructured.Unstructu
 		if commonworkload.IsRayJob(adminWorkload) && i == 0 {
 			continue
 		}
-		newEntrypoint := buildEntryPoint(adminWorkload, i)
+		// expectedEntryPoint, not buildEntryPoint: an InferaDeployment's
+		// rendered command is buildEntryPoint's output plus the sglang flags
+		// normalizeInferaIDEP grafts on for that role. Comparing against the
+		// bare entrypoint would report drift on every reconcile for a
+		// prefill/decode or multi-node role; comparing against buildEntryPoint
+		// for every role would miss a real edit on the roles that get no flags.
+		newEntrypoint := expectedEntryPoint(adminWorkload, i)
 		oldCommand := commands[i]
 		if len(oldCommand) == 0 {
 			if newEntrypoint != "" {

--- a/SaFE/job-manager/pkg/dispatcher/dispatcher_help.go
+++ b/SaFE/job-manager/pkg/dispatcher/dispatcher_help.go
@@ -1052,15 +1052,40 @@ func convertEnvsToStringMap(envs []interface{}) map[string]string {
 	return result
 }
 
+// expectedReplica returns the replica count for Resources[id] as it appears in
+// the target object. It is Resources[id].Replica, except for an Infera
+// multi-node role, whose count is the node count of a single LeaderWorkerSet
+// group: normalizeInferaIDEP carries that in the flat numberOfNodes field and
+// sets replicas to 1. updateReplica and the drift check both take the value
+// from here.
+//
+// numberOfNodes is written at create time only. It also appears in the
+// launcher's --nnodes flag, which isEntrypointChanged excludes from the sync.
+func expectedReplica(adminWorkload *v1.Workload, id int) int64 {
+	if id >= len(adminWorkload.Spec.Resources) {
+		return 0
+	}
+	replica := int64(adminWorkload.Spec.Resources[id].Replica)
+	if !commonworkload.IsInferaDeployment(adminWorkload) || replica <= 1 {
+		return replica
+	}
+	roles := commonworkload.GetInferaServiceRoles(adminWorkload)
+	if id < len(roles) && commonworkload.IsInferaMultinodeRole(adminWorkload, roles[id]) {
+		klog.V(4).InfoS("infera multi-node role pins replicas=1; node count is fixed at create time",
+			"workload", adminWorkload.Name, "role", roles[id], "nodes", replica)
+		return 1
+	}
+	return replica
+}
+
 // updateReplica updates the replica count in the unstructured object.
 func updateReplica(adminWorkload *v1.Workload,
 	obj *unstructured.Unstructured, resourceSpec v1.ResourceSpec, id int) error {
 	if len(resourceSpec.ReplicasPaths) == 0 {
 		return nil
 	}
-	replica := int64(adminWorkload.Spec.Resources[id].Replica)
-	path := resourceSpec.PrePaths
-	path = append(path, resourceSpec.ReplicasPaths...)
+	replica := expectedReplica(adminWorkload, id)
+	path := resourceSpec.ReplicasPath()
 	if err := jobutils.SetNestedField(obj.Object, replica, path); err != nil {
 		return err
 	}
@@ -1079,9 +1104,7 @@ func updateMaxReplicas(obj *unstructured.Unstructured, resourceSpec v1.ResourceS
 	if len(resourceSpec.MaxReplicasPaths) == 0 {
 		return nil
 	}
-	path := resourceSpec.PrePaths
-	path = append(path, resourceSpec.MaxReplicasPaths...)
-	return jobutils.SetNestedField(obj.Object, replica, path)
+	return jobutils.SetNestedField(obj.Object, replica, resourceSpec.MaxReplicasPath())
 }
 
 // updateMinReplicas updates the min-replicas(for job, it's completions count) in the unstructured object. only for job or ray-job
@@ -1090,9 +1113,7 @@ func updateMinReplicas(obj *unstructured.Unstructured, resourceSpec v1.ResourceS
 	if len(resourceSpec.MinReplicasPaths) == 0 {
 		return nil
 	}
-	path := resourceSpec.PrePaths
-	path = append(path, resourceSpec.MinReplicasPaths...)
-	return jobutils.SetNestedField(obj.Object, replica, path)
+	return jobutils.SetNestedField(obj.Object, replica, resourceSpec.MinReplicasPath())
 }
 
 // updateCICDScaleSet updates the CICD scale set configuration in the unstructured object.
@@ -1863,6 +1884,13 @@ func updateMetadata(adminWorkload *v1.Workload,
 	if commonworkload.IsMonarchMesh(adminWorkload) {
 		return nil
 	}
+	// IDEP's extraPodSpec is a bare corev1.PodSpec with no metadata field; the
+	// CRD schema prunes anything written to extraPodSpec.metadata.
+	// normalizeInferaIDEP carries these labels on the slot's podLabels field
+	// instead, at create time.
+	if commonworkload.IsInferaDeployment(adminWorkload) {
+		return nil
+	}
 	if len(resourceSpec.TemplatePath()) > 0 {
 		_, found, err := jobutils.NestedMap(obj.Object, resourceSpec.TemplatePath())
 		if err != nil || !found {
@@ -1934,8 +1962,15 @@ func updateContainers(adminWorkload *v1.Workload,
 			if len(adminWorkload.Spec.Images) > id && adminWorkload.Spec.Images[id] != "" {
 				container["image"] = adminWorkload.Spec.Images[id]
 			}
-			if cmds := buildCommands(adminWorkload, id); len(cmds) > 0 {
-				container["command"] = cmds
+			// The IDEP command is set at create time by normalizeInferaIDEP,
+			// which appends disaggregation and multi-node flags that are absent
+			// from Workload.Spec.EntryPoints. buildCommands reproduces only the
+			// EntryPoints part, so the rendered command is left in place. This
+			// mirrors isEntrypointChanged, which excludes the same field.
+			if !commonworkload.IsInferaDeployment(adminWorkload) {
+				if cmds := buildCommands(adminWorkload, id); len(cmds) > 0 {
+					container["command"] = cmds
+				}
 			}
 		}
 	}
@@ -2016,7 +2051,7 @@ func updateSharedMemory(adminWorkload *v1.Workload, obj *unstructured.Unstructur
 	// podSpec raw inserted a "" path segment, writing the shared-memory volume to
 	// extraPodSpec."".volumes instead of extraPodSpec.volumes — leaving the
 	// container's /dev/shm mount dangling ("shared-memory" volume Not found).
-	templatePath := append(append([]string{}, resourceSpec.PrePaths...), resourceSpec.TemplatePaths...)
+	templatePath := resourceSpec.TemplatePath()
 	podSpec := getPodSpec(adminWorkload)
 	path := buildPodSpecPath(templatePath, podSpec, "volumes")
 	volumes, found, err := jobutils.NestedSlice(obj.Object, path)

--- a/SaFE/job-manager/pkg/dispatcher/dispatcher_help.go
+++ b/SaFE/job-manager/pkg/dispatcher/dispatcher_help.go
@@ -57,33 +57,31 @@ func initializeObject(obj *unstructured.Unstructured,
 	}
 
 	var err error
-	templatePath := resourceSpec.TemplatePath()
-	podSpec := getPodSpec(workload)
 
-	path := buildPodSpecPath(templatePath, podSpec,
+	path := podSpecPath(workload, resourceSpec,
 		"affinity", "nodeAffinity", "requiredDuringSchedulingIgnoredDuringExecution", "nodeSelectorTerms")
 	if err = modifyRequiredNodeAffinity(obj, workload, path); err != nil {
 		return fmt.Errorf("failed to modify nodeSelectorTerms: %v", err.Error())
 	}
 	if v1.IsRetryingOnOriginal(workload) || v1.GetNodesAffinity(workload) == common.NodesAffinityPreferred {
-		path = buildPodSpecPath(templatePath, podSpec,
+		path = podSpecPath(workload, resourceSpec,
 			"affinity", "nodeAffinity", "preferredDuringSchedulingIgnoredDuringExecution")
 		if err = modifyPreferredNodeAffinity(obj, workload, path); err != nil {
 			return fmt.Errorf("failed to modify preferredNodeAffinity: %v", err.Error())
 		}
 	}
 	if v1.IsRequireNodeSpread(workload) {
-		path = buildPodSpecPath(templatePath, podSpec,
+		path = podSpecPath(workload, resourceSpec,
 			"affinity", "podAntiAffinity", "requiredDuringSchedulingIgnoredDuringExecution")
 		if err = modifyPodAntiAffinity(obj, workload, path); err != nil {
 			return fmt.Errorf("failed to modify podAntiAffinity: %v", err.Error())
 		}
 	}
-	path = buildPodSpecPath(templatePath, podSpec, "containers")
+	path = podSpecPath(workload, resourceSpec, "containers")
 	if err = modifyContainers(obj, workload, workspace, path, resourceId); err != nil {
 		return fmt.Errorf("failed to modify main container: %v", err.Error())
 	}
-	path = buildPodSpecPath(templatePath, podSpec, "volumes")
+	path = podSpecPath(workload, resourceSpec, "volumes")
 	if err = modifyVolumes(obj, workload, workspace, path); err != nil {
 		return fmt.Errorf("failed to modify volumes: %v", err.Error())
 	}
@@ -92,27 +90,27 @@ func initializeObject(obj *unstructured.Unstructured,
 	// sidecar) can resolve `docker run -v <path>` bind mounts. The matching
 	// pod-level volumes were just added by modifyVolumes; only the volumeMounts
 	// need to be applied here. This is a no-op for kinds without init containers.
-	path = buildPodSpecPath(templatePath, podSpec, "initContainers")
+	path = podSpecPath(workload, resourceSpec, "initContainers")
 	if err = modifyInitContainerVolumeMounts(obj, workload, workspace, path); err != nil {
 		return fmt.Errorf("failed to modify init containers: %v", err.Error())
 	}
-	path = buildPodSpecPath(templatePath, podSpec, "imagePullSecrets")
+	path = podSpecPath(workload, resourceSpec, "imagePullSecrets")
 	if err = modifyImageSecrets(obj, workload, path); err != nil {
 		return fmt.Errorf("failed to modify image secrets: %v", err.Error())
 	}
-	path = buildPodSpecPath(templatePath, podSpec, "priorityClassName")
+	path = podSpecPath(workload, resourceSpec, "priorityClassName")
 	if err = modifyPriorityClass(obj, workload, path); err != nil {
 		return fmt.Errorf("failed to modify priority: %v", err.Error())
 	}
-	path = buildPodSpecPath(templatePath, podSpec, "serviceAccountName")
+	path = podSpecPath(workload, resourceSpec, "serviceAccountName")
 	if err = modifyServiceAccountName(obj, workload, path); err != nil {
 		return fmt.Errorf("failed to modify sa: %v", err.Error())
 	}
-	path = buildPodSpecPath(templatePath, podSpec, "hostNetwork")
+	path = podSpecPath(workload, resourceSpec, "hostNetwork")
 	if err = modifyHostNetwork(obj, workload, path, resourceId); err != nil {
 		return fmt.Errorf("failed to modify host network: %v", err.Error())
 	}
-	path = buildPodSpecPath(templatePath, podSpec, "tolerations")
+	path = podSpecPath(workload, resourceSpec, "tolerations")
 	if err = modifyTolerations(obj, workload, path); err != nil {
 		return fmt.Errorf("failed to modify tolerations: %v", err.Error())
 	}
@@ -126,7 +124,7 @@ func initializeObject(obj *unstructured.Unstructured,
 			return fmt.Errorf("failed to modify selector: %v", err.Error())
 		}
 	}
-	if err = modifyHostPid(obj, workload, templatePath); err != nil {
+	if err = modifyHostPid(obj, workload, resourceSpec); err != nil {
 		return fmt.Errorf("failed to modify by opsjob: %v", err.Error())
 	}
 	return nil
@@ -601,16 +599,15 @@ func modifyHostNetwork(obj *unstructured.Unstructured, workload *v1.Workload, pa
 }
 
 // modifyHostPid configures host PID and IPC settings for OpsJob preflight operations.
-func modifyHostPid(obj *unstructured.Unstructured, workload *v1.Workload, templatePath []string) error {
+func modifyHostPid(obj *unstructured.Unstructured, workload *v1.Workload, resourceSpec *v1.ResourceSpec) error {
 	if !v1.IsPrivileged(workload) {
 		return nil
 	}
-	podSpec := getPodSpec(workload)
-	path := buildPodSpecPath(templatePath, podSpec, "hostPID")
+	path := podSpecPath(workload, resourceSpec, "hostPID")
 	if err := jobutils.SetNestedField(obj.Object, true, path); err != nil {
 		return err
 	}
-	path = buildPodSpecPath(templatePath, podSpec, "hostIPC")
+	path = podSpecPath(workload, resourceSpec, "hostIPC")
 	if err := jobutils.SetNestedField(obj.Object, true, path); err != nil {
 		return err
 	}
@@ -2045,15 +2042,7 @@ func updateSharedMemory(adminWorkload *v1.Workload, obj *unstructured.Unstructur
 	if adminWorkload.Spec.Resources[id].SharedMemory == "" {
 		return nil
 	}
-	// Build [<prePaths>, <templatePaths>, <podSpec?>, volumes] via buildPodSpecPath
-	// so the empty podSpec segment is omitted for kinds whose extraPodSpec embeds
-	// PodSpec inline (DGD / InferaDeployment, getPodSpec == ""). Appending
-	// podSpec raw inserted a "" path segment, writing the shared-memory volume to
-	// extraPodSpec."".volumes instead of extraPodSpec.volumes — leaving the
-	// container's /dev/shm mount dangling ("shared-memory" volume Not found).
-	templatePath := resourceSpec.TemplatePath()
-	podSpec := getPodSpec(adminWorkload)
-	path := buildPodSpecPath(templatePath, podSpec, "volumes")
+	path := podSpecPath(adminWorkload, &resourceSpec, "volumes")
 	volumes, found, err := jobutils.NestedSlice(obj.Object, path)
 	if err != nil {
 		return err
@@ -2085,31 +2074,21 @@ func updateSharedMemory(adminWorkload *v1.Workload, obj *unstructured.Unstructur
 // updateHostNetwork updates the host network configuration.
 func updateHostNetwork(adminWorkload *v1.Workload,
 	obj *unstructured.Unstructured, resourceSpec v1.ResourceSpec, resourceId int) error {
-	templatePath := resourceSpec.TemplatePath()
-	podSpec := getPodSpec(adminWorkload)
-	path := buildPodSpecPath(templatePath, podSpec, "hostNetwork")
+	path := podSpecPath(adminWorkload, &resourceSpec, "hostNetwork")
 	return modifyHostNetwork(obj, adminWorkload, path, resourceId)
 }
 
 // updatePriorityClass updates the priority class configuration.
 func updatePriorityClass(adminWorkload *v1.Workload,
 	obj *unstructured.Unstructured, resourceSpec v1.ResourceSpec) error {
-	templatePath := resourceSpec.TemplatePath()
-	podSpec := getPodSpec(adminWorkload)
-	path := buildPodSpecPath(templatePath, podSpec, "priorityClassName")
+	path := podSpecPath(adminWorkload, &resourceSpec, "priorityClassName")
 	return modifyPriorityClass(obj, adminWorkload, path)
 }
 
 // getContainers retrieves the containers slice and its path from the unstructured object based on the resource specification.
 // Returns the containers slice, the path to the containers field, and an error if the operation fails or no containers are found.
 func getContainers(adminWorkload *v1.Workload, obj *unstructured.Unstructured, resourceSpec v1.ResourceSpec) ([]interface{}, []string, error) {
-	templatePath := resourceSpec.TemplatePath()
-	podSpec := getPodSpec(adminWorkload)
-	// DGD ExtraPodSpec embeds PodSpec inline, so containers live directly under
-	// extraPodSpec (no nested "spec" wrapper). PyTorchJob / Deployment / RayJob
-	// all wrap pods in template.spec.containers and keep the "spec" segment.
-	// buildPodSpecPath omits the empty podSpec segment automatically.
-	path := buildPodSpecPath(templatePath, podSpec, "containers")
+	path := podSpecPath(adminWorkload, &resourceSpec, "containers")
 	containers, found, err := jobutils.NestedSlice(obj.Object, path)
 	if err != nil {
 		return nil, nil, err
@@ -2153,17 +2132,13 @@ func buildDispatchCount(w *v1.Workload) string {
 	return strconv.Itoa(v1.GetWorkloadDispatchCnt(w) + 1)
 }
 
-// getPodSpec resolves the pod spec path segment for this workload's kind. The
-// readers in jobutils resolve the same segment from the ResourceTemplate kind,
-// so both sides stay in sync through commonworkload.PodSpecSegment.
-func getPodSpec(w *v1.Workload) string {
-	return commonworkload.PodSpecSegment(w.SpecKind())
-}
-
-// buildPodSpecPath constructs a path of the form
-// [templatePath..., podSpec, fields...] but omits podSpec when it is empty.
-func buildPodSpecPath(templatePath []string, podSpec string, fields ...string) []string {
-	return commonworkload.BuildPodSpecPath(templatePath, podSpec, fields...)
+// podSpecPath resolves the absolute path to this resource spec's pod spec,
+// followed by fields. The location comes from the ResourceTemplate's
+// podSpecPaths, which the readers in jobutils resolve from the same field, so
+// both sides address the same node of the object. Each call returns a fresh
+// slice.
+func podSpecPath(w *v1.Workload, resourceSpec *v1.ResourceSpec, fields ...string) []string {
+	return commonworkload.ResolvePodSpecPath(resourceSpec, w.SpecKind(), fields...)
 }
 
 func generateUserDir(userId string) string {

--- a/SaFE/job-manager/pkg/dispatcher/dispatcher_help.go
+++ b/SaFE/job-manager/pkg/dispatcher/dispatcher_help.go
@@ -1959,12 +1959,14 @@ func updateContainers(adminWorkload *v1.Workload,
 			if len(adminWorkload.Spec.Images) > id && adminWorkload.Spec.Images[id] != "" {
 				container["image"] = adminWorkload.Spec.Images[id]
 			}
-			// The IDEP command is set at create time by normalizeInferaIDEP,
-			// which appends disaggregation and multi-node flags that are absent
-			// from Workload.Spec.EntryPoints. buildCommands reproduces only the
-			// EntryPoints part, so the rendered command is left in place. This
-			// mirrors isEntrypointChanged, which excludes the same field.
-			if !commonworkload.IsInferaDeployment(adminWorkload) {
+			// An IDEP command carries the disaggregation and multi-node flags
+			// that normalizeInferaIDEP appends on top of buildCommands and that
+			// Workload.Spec.EntryPoints does not describe, so an IDEP container
+			// that already holds one keeps it. This mirrors isEntrypointChanged,
+			// which excludes the same field. A container with no command yet is
+			// on the create path, where buildCommands produces the launcher form
+			// that normalizeInferaIDEP then appends its flags to.
+			if !commonworkload.IsInferaDeployment(adminWorkload) || !hasCommand(container) {
 				if cmds := buildCommands(adminWorkload, id); len(cmds) > 0 {
 					container["command"] = cmds
 				}
@@ -1975,6 +1977,12 @@ func updateContainers(adminWorkload *v1.Workload,
 		return err
 	}
 	return nil
+}
+
+// hasCommand reports whether a rendered container already carries a command.
+func hasCommand(container map[string]interface{}) bool {
+	cmd, ok := container["command"].([]interface{})
+	return ok && len(cmd) > 0
 }
 
 // updateContainerEnv updates environment variables in the container.

--- a/SaFE/job-manager/pkg/dispatcher/dispatcher_help.go
+++ b/SaFE/job-manager/pkg/dispatcher/dispatcher_help.go
@@ -739,6 +739,71 @@ func entrypointsEqual(newEp, oldEp string) bool {
 	return false
 }
 
+// inferaLauncherFlags returns the launcher flags normalizeInferaIDEP grafts
+// onto the Resources[id] slot's command on top of buildCommands: the sglang
+// disaggregation flags for a prefill/decode role, and the multi-node flags for
+// a role declared multi-node with more than one node. It returns "" for a role
+// that gets neither - frontend, and a worker that is not multi-node - whose
+// rendered command is therefore exactly what buildCommands produces.
+//
+// The concatenation order matches normalizeInferaIDEP, which runs
+// applyInferaRoleFields before appendSglangMultinodeArgs. The two flag sets
+// share no flag name, so appending them in one pass drops the same
+// user-declared flags (stripUserDeclaredFlags) that two passes would.
+func inferaLauncherFlags(adminWorkload *v1.Workload, id int) string {
+	if !commonworkload.IsInferaDeployment(adminWorkload) || id >= len(adminWorkload.Spec.Resources) {
+		return ""
+	}
+	roles := commonworkload.GetInferaServiceRoles(adminWorkload)
+	if id >= len(roles) {
+		return ""
+	}
+	role := roles[id]
+	flags := make([]string, 0, 2)
+	switch role {
+	case common.DynamoRolePrefill, common.DynamoRoleDecode:
+		flags = append(flags, sglangDisaggFlags(role, commonworkload.GetInferaKVTransferBackend(adminWorkload)))
+	}
+	if n := adminWorkload.Spec.Resources[id].Replica; n > 1 &&
+		commonworkload.IsInferaMultinodeRole(adminWorkload, role) {
+		flags = append(flags, sglangMultinodeFlags(n))
+	}
+	return strings.Join(flags, " ")
+}
+
+// expectedCommands returns the command the object should carry for
+// Resources[id]: buildCommands, plus for an InferaDeployment the flags
+// normalizeInferaIDEP injects on top of it. Rebuilding an IDEP command through
+// here is what lets the sync path apply an entrypoint edit without dropping
+// the disaggregation and multi-node flags the Workload spec does not describe.
+func expectedCommands(adminWorkload *v1.Workload, id int) []interface{} {
+	cmds := buildCommands(adminWorkload, id)
+	flags := inferaLauncherFlags(adminWorkload, id)
+	if len(cmds) == 0 || flags == "" {
+		return cmds
+	}
+	if out, ok := appendLauncherArgs(cmds, flags); ok {
+		return out
+	}
+	return cmds
+}
+
+// expectedEntryPoint is the read side of expectedCommands: the entry the
+// rendered command is compared against by isEntrypointChanged. Keeping the two
+// in step is what keeps a steady-state IDEP from reporting drift on every
+// reconcile.
+func expectedEntryPoint(adminWorkload *v1.Workload, id int) string {
+	ep := buildEntryPoint(adminWorkload, id)
+	flags := inferaLauncherFlags(adminWorkload, id)
+	if ep == "" || flags == "" {
+		return ep
+	}
+	if out, ok := appendLauncherFlags(ep, flags); ok {
+		return out
+	}
+	return ep
+}
+
 // buildObjectLabels creates a map of labels for object tracking.
 func buildObjectLabels(workload *v1.Workload) map[string]interface{} {
 	result := map[string]interface{}{
@@ -1719,25 +1784,38 @@ func appendLauncherArgs(cmd []interface{}, extraFlags string) ([]interface{}, bo
 	if !ok {
 		return nil, false
 	}
+	rewritten, ok := appendLauncherFlags(full, extraFlags)
+	if !ok {
+		return nil, false
+	}
+	out := make([]interface{}, len(cmd))
+	copy(out, cmd)
+	out[2] = rewritten
+	return out, true
+}
+
+// appendLauncherFlags is the string half of appendLauncherArgs: it appends
+// extraFlags to the base64 payload of a single launcher-style entry
+// (`[exec ]/bin/sh /shared-data/launcher.sh <base64>`), leaving the launcher
+// prefix untouched. Returns ("", false) when the entry is not in launcher form
+// or its payload does not decode, so callers can fall back to the entry as-is.
+func appendLauncherFlags(full, extraFlags string) (string, bool) {
 	payload, ok := launcherEntryPayload(full)
 	if !ok || payload == "" {
-		return nil, false
+		return "", false
 	}
 	decoded := stringutil.Base64Decode(payload)
 	if decoded == "" {
-		return nil, false
+		return "", false
 	}
 	filtered := stripUserDeclaredFlags(extraFlags, decoded)
 	if filtered == "" {
-		return cmd, true
+		return full, true
 	}
 	decoded = strings.TrimRight(decoded, "\n")
 	newPayload := stringutil.Base64Encode(decoded + " " + filtered)
 	prefix := full[:strings.LastIndex(full, payload)]
-	out := make([]interface{}, len(cmd))
-	copy(out, cmd)
-	out[2] = prefix + newPayload
-	return out, true
+	return prefix + newPayload, true
 }
 
 // stripUserDeclaredFlags returns extraFlags with any "--name value" pair
@@ -1959,17 +2037,16 @@ func updateContainers(adminWorkload *v1.Workload,
 			if len(adminWorkload.Spec.Images) > id && adminWorkload.Spec.Images[id] != "" {
 				container["image"] = adminWorkload.Spec.Images[id]
 			}
-			// An IDEP command carries the disaggregation and multi-node flags
-			// that normalizeInferaIDEP appends on top of buildCommands and that
-			// Workload.Spec.EntryPoints does not describe, so an IDEP container
-			// that already holds one keeps it. This mirrors isEntrypointChanged,
-			// which excludes the same field. A container with no command yet is
-			// on the create path, where buildCommands produces the launcher form
-			// that normalizeInferaIDEP then appends its flags to.
-			if !commonworkload.IsInferaDeployment(adminWorkload) || !hasCommand(container) {
-				if cmds := buildCommands(adminWorkload, id); len(cmds) > 0 {
-					container["command"] = cmds
-				}
+			// expectedCommands, not buildCommands: an IDEP command carries the
+			// disaggregation and multi-node flags normalizeInferaIDEP grafts on
+			// top of the launcher payload, which Workload.Spec.EntryPoints does
+			// not describe. Rebuilding through expectedCommands re-grafts them,
+			// so an entrypoint or image edit reaches the object without
+			// degrading a PD deployment to aggregated. On the create path the
+			// flags are then a no-op for normalizeInferaIDEP, whose per-flag
+			// dedup sees them already present.
+			if cmds := expectedCommands(adminWorkload, id); len(cmds) > 0 {
+				container["command"] = cmds
 			}
 		}
 	}
@@ -1977,12 +2054,6 @@ func updateContainers(adminWorkload *v1.Workload,
 		return err
 	}
 	return nil
-}
-
-// hasCommand reports whether a rendered container already carries a command.
-func hasCommand(container map[string]interface{}) bool {
-	cmd, ok := container["command"].([]interface{})
-	return ok && len(cmd) > 0
 }
 
 // updateContainerEnv updates environment variables in the container.

--- a/SaFE/job-manager/pkg/dispatcher/dispatcher_help.go
+++ b/SaFE/job-manager/pkg/dispatcher/dispatcher_help.go
@@ -1864,7 +1864,7 @@ func (r *DispatcherReconciler) updateSandbox(ctx context.Context, clientSets *sy
 		return fmt.Errorf("no resource specs found")
 	}
 	if adminWorkload.GetTimeout() > 0 {
-		path := append(rt.Spec.ResourceSpecs[0].PrePaths, "shutdownTime")
+		path := rt.Spec.ResourceSpecs[0].Path("shutdownTime")
 		timeoutSeconds := adminWorkload.GetTimeout() + 120
 		shutdownTime := time.Now().Add(time.Duration(timeoutSeconds) * time.Second)
 		shutdownTimeStr := shutdownTime.UTC().Format(timeutil.TimeRFC3339Milli)

--- a/SaFE/job-manager/pkg/dispatcher/dispatcher_help.go
+++ b/SaFE/job-manager/pkg/dispatcher/dispatcher_help.go
@@ -2118,43 +2118,17 @@ func buildDispatchCount(w *v1.Workload) string {
 	return strconv.Itoa(v1.GetWorkloadDispatchCnt(w) + 1)
 }
 
+// getPodSpec resolves the pod spec path segment for this workload's kind. The
+// readers in jobutils resolve the same segment from the ResourceTemplate kind,
+// so both sides stay in sync through commonworkload.PodSpecSegment.
 func getPodSpec(w *v1.Workload) string {
-	if commonworkload.IsMonarchMesh(w) {
-		return "podTemplate"
-	}
-	// DGD `extraPodSpec` embeds PodSpec inline (see dynamo
-	// operator/api/v1alpha1/common.go::ExtraPodSpec), so the rendered yaml has
-	// containers directly under extraPodSpec rather than under the standard
-	// pyt./dep./ray "template.spec.containers" path. InferaDeployment
-	// (InferaDeployment) uses the same inline-PodSpec shape (ServiceSpec.
-	// ExtraPodSpec is a core/v1 PodSpec), so it resolves identically. This
-	// single branch makes the entire generic flow (container/env/resource
-	// injection, volume mounts, hostNetwork, sharedMemory, ...) target
-	// extraPodSpec.* for both kinds.
-	if commonworkload.IsDynamoDeployment(w) || commonworkload.IsInferaDeployment(w) {
-		return ""
-	}
-	return "spec"
+	return commonworkload.PodSpecSegment(w.SpecKind())
 }
 
 // buildPodSpecPath constructs a path of the form
 // [templatePath..., podSpec, fields...] but omits podSpec when it is empty.
-//
-// CRDs like DGD have ExtraPodSpec embedding PodSpec inline; their
-// ResourceTemplate.templatePaths already points at the pod spec so there is
-// no extra "spec" / "podTemplate" wrapper to traverse. getPodSpec returns ""
-// for these kinds. Using this helper everywhere keeps callers from
-// accidentally emitting "" as a path segment (which would write to or look
-// up a non-existent map key named "" — causing CRD schema warnings and
-// dispatcher path-not-found failures).
 func buildPodSpecPath(templatePath []string, podSpec string, fields ...string) []string {
-	out := make([]string, 0, len(templatePath)+1+len(fields))
-	out = append(out, templatePath...)
-	if podSpec != "" {
-		out = append(out, podSpec)
-	}
-	out = append(out, fields...)
-	return out
+	return commonworkload.BuildPodSpecPath(templatePath, podSpec, fields...)
 }
 
 func generateUserDir(userId string) string {

--- a/SaFE/job-manager/pkg/dispatcher/dispatcher_help.go
+++ b/SaFE/job-manager/pkg/dispatcher/dispatcher_help.go
@@ -42,6 +42,11 @@ const (
 
 	sandboxAuthPublicKeyEnvName = "ENVD_AUTH_PUBLIC_KEY"
 	sandboxSecretPublicPemKey   = "public.pem"
+
+	// inferaNodeCountField is the flat IDEP ServiceSpec field carrying the node
+	// count of a multi-node role's LeaderWorkerSet group. Written by
+	// normalizeInferaIDEP on create and by updateInferaNodeCount on sync.
+	inferaNodeCountField = "numberOfNodes"
 )
 
 // initializeObject modifies various aspects of a Kubernetes object during workload creation.
@@ -1121,8 +1126,9 @@ func convertEnvsToStringMap(envs []interface{}) map[string]string {
 // sets replicas to 1. updateReplica and the drift check both take the value
 // from here.
 //
-// numberOfNodes is written at create time only. It also appears in the
-// launcher's --nnodes flag, which isEntrypointChanged excludes from the sync.
+// The node count itself reaches the object twice: as numberOfNodes, which
+// updateInferaNodeCount keeps in step, and inside the launcher's --nnodes flag,
+// which expectedCommands rebuilds. Both have to move together.
 func expectedReplica(adminWorkload *v1.Workload, id int) int64 {
 	if id >= len(adminWorkload.Spec.Resources) {
 		return 0
@@ -1143,6 +1149,9 @@ func expectedReplica(adminWorkload *v1.Workload, id int) int64 {
 // updateReplica updates the replica count in the unstructured object.
 func updateReplica(adminWorkload *v1.Workload,
 	obj *unstructured.Unstructured, resourceSpec v1.ResourceSpec, id int) error {
+	if err := updateInferaNodeCount(adminWorkload, obj, resourceSpec, id); err != nil {
+		return err
+	}
 	if len(resourceSpec.ReplicasPaths) == 0 {
 		return nil
 	}
@@ -1158,6 +1167,33 @@ func updateReplica(adminWorkload *v1.Workload,
 		return err
 	}
 	return nil
+}
+
+// updateInferaNodeCount keeps an IDEP slot's numberOfNodes in step with
+// Resources[id].Replica for a multi-node role.
+//
+// normalizeInferaIDEP writes the field on create only, but the same node count
+// also reaches the object through the launcher's --nnodes flag, which the sync
+// path rebuilds (expectedCommands). Scaling a multi-node role would otherwise
+// leave a LeaderWorkerSet group of the old size running --nnodes with the new
+// one: the rendezvous never completes, and because replicas stays pinned at 1
+// the next reconcile sees no drift, so the broken state is stable and silent.
+//
+// The field is removed rather than set to 1 when the role is no longer
+// multi-node or has scaled down to a single node, which is the shape
+// normalizeInferaIDEP produces for that case.
+func updateInferaNodeCount(adminWorkload *v1.Workload,
+	obj *unstructured.Unstructured, resourceSpec v1.ResourceSpec, id int) error {
+	if !commonworkload.IsInferaDeployment(adminWorkload) || id >= len(adminWorkload.Spec.Resources) {
+		return nil
+	}
+	path := resourceSpec.Path(inferaNodeCountField)
+	roles := commonworkload.GetInferaServiceRoles(adminWorkload)
+	n := adminWorkload.Spec.Resources[id].Replica
+	if n <= 1 || id >= len(roles) || !commonworkload.IsInferaMultinodeRole(adminWorkload, roles[id]) {
+		return jobutils.RemoveNestedField(obj.Object, path)
+	}
+	return jobutils.SetNestedField(obj.Object, int64(n), path)
 }
 
 // updateMaxReplicas updates the max-replicas in the unstructured object. only for ray-job
@@ -1561,7 +1597,7 @@ func normalizeInferaIDEP(obj *unstructured.Unstructured, adminWorkload *v1.Workl
 			i < len(adminWorkload.Spec.Resources) {
 			if n := adminWorkload.Spec.Resources[i].Replica; n > 1 {
 				appendSglangMultinodeArgs(slot, n)
-				slot["numberOfNodes"] = int64(n)
+				slot[inferaNodeCountField] = int64(n)
 				slot["replicas"] = int64(1)
 			}
 		}
@@ -1814,8 +1850,15 @@ func appendLauncherFlags(full, extraFlags string) (string, bool) {
 	}
 	decoded = strings.TrimRight(decoded, "\n")
 	newPayload := stringutil.Base64Encode(decoded + " " + filtered)
-	prefix := full[:strings.LastIndex(full, payload)]
-	return prefix + newPayload, true
+	// Splice the new payload in where the old one sat, keeping whatever
+	// surrounds it. launcherEntryPayload trims the quotes off a quoted payload,
+	// so dropping the tail here would return an entry with an opening quote and
+	// no closing one.
+	at := strings.LastIndex(full, payload)
+	if at < 0 {
+		return "", false
+	}
+	return full[:at] + newPayload + full[at+len(payload):], true
 }
 
 // stripUserDeclaredFlags returns extraFlags with any "--name value" pair

--- a/SaFE/job-manager/pkg/dispatcher/dispatcher_help_test.go
+++ b/SaFE/job-manager/pkg/dispatcher/dispatcher_help_test.go
@@ -2163,6 +2163,171 @@ func TestUpdateReplicaInfera(t *testing.T) {
 	assert.Equal(t, decode, int64(1))
 }
 
+// TestUpdateInferaNodeCount pins the field that has to move with --nnodes.
+// A multi-node role's node count reaches the object twice - as numberOfNodes
+// and inside the launcher flag - and the two disagreeing is silent: replicas
+// stays 1, so no drift check fires, and the LeaderWorkerSet group never
+// finishes its rendezvous.
+func TestUpdateInferaNodeCount(t *testing.T) {
+	roles := []string{common.DynamoRoleFrontend, common.DynamoRoleDecode}
+	nodesPath := []string{"spec", "services", "role1", "numberOfNodes"}
+
+	t.Run("scale up rewrites numberOfNodes and --nnodes together", func(t *testing.T) {
+		// The object as create left it: a two-node decode group.
+		workload := newInferaWorkload(roles, []string{common.DynamoRoleDecode}, []int{1, 2})
+		workload.Spec.EntryPoints = []string{"", stringutil.Base64Encode("serve --model /models/m")}
+		obj := inferaObject(nil, expectedCommands(workload, 1))
+		assert.NilError(t, jobutils.SetNestedField(obj.Object, int64(2), nodesPath))
+
+		// The user scales the decode role to four nodes.
+		workload.Spec.Resources[1].Replica = 4
+		assert.NilError(t, updateReplica(workload, obj, inferaResourceSpec(1), 1))
+		assert.NilError(t, updateContainers(workload, obj, inferaResourceSpec(1), 1))
+
+		nodes, found, err := jobutils.NestedInt64(obj.Object, nodesPath)
+		assert.NilError(t, err)
+		assert.Equal(t, found, true)
+		assert.Equal(t, nodes, int64(4))
+
+		payload := decodedPayload(t, inferaMainContainer(t, obj, 1)["command"])
+		assert.Assert(t, strings.Contains(payload, "--nnodes 4"),
+			"launcher flag must agree with numberOfNodes, got %q", payload)
+		assert.Equal(t, strings.Count(payload, "--nnodes "), 1)
+
+		// replicas stays pinned at one group, which is why nothing else would
+		// have caught the mismatch.
+		replicas, found, err := jobutils.NestedInt64(obj.Object, []string{"spec", "services", "role1", "replicas"})
+		assert.NilError(t, err)
+		assert.Equal(t, found, true)
+		assert.Equal(t, replicas, int64(1))
+	})
+
+	t.Run("scale down to one node removes numberOfNodes", func(t *testing.T) {
+		workload := newInferaWorkload(roles, []string{common.DynamoRoleDecode}, []int{1, 1})
+		obj := inferaObject(nil, nil)
+		assert.NilError(t, jobutils.SetNestedField(obj.Object, int64(4), nodesPath))
+
+		assert.NilError(t, updateReplica(workload, obj, inferaResourceSpec(1), 1))
+
+		_, found, err := jobutils.NestedInt64(obj.Object, nodesPath)
+		assert.NilError(t, err)
+		assert.Equal(t, found, false,
+			"a single-node role must not keep a stale numberOfNodes")
+
+		// This is the shape normalizeInferaIDEP produces for one node: the
+		// field absent and replicas carrying the count.
+		replicas, found, err := jobutils.NestedInt64(obj.Object, []string{"spec", "services", "role1", "replicas"})
+		assert.NilError(t, err)
+		assert.Equal(t, found, true)
+		assert.Equal(t, replicas, int64(1))
+	})
+
+	t.Run("role dropped from multinode-roles removes numberOfNodes", func(t *testing.T) {
+		workload := newInferaWorkload(roles, nil, []int{1, 4})
+		obj := inferaObject(nil, nil)
+		assert.NilError(t, jobutils.SetNestedField(obj.Object, int64(4), nodesPath))
+
+		assert.NilError(t, updateReplica(workload, obj, inferaResourceSpec(1), 1))
+
+		_, found, err := jobutils.NestedInt64(obj.Object, nodesPath)
+		assert.NilError(t, err)
+		assert.Equal(t, found, false)
+
+		// No longer multi-node, so the role scales as replicas again.
+		replicas, found, err := jobutils.NestedInt64(obj.Object, []string{"spec", "services", "role1", "replicas"})
+		assert.NilError(t, err)
+		assert.Equal(t, found, true)
+		assert.Equal(t, replicas, int64(4))
+	})
+
+	t.Run("non-infera object is untouched", func(t *testing.T) {
+		pytorch := &v1.Workload{
+			ObjectMeta: metav1.ObjectMeta{Name: "pyt"},
+			Spec: v1.WorkloadSpec{
+				GroupVersionKind: v1.GroupVersionKind{Kind: common.PytorchJobKind, Version: common.DefaultVersion},
+				Resources:        []v1.WorkloadResource{{Replica: 2}},
+			},
+		}
+		obj := &unstructured.Unstructured{Object: map[string]interface{}{
+			"spec": map[string]interface{}{"numberOfNodes": int64(7)},
+		}}
+		spec := v1.ResourceSpec{PrePaths: []string{"spec"}, ReplicasPaths: []string{"replicas"}}
+		assert.NilError(t, updateReplica(pytorch, obj, spec, 0))
+
+		nodes, found, err := jobutils.NestedInt64(obj.Object, []string{"spec", "numberOfNodes"})
+		assert.NilError(t, err)
+		assert.Equal(t, found, true)
+		assert.Equal(t, nodes, int64(7))
+	})
+}
+
+// TestInferaNodeCountMatchesCreatePath ties the sync write to the create write:
+// normalizeInferaIDEP and updateInferaNodeCount must land on the same field at
+// the same path, or the sync silently writes a sibling nobody reads.
+func TestInferaNodeCountMatchesCreatePath(t *testing.T) {
+	roles := []string{common.DynamoRoleFrontend, common.DynamoRoleDecode}
+	workload := newInferaWorkload(roles, []string{common.DynamoRoleDecode}, []int{1, 3})
+	workload.Spec.EntryPoints = []string{"", stringutil.Base64Encode("serve --model /models/m")}
+
+	created := inferaObject(nil, nil)
+	for i := range roles {
+		assert.NilError(t, updateContainers(workload, created, inferaResourceSpec(i), i))
+		assert.NilError(t, updateReplica(workload, created, inferaResourceSpec(i), i))
+	}
+	assert.NilError(t, normalizeInferaIDEP(created, workload))
+
+	synced := inferaObject(nil, nil)
+	for i := range roles {
+		assert.NilError(t, updateContainers(workload, synced, inferaResourceSpec(i), i))
+		assert.NilError(t, updateReplica(workload, synced, inferaResourceSpec(i), i))
+	}
+
+	path := []string{"spec", "services", "role1", "numberOfNodes"}
+	fromCreate, found, err := jobutils.NestedInt64(created.Object, path)
+	assert.NilError(t, err)
+	assert.Equal(t, found, true)
+	fromSync, found, err := jobutils.NestedInt64(synced.Object, path)
+	assert.NilError(t, err)
+	assert.Equal(t, found, true)
+	assert.Equal(t, fromSync, fromCreate)
+	assert.Equal(t, fromSync, int64(3))
+}
+
+// TestAppendLauncherFlagsKeepsQuoting pins the splice: launcherEntryPayload
+// strips the quotes off a quoted payload, so rebuilding the entry from the
+// prefix alone would drop the closing quote and hand the shell an unterminated
+// string.
+func TestAppendLauncherFlagsKeepsQuoting(t *testing.T) {
+	encoded := stringutil.Base64Encode("python -m sglang.launch_server")
+
+	cases := []struct {
+		name string
+		full string
+	}{
+		{name: "bare payload", full: "exec " + Launcher + " " + encoded},
+		{name: "single quoted", full: "exec " + Launcher + " '" + encoded + "'"},
+		{name: "double quoted", full: "exec " + Launcher + " \"" + encoded + "\""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			out, ok := appendLauncherFlags(c.full, "--nnodes 2")
+			assert.Assert(t, ok)
+
+			// The launcher prefix and whatever wrapped the payload survive:
+			// only the base64 run between them is replaced.
+			head := c.full[:strings.Index(c.full, encoded)]
+			tail := c.full[strings.Index(c.full, encoded)+len(encoded):]
+			assert.Assert(t, strings.HasPrefix(out, head), "lost the prefix: %q", out)
+			assert.Assert(t, strings.HasSuffix(out, tail), "lost the trailing quote: %q", out)
+
+			payload, ok := launcherEntryPayload(out)
+			assert.Assert(t, ok)
+			assert.Equal(t, stringutil.Base64Decode(payload),
+				"python -m sglang.launch_server --nnodes 2")
+		})
+	}
+}
+
 // TestUpdateMetadataSkipsInfera pins the early return: the IDEP extraPodSpec is
 // a bare core/v1 PodSpec, so a metadata block written there is pruned by the
 // CRD schema. normalizeInferaIDEP carries the same labels on the slot's

--- a/SaFE/job-manager/pkg/dispatcher/dispatcher_help_test.go
+++ b/SaFE/job-manager/pkg/dispatcher/dispatcher_help_test.go
@@ -1743,113 +1743,243 @@ func TestExpectedReplica(t *testing.T) {
 	}
 }
 
-// TestUpdateContainersPreservesInferaCommand guards the reason IDEP is exempt
-// from the entrypoint sync: normalizeInferaIDEP appended disaggregation flags
-// that are not in Workload.Spec.EntryPoints, so rebuilding the command would
-// silently drop them and turn a PD deployment into an aggregated one. Image,
-// env and resources must still be synced.
-func TestUpdateContainersPreservesInferaCommand(t *testing.T) {
-	workload := newInferaWorkload([]string{"frontend", "prefill", "decode"}, nil, []int{1, 1, 1})
-	workload.Spec.EntryPoints = []string{"serve --model /models/m"}
-	workload.Spec.Images = []string{"infera:new"}
+// TestInferaLauncherFlags pins which roles the create path actually injects
+// flags for. Only these roles may be excused from a plain entrypoint
+// comparison; a frontend or single-node worker carries exactly what
+// buildCommands produced, so an edit to it must reach the object.
+func TestInferaLauncherFlags(t *testing.T) {
+	disagg := func(mode string) string {
+		return fmt.Sprintf(
+			"--disaggregation-mode %s --disaggregation-transfer-backend %s --disaggregation-bootstrap-port %d",
+			mode, common.InferaDefaultKVBackend, common.DynamoBootstrapPort)
+	}
+	multinode := func(n int) string {
+		return fmt.Sprintf("--nnodes %d --node-rank $LWS_WORKER_INDEX --dist-init-addr $LWS_LEADER_ADDRESS:%d",
+			n, common.DynamoMultinodeDistInitPort)
+	}
+	pd := []string{common.DynamoRoleFrontend, common.DynamoRolePrefill, common.DynamoRoleDecode}
 
-	// What the object actually carries: the launcher payload plus the flags the
-	// create path injected.
-	injected := Launcher + " serve --model /models/m" +
-		" --disaggregation-mode decode --disaggregation-bootstrap-port 30001"
-	preserved := []interface{}{"/bin/sh", "-c", "exec " + injected}
-
-	obj := &unstructured.Unstructured{Object: map[string]interface{}{
-		"apiVersion": "infera.amd.com/v1alpha1",
-		"kind":       common.InferaDeploymentKind,
-		"spec": map[string]interface{}{
-			"services": map[string]interface{}{
-				"role0": map[string]interface{}{
-					"replicas": int64(1),
-					"extraPodSpec": map[string]interface{}{
-						"containers": []interface{}{
-							map[string]interface{}{
-								"name":    "main",
-								"image":   "infera:old",
-								"command": preserved,
-							},
-						},
-					},
+	cases := []struct {
+		name     string
+		workload *v1.Workload
+		id       int
+		want     string
+	}{
+		{
+			name: "non-infera",
+			workload: &v1.Workload{
+				Spec: v1.WorkloadSpec{
+					GroupVersionKind: v1.GroupVersionKind{Kind: common.PytorchJobKind, Version: common.DefaultVersion},
+					Resources:        []v1.WorkloadResource{{Replica: 4}},
 				},
 			},
+			id:   0,
+			want: "",
 		},
-	}}
-
-	resourceSpec := v1.ResourceSpec{
-		PrePaths:      []string{"spec", "services", "role0"},
-		TemplatePaths: []string{"extraPodSpec"},
-		ReplicasPaths: []string{"replicas"},
+		{
+			name:     "frontend gets nothing",
+			workload: newInferaWorkload(pd, nil, []int{1, 1, 1}),
+			id:       0,
+			want:     "",
+		},
+		{
+			name:     "default two-role worker gets nothing",
+			workload: newInferaWorkload(nil, nil, []int{1, 1}),
+			id:       1,
+			want:     "",
+		},
+		{
+			name:     "prefill gets the disaggregation flags",
+			workload: newInferaWorkload(pd, nil, []int{1, 1, 1}),
+			id:       1,
+			want:     disagg("prefill"),
+		},
+		{
+			name:     "decode gets the disaggregation flags",
+			workload: newInferaWorkload(pd, nil, []int{1, 1, 1}),
+			id:       2,
+			want:     disagg("decode"),
+		},
+		{
+			name:     "multi-node decode gets both sets, disaggregation first",
+			workload: newInferaWorkload(pd, []string{common.DynamoRoleDecode}, []int{1, 1, 4}),
+			id:       2,
+			want:     disagg("decode") + " " + multinode(4),
+		},
+		{
+			name:     "multi-node worker gets only the multi-node flags",
+			workload: newInferaWorkload(nil, []string{common.DynamoRoleWorker}, []int{1, 2}),
+			id:       1,
+			want:     multinode(2),
+		},
+		{
+			name:     "a multi-node role with one node is a single node",
+			workload: newInferaWorkload(nil, []string{common.DynamoRoleWorker}, []int{1, 1}),
+			id:       1,
+			want:     "",
+		},
+		{
+			name:     "id past the resource list",
+			workload: newInferaWorkload(pd, nil, []int{1}),
+			id:       2,
+			want:     "",
+		},
 	}
 
-	// Control: buildCommands does have a replacement on offer, and it is the
-	// truncated one. Without the guard the assertions below would see this.
-	rebuilt := buildCommands(workload, 0)
-	assert.Assert(t, len(rebuilt) > 0)
-	assert.Assert(t, rebuilt[len(rebuilt)-1] != preserved[len(preserved)-1])
-
-	assert.NilError(t, updateContainers(workload, obj, resourceSpec, 0))
-
-	containers, _, err := jobutils.NestedSlice(obj.Object,
-		[]string{"spec", "services", "role0", "extraPodSpec", "containers"})
-	assert.NilError(t, err)
-	assert.Equal(t, len(containers), 1)
-	main := containers[0].(map[string]interface{})
-
-	// The injected flags survived...
-	assert.DeepEqual(t, main["command"], preserved)
-	// ...while the fields IDEP does sync were applied, proving the path resolved
-	// and the container really was visited.
-	assert.Equal(t, main["image"], "infera:new")
-	assert.Assert(t, main["resources"] != nil)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, inferaLauncherFlags(tc.workload, tc.id), tc.want)
+		})
+	}
 }
 
-// TestUpdateContainersBuildsInferaCommandOnCreate is the create-path half of
-// TestUpdateContainersPreservesInferaCommand. generateK8sObject runs
-// applyWorkloadSpecToObject before normalizeInferaIDEP, and the shipped IDEP
-// template declares no command on containers[main], so buildCommands is the
-// only writer of one: an IDEP container that arrives without a command gets the
-// launcher form that normalizeInferaIDEP then appends its flags to.
-func TestUpdateContainersBuildsInferaCommandOnCreate(t *testing.T) {
-	workload := newInferaWorkload([]string{"frontend"}, nil, []int{1})
-	// EntryPoints carries the base64 payload launcher.sh decodes, which is the
-	// form appendLauncherArgs rewrites.
-	workload.Spec.EntryPoints = []string{stringutil.Base64Encode("serve --model /models/m")}
-
-	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+// inferaObject renders a minimal IDEP holding one services.role<i> slot per
+// command, each with a "main" container. A nil command leaves that container
+// without one, which is the shape the create path sees.
+func inferaObject(commands ...[]interface{}) *unstructured.Unstructured {
+	services := map[string]interface{}{}
+	for i, cmd := range commands {
+		main := map[string]interface{}{"name": "main", "image": "infera:old"}
+		if cmd != nil {
+			main["command"] = cmd
+		}
+		services["role"+strconv.Itoa(i)] = map[string]interface{}{
+			"replicas": int64(1),
+			"extraPodSpec": map[string]interface{}{
+				"containers": []interface{}{main},
+			},
+		}
+	}
+	return &unstructured.Unstructured{Object: map[string]interface{}{
 		"apiVersion": "infera.amd.com/v1alpha1",
 		"kind":       common.InferaDeploymentKind,
-		"spec": map[string]interface{}{
-			"services": map[string]interface{}{
-				"role0": map[string]interface{}{
-					"replicas": int64(1),
-					"extraPodSpec": map[string]interface{}{
-						"containers": []interface{}{
-							map[string]interface{}{"name": "main"},
-						},
-					},
-				},
-			},
+		"metadata": map[string]interface{}{
+			"name":        "test-idep",
+			"annotations": map[string]interface{}{v1.MainContainerAnnotation: "main"},
 		},
+		"spec": map[string]interface{}{"services": services},
 	}}
+}
 
-	resourceSpec := v1.ResourceSpec{
-		PrePaths:      []string{"spec", "services", "role0"},
+// inferaResourceSpec is the rendered chart's IDEP slot spec: the slot's
+// extraPodSpec is a bare core/v1 PodSpec, so it is both the template path and
+// the pod spec path.
+func inferaResourceSpec(id int) v1.ResourceSpec {
+	return v1.ResourceSpec{
+		PrePaths:      []string{"spec", "services", "role" + strconv.Itoa(id)},
 		TemplatePaths: []string{"extraPodSpec"},
 		PodSpecPaths:  []string{"extraPodSpec"},
 		ReplicasPaths: []string{"replicas"},
 	}
+}
 
-	assert.NilError(t, updateContainers(workload, obj, resourceSpec, 0))
+func inferaResourceTemplate(slots int) *v1.ResourceTemplate {
+	specs := make([]v1.ResourceSpec, slots)
+	for i := range specs {
+		specs[i] = inferaResourceSpec(i)
+	}
+	return &v1.ResourceTemplate{Spec: v1.ResourceTemplateSpec{
+		GroupVersionKind: v1.GroupVersionKind{Kind: common.InferaDeploymentKind},
+		ResourceSpecs:    specs,
+	}}
+}
 
-	containers, _, err := jobutils.NestedSlice(obj.Object,
-		[]string{"spec", "services", "role0", "extraPodSpec", "containers"})
+// inferaMainContainer returns the rendered main container of slot id.
+func inferaMainContainer(t *testing.T, obj *unstructured.Unstructured, id int) map[string]interface{} {
+	t.Helper()
+	containers, found, err := jobutils.NestedSlice(obj.Object,
+		[]string{"spec", "services", "role" + strconv.Itoa(id), "extraPodSpec", "containers"})
 	assert.NilError(t, err)
-	main := containers[0].(map[string]interface{})
+	assert.Equal(t, found, true)
+	for _, c := range containers {
+		m := c.(map[string]interface{})
+		if m["name"] == "main" {
+			return m
+		}
+	}
+	t.Fatalf("no main container in slot role%d", id)
+	return nil
+}
+
+// decodedPayload returns the launcher payload of a rendered command, decoded.
+func decodedPayload(t *testing.T, cmd interface{}) string {
+	t.Helper()
+	slice, ok := cmd.([]interface{})
+	assert.Assert(t, ok)
+	assert.Assert(t, len(slice) == 3)
+	payload, ok := launcherEntryPayload(slice[2].(string))
+	assert.Assert(t, ok)
+	return stringutil.Base64Decode(payload)
+}
+
+// TestUpdateContainersSyncsInferaEntrypoint is the regression that a
+// kind-wide entrypoint exemption introduced: the default two-role IDEP
+// (frontend + worker, the shape GetInferaServiceRoles falls back to) has no
+// injected flags at all, so skipping the rebuild left the old engine arguments
+// running under a freshly synced image, with no error and no event.
+func TestUpdateContainersSyncsInferaEntrypoint(t *testing.T) {
+	workload := newInferaWorkload(nil, nil, []int{1, 1})
+	workload.Spec.EntryPoints = []string{
+		stringutil.Base64Encode("serve --model /models/new"),
+		stringutil.Base64Encode("worker --model /models/new"),
+	}
+	workload.Spec.Images = []string{"infera:new", "infera:new"}
+
+	stale := []interface{}{"/bin/sh", "-c", "exec " + Launcher + " " + stringutil.Base64Encode("serve --model /models/old")}
+	obj := inferaObject(stale, nil)
+
+	// Control: the object is stale in a way the rebuild has to correct, and
+	// this role really does get no injected flags to preserve.
+	assert.Equal(t, inferaLauncherFlags(workload, 0), "")
+	assert.Assert(t, len(buildCommands(workload, 0)) > 0)
+	assert.Assert(t, decodedPayload(t, stale) != "serve --model /models/new")
+
+	assert.NilError(t, updateContainers(workload, obj, inferaResourceSpec(0), 0))
+
+	main := inferaMainContainer(t, obj, 0)
+	assert.Equal(t, decodedPayload(t, main["command"]), "serve --model /models/new")
+	assert.Equal(t, main["image"], "infera:new")
+	assert.Assert(t, main["resources"] != nil)
+}
+
+// TestUpdateContainersRegraftsInferaFlags is the other half: a role that does
+// carry injected flags must keep them across the rebuild, or the sync degrades
+// a PD deployment to aggregated and drops the multi-node wiring.
+func TestUpdateContainersRegraftsInferaFlags(t *testing.T) {
+	roles := []string{common.DynamoRoleFrontend, common.DynamoRolePrefill, common.DynamoRoleDecode}
+	workload := newInferaWorkload(roles, []string{common.DynamoRoleDecode}, []int{1, 1, 2})
+	workload.Spec.EntryPoints = []string{"", "", stringutil.Base64Encode("serve --model /models/new")}
+
+	stale := []interface{}{"/bin/sh", "-c", "exec " + Launcher + " " +
+		stringutil.Base64Encode("serve --model /models/old --disaggregation-mode decode")}
+	obj := inferaObject(nil, nil, stale)
+
+	assert.NilError(t, updateContainers(workload, obj, inferaResourceSpec(2), 2))
+
+	main := inferaMainContainer(t, obj, 2)
+	assert.Equal(t, decodedPayload(t, main["command"]),
+		"serve --model /models/new"+
+			" --disaggregation-mode decode"+
+			" --disaggregation-transfer-backend "+common.InferaDefaultKVBackend+
+			fmt.Sprintf(" --disaggregation-bootstrap-port %d", common.DynamoBootstrapPort)+
+			" --nnodes 2 --node-rank $LWS_WORKER_INDEX"+
+			fmt.Sprintf(" --dist-init-addr $LWS_LEADER_ADDRESS:%d", common.DynamoMultinodeDistInitPort))
+}
+
+// TestUpdateContainersBuildsInferaCommandOnCreate covers the create path:
+// generateK8sObject runs applyWorkloadSpecToObject before normalizeInferaIDEP,
+// and the shipped IDEP template declares no command on containers[main], so
+// updateContainers is the only writer of one.
+func TestUpdateContainersBuildsInferaCommandOnCreate(t *testing.T) {
+	workload := newInferaWorkload([]string{common.DynamoRoleFrontend}, nil, []int{1})
+	// EntryPoints carries the base64 payload launcher.sh decodes, which is the
+	// form appendLauncherArgs rewrites.
+	workload.Spec.EntryPoints = []string{stringutil.Base64Encode("serve --model /models/m")}
+
+	obj := inferaObject(nil)
+	assert.NilError(t, updateContainers(workload, obj, inferaResourceSpec(0), 0))
+
+	main := inferaMainContainer(t, obj, 0)
 	assert.DeepEqual(t, main["command"], buildCommands(workload, 0))
 
 	// appendLauncherArgs needs the three-element launcher form to graft the
@@ -1859,50 +1989,210 @@ func TestUpdateContainersBuildsInferaCommandOnCreate(t *testing.T) {
 	assert.Assert(t, ok)
 }
 
-// TestIsEntrypointChangedSkipsInfera is the read-side half of the same
-// exemption: the rendered command is a deliberate superset of the workload's
-// entrypoint, so reporting drift would re-sync on every reconcile.
-func TestIsEntrypointChangedSkipsInfera(t *testing.T) {
-	workload := newInferaWorkload([]string{"frontend"}, nil, []int{1})
-	workload.Spec.EntryPoints = []string{"serve --model /models/m"}
+// TestInferaCreatePathIsIdempotent runs the create order for a PD deployment -
+// updateContainers, then normalizeInferaIDEP - and checks the flags
+// updateContainers now grafts are not appended a second time. Per-flag dedup in
+// stripUserDeclaredFlags is what makes the second pass a no-op; a duplicate
+// would crash the worker, because dynamo.sglang's argparse rejects one.
+func TestInferaCreatePathIsIdempotent(t *testing.T) {
+	roles := []string{common.DynamoRoleFrontend, common.DynamoRolePrefill, common.DynamoRoleDecode}
+	workload := newInferaWorkload(roles, []string{common.DynamoRoleDecode}, []int{1, 1, 2})
+	for range roles {
+		workload.Spec.EntryPoints = append(workload.Spec.EntryPoints,
+			stringutil.Base64Encode("serve --model /models/m"))
+	}
 
-	// A readable object whose command is the injected superset. The generic
-	// comparison would call this drift; the guard is what stops it.
-	injected := Launcher + " serve --model /models/m" +
-		" --disaggregation-mode decode --disaggregation-bootstrap-port 30001"
-	obj := &unstructured.Unstructured{Object: map[string]interface{}{
-		"apiVersion": "infera.amd.com/v1alpha1",
-		"kind":       common.InferaDeploymentKind,
-		"spec": map[string]interface{}{
-			"services": map[string]interface{}{
-				"role0": map[string]interface{}{
-					"extraPodSpec": map[string]interface{}{
-						"containers": []interface{}{
-							map[string]interface{}{
-								"name":    "main",
-								"image":   "infera:x",
-								"command": []interface{}{"/bin/sh", "-c", "exec " + injected},
-							},
-						},
-					},
-				},
-			},
+	obj := inferaObject(nil, nil, nil)
+	for i := range roles {
+		assert.NilError(t, updateContainers(workload, obj, inferaResourceSpec(i), i))
+	}
+	afterWrite := decodedPayload(t, inferaMainContainer(t, obj, 2)["command"])
+
+	assert.NilError(t, normalizeInferaIDEP(obj, workload))
+
+	main := inferaMainContainer(t, obj, 2)
+	assert.Equal(t, decodedPayload(t, main["command"]), afterWrite)
+	assert.Equal(t, strings.Count(afterWrite, "--disaggregation-mode "), 1)
+	assert.Equal(t, strings.Count(afterWrite, "--nnodes "), 1)
+
+	// And the object the second pass produces is what the drift check expects
+	// to find, so a steady-state IDEP does not resync on every reconcile.
+	assert.DeepEqual(t, main["command"], expectedCommands(workload, 2))
+}
+
+// TestIsEntrypointChangedInfera is the read side. It has to distinguish a role
+// whose rendered command is exactly buildCommands' output - where a plain
+// comparison is correct - from one carrying injected flags, where comparing
+// against the bare entrypoint would report drift forever.
+func TestIsEntrypointChangedInfera(t *testing.T) {
+	entry := stringutil.Base64Encode("serve --model /models/new")
+	staleEntry := stringutil.Base64Encode("serve --model /models/old")
+
+	frontend := newInferaWorkload([]string{common.DynamoRoleFrontend}, nil, []int{1})
+	frontend.Spec.EntryPoints = []string{entry}
+
+	decode := newInferaWorkload([]string{common.DynamoRoleDecode}, []string{common.DynamoRoleDecode}, []int{2})
+	decode.Spec.EntryPoints = []string{entry}
+
+	staleDecode := newInferaWorkload([]string{common.DynamoRoleDecode}, []string{common.DynamoRoleDecode}, []int{2})
+	staleDecode.Spec.EntryPoints = []string{staleEntry}
+
+	cases := []struct {
+		name     string
+		workload *v1.Workload
+		rendered []interface{}
+		want     bool
+	}{
+		{
+			name:     "flagless role in step",
+			workload: frontend,
+			rendered: expectedCommands(frontend, 0),
+			want:     false,
 		},
-	}}
-	rt := &v1.ResourceTemplate{Spec: v1.ResourceTemplateSpec{
-		GroupVersionKind: v1.GroupVersionKind{Kind: common.InferaDeploymentKind},
-		ResourceSpecs: []v1.ResourceSpec{{
-			PrePaths:      []string{"spec", "services", "role0"},
-			TemplatePaths: []string{"extraPodSpec"},
-		}},
-	}}
+		{
+			name:     "flagless role with an edited entrypoint",
+			workload: frontend,
+			rendered: []interface{}{"/bin/sh", "-c", "exec " + Launcher + " " + staleEntry},
+			want:     true,
+		},
+		{
+			name:     "injected role in step",
+			workload: decode,
+			rendered: expectedCommands(decode, 0),
+			want:     false,
+		},
+		{
+			name:     "injected role with an edited entrypoint",
+			workload: decode,
+			rendered: expectedCommands(staleDecode, 0),
+			want:     true,
+		},
+	}
 
-	// Control: the object really is readable and really does disagree with the
-	// workload, so a false here means the guard fired, not that the read missed.
-	commands, err := jobutils.GetCommands(obj, rt, len(workload.Spec.Resources))
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := inferaObject(tc.rendered)
+			rt := inferaResourceTemplate(1)
+
+			// Control: the object really is readable, so a false below means
+			// the comparison matched, not that the read missed the container.
+			commands, err := jobutils.GetCommands(obj, rt, len(tc.workload.Spec.Resources))
+			assert.NilError(t, err)
+			assert.Equal(t, len(commands), 1)
+
+			assert.Equal(t, isEntrypointChanged(tc.workload, obj, rt), tc.want)
+		})
+	}
+}
+
+// setInferaResources writes onto slot id the container limits updateContainers
+// would produce for Resources[id], so a drift test can vary replicas alone.
+func setInferaResources(t *testing.T, obj *unstructured.Unstructured, workload *v1.Workload, id int) {
+	t.Helper()
+	rl, err := commonworkload.GetPodResourceList(&workload.Spec.Resources[id])
 	assert.NilError(t, err)
-	assert.Equal(t, len(commands), 1)
-	assert.Assert(t, !entrypointsEqual(buildEntryPoint(workload, 0), commands[0][len(commands[0])-1]))
+	limits := map[string]interface{}{}
+	for k, v := range rl {
+		limits[string(k)] = v.String()
+	}
+	path := []string{"spec", "services", "role" + strconv.Itoa(id), "extraPodSpec", "containers"}
+	containers, found, err := jobutils.NestedSlice(obj.Object, path)
+	assert.NilError(t, err)
+	assert.Equal(t, found, true)
+	for _, c := range containers {
+		if m := c.(map[string]interface{}); m["name"] == "main" {
+			m["resources"] = map[string]interface{}{"limits": limits}
+		}
+	}
+	assert.NilError(t, jobutils.SetNestedField(obj.Object, containers, path))
+}
 
-	assert.Equal(t, isEntrypointChanged(workload, obj, rt), false)
+// TestIsResourceChangedInferaMultinode pins the drift check to expectedReplica.
+// A multi-node role's object carries replicas=1 with the node count in
+// numberOfNodes, so comparing against Resources[i].Replica would report drift
+// on every reconcile - and each resync also rewrites replicas to n while
+// numberOfNodes stays n, which is n groups of n nodes.
+func TestIsResourceChangedInferaMultinode(t *testing.T) {
+	roles := []string{common.DynamoRoleFrontend, common.DynamoRoleDecode}
+	workload := newInferaWorkload(roles, []string{common.DynamoRoleDecode}, []int{2, 4})
+
+	obj := inferaObject(nil, nil)
+	rt := inferaResourceTemplate(2)
+	for i := range roles {
+		setInferaResources(t, obj, workload, i)
+	}
+	replicasPath := func(id int) []string {
+		return []string{"spec", "services", "role" + strconv.Itoa(id), "replicas"}
+	}
+	assert.NilError(t, jobutils.SetNestedField(obj.Object, int64(2), replicasPath(0)))
+	assert.NilError(t, jobutils.SetNestedField(obj.Object, int64(1), replicasPath(1)))
+
+	// Control: both slots are readable and their resources already agree, so
+	// the verdict below is the replica comparison and nothing else.
+	replicaList, resourceList, err := jobutils.GetResources(obj, rt, "", len(workload.Spec.Resources))
+	assert.NilError(t, err)
+	assert.Equal(t, len(replicaList), 2)
+	assert.Equal(t, len(resourceList), 2)
+
+	assert.Equal(t, isResourceChanged(workload, obj, rt), false)
+
+	// The count normalizeInferaIDEP does not write is drift.
+	assert.NilError(t, jobutils.SetNestedField(obj.Object, int64(4), replicasPath(1)))
+	assert.Equal(t, isResourceChanged(workload, obj, rt), true)
+}
+
+// TestUpdateReplicaInfera is the write half of the same agreement: the value
+// updateReplica puts in the object has to be the one the drift check expects.
+func TestUpdateReplicaInfera(t *testing.T) {
+	roles := []string{common.DynamoRoleFrontend, common.DynamoRoleDecode}
+	workload := newInferaWorkload(roles, []string{common.DynamoRoleDecode}, []int{2, 4})
+	obj := inferaObject(nil, nil)
+
+	for i := range roles {
+		assert.NilError(t, updateReplica(workload, obj, inferaResourceSpec(i), i))
+	}
+
+	frontend, found, err := jobutils.NestedInt64(obj.Object, []string{"spec", "services", "role0", "replicas"})
+	assert.NilError(t, err)
+	assert.Equal(t, found, true)
+	assert.Equal(t, frontend, int64(2))
+
+	decode, found, err := jobutils.NestedInt64(obj.Object, []string{"spec", "services", "role1", "replicas"})
+	assert.NilError(t, err)
+	assert.Equal(t, found, true)
+	assert.Equal(t, decode, int64(1))
+}
+
+// TestUpdateMetadataSkipsInfera pins the early return: the IDEP extraPodSpec is
+// a bare core/v1 PodSpec, so a metadata block written there is pruned by the
+// CRD schema. normalizeInferaIDEP carries the same labels on the slot's
+// podLabels field instead.
+func TestUpdateMetadataSkipsInfera(t *testing.T) {
+	workload := newInferaWorkload([]string{common.DynamoRoleFrontend}, nil, []int{1})
+	obj := inferaObject(nil)
+
+	assert.NilError(t, updateMetadata(workload, obj, inferaResourceSpec(0), 0))
+
+	_, found, err := jobutils.NestedMap(obj.Object,
+		[]string{"spec", "services", "role0", "extraPodSpec", "metadata"})
+	assert.NilError(t, err)
+	assert.Equal(t, found, false)
+
+	// Control: the same call on a kind that does sync metadata writes one, so
+	// the absence above is the guard and not an unresolvable path.
+	pytorch := &v1.Workload{
+		ObjectMeta: metav1.ObjectMeta{Name: "pyt"},
+		Spec: v1.WorkloadSpec{
+			GroupVersionKind: v1.GroupVersionKind{Kind: common.PytorchJobKind, Version: common.DefaultVersion},
+			Resources:        []v1.WorkloadResource{{Replica: 1}},
+		},
+	}
+	pytObj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"spec": map[string]interface{}{"template": map[string]interface{}{}},
+	}}
+	pytSpec := v1.ResourceSpec{PrePaths: []string{"spec"}, TemplatePaths: []string{"template"}}
+	assert.NilError(t, updateMetadata(pytorch, pytObj, pytSpec, 0))
+	_, found, err = jobutils.NestedMap(pytObj.Object, []string{"spec", "template", "metadata", "labels"})
+	assert.NilError(t, err)
+	assert.Equal(t, found, true)
 }

--- a/SaFE/job-manager/pkg/dispatcher/dispatcher_help_test.go
+++ b/SaFE/job-manager/pkg/dispatcher/dispatcher_help_test.go
@@ -13,8 +13,8 @@ import (
 	"testing"
 
 	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/apikey"
-	commonfaults "github.com/AMD-AIG-AIMA/SAFE/common/pkg/faults"
 	dbclient "github.com/AMD-AIG-AIMA/SAFE/common/pkg/database/client"
+	commonfaults "github.com/AMD-AIG-AIMA/SAFE/common/pkg/faults"
 	"github.com/agiledragon/gomonkey/v2"
 	"gotest.tools/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -1681,4 +1681,201 @@ func TestBuildRequiredMatchExpressionExcludedNodes(t *testing.T) {
 	assert.Assert(t, len(exprs) >= 1)
 	m := exprs[0].(map[string]interface{})
 	assert.Equal(t, m["operator"], "NotIn")
+}
+
+// newInferaWorkload builds an InferaDeployment workload with the given roles,
+// the subset of them that run multi-node, and one resource per role.
+func newInferaWorkload(roles, multinodeRoles []string, replicas []int) *v1.Workload {
+	resources := make([]v1.WorkloadResource, len(replicas))
+	for i, r := range replicas {
+		resources[i] = v1.WorkloadResource{Replica: r, CPU: "1", Memory: "1Gi"}
+	}
+	return &v1.Workload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-idep",
+			Annotations: map[string]string{
+				v1.MainContainerAnnotation:        "main",
+				v1.InferaServiceRolesAnnotation:   strings.Join(roles, ","),
+				v1.InferaMultinodeRolesAnnotation: strings.Join(multinodeRoles, ","),
+			},
+		},
+		Spec: v1.WorkloadSpec{
+			GroupVersionKind: v1.GroupVersionKind{
+				Kind:    common.InferaDeploymentKind,
+				Version: common.DefaultVersion,
+			},
+			Resources: resources,
+		},
+	}
+}
+
+// TestExpectedReplica pins the one place the drift check and the write agree on
+// what "replicas" should be. A multi-node Infera role keeps replicas=1 because
+// its node count lives in numberOfNodes (normalizeInferaIDEP); every other role
+// scales normally.
+func TestExpectedReplica(t *testing.T) {
+	roles := []string{"frontend", "prefill", "decode"}
+
+	cases := []struct {
+		name     string
+		workload *v1.Workload
+		id       int
+		want     int64
+	}{
+		{
+			name: "non-infera scales normally",
+			workload: &v1.Workload{
+				ObjectMeta: metav1.ObjectMeta{Name: "pyt"},
+				Spec: v1.WorkloadSpec{
+					GroupVersionKind: v1.GroupVersionKind{Kind: common.PytorchJobKind, Version: common.DefaultVersion},
+					Resources:        []v1.WorkloadResource{{Replica: 4}},
+				},
+			},
+			id:   0,
+			want: 4,
+		},
+		{
+			name:     "infera single-node role scales normally",
+			workload: newInferaWorkload(roles, []string{"decode"}, []int{4, 2, 8}),
+			id:       0,
+			want:     4,
+		},
+		{
+			name:     "infera multi-node role pins to one group",
+			workload: newInferaWorkload(roles, []string{"decode"}, []int{4, 2, 8}),
+			id:       2,
+			want:     1,
+		},
+		{
+			name:     "infera multi-node role with a single node is unaffected",
+			workload: newInferaWorkload(roles, []string{"decode"}, []int{4, 2, 1}),
+			id:       2,
+			want:     1,
+		},
+		{
+			name:     "id past the resource list",
+			workload: newInferaWorkload(roles, nil, []int{4}),
+			id:       3,
+			want:     0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, expectedReplica(tc.workload, tc.id), tc.want)
+		})
+	}
+}
+
+// TestUpdateContainersPreservesInferaCommand guards the reason IDEP is exempt
+// from the entrypoint sync: normalizeInferaIDEP appended disaggregation flags
+// that are not in Workload.Spec.EntryPoints, so rebuilding the command would
+// silently drop them and turn a PD deployment into an aggregated one. Image,
+// env and resources must still be synced.
+func TestUpdateContainersPreservesInferaCommand(t *testing.T) {
+	workload := newInferaWorkload([]string{"frontend", "prefill", "decode"}, nil, []int{1, 1, 1})
+	workload.Spec.EntryPoints = []string{"serve --model /models/m"}
+	workload.Spec.Images = []string{"infera:new"}
+
+	// What the object actually carries: the launcher payload plus the flags the
+	// create path injected.
+	injected := Launcher + " serve --model /models/m" +
+		" --disaggregation-mode decode --disaggregation-bootstrap-port 30001"
+	preserved := []interface{}{"/bin/sh", "-c", "exec " + injected}
+
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "infera.amd.com/v1alpha1",
+		"kind":       common.InferaDeploymentKind,
+		"spec": map[string]interface{}{
+			"services": map[string]interface{}{
+				"role0": map[string]interface{}{
+					"replicas": int64(1),
+					"extraPodSpec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":    "main",
+								"image":   "infera:old",
+								"command": preserved,
+							},
+						},
+					},
+				},
+			},
+		},
+	}}
+
+	resourceSpec := v1.ResourceSpec{
+		PrePaths:      []string{"spec", "services", "role0"},
+		TemplatePaths: []string{"extraPodSpec"},
+		ReplicasPaths: []string{"replicas"},
+	}
+
+	// Control: buildCommands does have a replacement on offer, and it is the
+	// truncated one. Without the guard the assertions below would see this.
+	rebuilt := buildCommands(workload, 0)
+	assert.Assert(t, len(rebuilt) > 0)
+	assert.Assert(t, rebuilt[len(rebuilt)-1] != preserved[len(preserved)-1])
+
+	assert.NilError(t, updateContainers(workload, obj, resourceSpec, 0))
+
+	containers, _, err := jobutils.NestedSlice(obj.Object,
+		[]string{"spec", "services", "role0", "extraPodSpec", "containers"})
+	assert.NilError(t, err)
+	assert.Equal(t, len(containers), 1)
+	main := containers[0].(map[string]interface{})
+
+	// The injected flags survived...
+	assert.DeepEqual(t, main["command"], preserved)
+	// ...while the fields IDEP does sync were applied, proving the path resolved
+	// and the container really was visited.
+	assert.Equal(t, main["image"], "infera:new")
+	assert.Assert(t, main["resources"] != nil)
+}
+
+// TestIsEntrypointChangedSkipsInfera is the read-side half of the same
+// exemption: the rendered command is a deliberate superset of the workload's
+// entrypoint, so reporting drift would re-sync on every reconcile.
+func TestIsEntrypointChangedSkipsInfera(t *testing.T) {
+	workload := newInferaWorkload([]string{"frontend"}, nil, []int{1})
+	workload.Spec.EntryPoints = []string{"serve --model /models/m"}
+
+	// A readable object whose command is the injected superset. The generic
+	// comparison would call this drift; the guard is what stops it.
+	injected := Launcher + " serve --model /models/m" +
+		" --disaggregation-mode decode --disaggregation-bootstrap-port 30001"
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "infera.amd.com/v1alpha1",
+		"kind":       common.InferaDeploymentKind,
+		"spec": map[string]interface{}{
+			"services": map[string]interface{}{
+				"role0": map[string]interface{}{
+					"extraPodSpec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":    "main",
+								"image":   "infera:x",
+								"command": []interface{}{"/bin/sh", "-c", "exec " + injected},
+							},
+						},
+					},
+				},
+			},
+		},
+	}}
+	rt := &v1.ResourceTemplate{Spec: v1.ResourceTemplateSpec{
+		GroupVersionKind: v1.GroupVersionKind{Kind: common.InferaDeploymentKind},
+		ResourceSpecs: []v1.ResourceSpec{{
+			PrePaths:      []string{"spec", "services", "role0"},
+			TemplatePaths: []string{"extraPodSpec"},
+		}},
+	}}
+
+	// Control: the object really is readable and really does disagree with the
+	// workload, so a false here means the guard fired, not that the read missed.
+	commands, err := jobutils.GetCommands(obj, rt, len(workload.Spec.Resources))
+	assert.NilError(t, err)
+	assert.Equal(t, len(commands), 1)
+	assert.Assert(t, !entrypointsEqual(buildEntryPoint(workload, 0), commands[0][len(commands[0])-1]))
+
+	assert.Equal(t, isEntrypointChanged(workload, obj, rt), false)
 }

--- a/SaFE/job-manager/pkg/dispatcher/dispatcher_help_test.go
+++ b/SaFE/job-manager/pkg/dispatcher/dispatcher_help_test.go
@@ -56,9 +56,7 @@ func checkResources(t *testing.T, obj *unstructured.Unstructured, workload *v1.W
 		}
 	}
 
-	path = append(template.PrePaths, template.TemplatePaths...)
-	podSpec := getPodSpec(workload)
-	path = append(path, podSpec, "containers")
+	path = commonworkload.ResolvePodSpecPath(template, workload.SpecKind(), "containers")
 	containers, found, err := jobutils.NestedSlice(obj.Object, path)
 	assert.NilError(t, err)
 	assert.Equal(t, found, true)
@@ -78,14 +76,12 @@ func checkResources(t *testing.T, obj *unstructured.Unstructured, workload *v1.W
 }
 
 func checkRaySubmitterPod(t *testing.T, obj *unstructured.Unstructured, workload *v1.Workload) {
-	podSpec := getPodSpec(workload)
-	val, found, err := jobutils.NestedString(obj.Object, []string{podSpec, "entrypoint"})
+	val, found, err := jobutils.NestedString(obj.Object, []string{"spec", "entrypoint"})
 	assert.NilError(t, err)
 	assert.Equal(t, found, true)
 	assert.Equal(t, val, "exec "+Launcher+fmt.Sprintf(" '%s'", workload.GetEnv(common.RayJobEntrypoint)))
 
-	path := []string{podSpec, "submitterPodTemplate"}
-	path = append(path, podSpec, "containers")
+	path := []string{"spec", "submitterPodTemplate", "spec", "containers"}
 	containers, found, err := jobutils.NestedSlice(obj.Object, path)
 	assert.NilError(t, err)
 	assert.Equal(t, found, true)
@@ -100,9 +96,7 @@ func checkRaySubmitterPod(t *testing.T, obj *unstructured.Unstructured, workload
 }
 
 func checkPorts(t *testing.T, obj *unstructured.Unstructured, workload *v1.Workload, template *v1.ResourceSpec, id int) {
-	containerPath := append(template.PrePaths, template.TemplatePaths...)
-	podPec := getPodSpec(workload)
-	containerPath = append(containerPath, podPec, "containers")
+	containerPath := commonworkload.ResolvePodSpecPath(template, workload.SpecKind(), "containers")
 
 	values, found, err := jobutils.NestedSlice(obj.Object, containerPath)
 	assert.NilError(t, err)
@@ -209,9 +203,7 @@ func findEnvFieldRef(envs []interface{}, name, fieldPath string) bool {
 }
 
 func checkVolumeMounts(t *testing.T, obj *unstructured.Unstructured, workload *v1.Workload, resourceSpec *v1.ResourceSpec) {
-	templatePath := append(resourceSpec.PrePaths, resourceSpec.TemplatePaths...)
-	podSpec := getPodSpec(workload)
-	containerPath := append(templatePath, podSpec, "containers")
+	containerPath := commonworkload.ResolvePodSpecPath(resourceSpec, workload.SpecKind(), "containers")
 
 	values, found, err := jobutils.NestedSlice(obj.Object, containerPath)
 	assert.NilError(t, err)
@@ -260,9 +252,7 @@ func findVolumeMount(volumeMounts []interface{}, name string) map[string]interfa
 }
 
 func checkVolumes(t *testing.T, obj *unstructured.Unstructured, workload *v1.Workload, resourceSpec *v1.ResourceSpec, id int) {
-	volumesPath := append(resourceSpec.PrePaths, resourceSpec.TemplatePaths...)
-	podSpec := getPodSpec(workload)
-	volumesPath = append(volumesPath, podSpec, "volumes")
+	volumesPath := commonworkload.ResolvePodSpecPath(resourceSpec, workload.SpecKind(), "volumes")
 
 	volumes, found, err := jobutils.NestedSlice(obj.Object, volumesPath)
 	assert.NilError(t, err)
@@ -345,9 +335,7 @@ func checkSandboxTemplateCleaned(t *testing.T, obj *unstructured.Unstructured, r
 }
 
 func checkRequiredNodeSelectorTerms(t *testing.T, obj *unstructured.Unstructured, workload *v1.Workload, resourceSpec *v1.ResourceSpec) {
-	nodeSelectorPath := append(resourceSpec.PrePaths, resourceSpec.TemplatePaths...)
-	podSpec := getPodSpec(workload)
-	nodeSelectorPath = append(nodeSelectorPath, podSpec, "affinity", "nodeAffinity",
+	nodeSelectorPath := commonworkload.ResolvePodSpecPath(resourceSpec, workload.SpecKind(), "affinity", "nodeAffinity",
 		"requiredDuringSchedulingIgnoredDuringExecution", "nodeSelectorTerms")
 
 	affinities, found, err := jobutils.NestedSlice(obj.Object, nodeSelectorPath)
@@ -388,9 +376,7 @@ func checkRequiredNodeSelectorTerms(t *testing.T, obj *unstructured.Unstructured
 }
 
 func checkPreferredNodeSelectorTerms(t *testing.T, obj *unstructured.Unstructured, workload *v1.Workload, resourceSpec *v1.ResourceSpec) {
-	nodeSelectorPath := append(resourceSpec.PrePaths, resourceSpec.TemplatePaths...)
-	podSpec := getPodSpec(workload)
-	nodeSelectorPath = append(nodeSelectorPath, podSpec, "affinity", "nodeAffinity",
+	nodeSelectorPath := commonworkload.ResolvePodSpecPath(resourceSpec, workload.SpecKind(), "affinity", "nodeAffinity",
 		"preferredDuringSchedulingIgnoredDuringExecution")
 
 	preferenceSlice, found, err := jobutils.NestedSlice(obj.Object, nodeSelectorPath)
@@ -421,9 +407,7 @@ func checkPreferredNodeSelectorTerms(t *testing.T, obj *unstructured.Unstructure
 }
 
 func checkPodAntiAffinity(t *testing.T, obj *unstructured.Unstructured, workload *v1.Workload, resourceSpec *v1.ResourceSpec) {
-	podAntiAffinityPath := append(resourceSpec.PrePaths, resourceSpec.TemplatePaths...)
-	podSpec := getPodSpec(workload)
-	podAntiAffinityPath = append(podAntiAffinityPath, podSpec, "affinity", "podAntiAffinity",
+	podAntiAffinityPath := commonworkload.ResolvePodSpecPath(resourceSpec, workload.SpecKind(), "affinity", "podAntiAffinity",
 		"requiredDuringSchedulingIgnoredDuringExecution")
 
 	antiAffinities, found, err := jobutils.NestedSlice(obj.Object, podAntiAffinityPath)
@@ -448,9 +432,7 @@ func checkPodAntiAffinity(t *testing.T, obj *unstructured.Unstructured, workload
 }
 
 func checkImage(t *testing.T, obj *unstructured.Unstructured, workload *v1.Workload, resourceSpec *v1.ResourceSpec, id int) {
-	containerPath := append(resourceSpec.PrePaths, resourceSpec.TemplatePaths...)
-	podSpec := getPodSpec(workload)
-	containerPath = append(containerPath, podSpec, "containers")
+	containerPath := commonworkload.ResolvePodSpecPath(resourceSpec, workload.SpecKind(), "containers")
 
 	values, found, err := jobutils.NestedSlice(obj.Object, containerPath)
 	assert.NilError(t, err)
@@ -468,8 +450,7 @@ func checkImage(t *testing.T, obj *unstructured.Unstructured, workload *v1.Workl
 }
 
 func checkHostNetwork(t *testing.T, obj *unstructured.Unstructured, workload *v1.Workload, resourceSpec *v1.ResourceSpec, id int) {
-	path := resourceSpec.TemplatePath()
-	path = append(path, getPodSpec(workload), "hostNetwork")
+	path := commonworkload.ResolvePodSpecPath(resourceSpec, workload.SpecKind(), "hostNetwork")
 
 	isHostNetWork, found, err := jobutils.NestedBool(obj.Object, path)
 	assert.NilError(t, err)
@@ -478,8 +459,7 @@ func checkHostNetwork(t *testing.T, obj *unstructured.Unstructured, workload *v1
 }
 
 func checkHostPid(t *testing.T, obj *unstructured.Unstructured, workload *v1.Workload, resourceSpec *v1.ResourceSpec) {
-	path := append(resourceSpec.PrePaths, resourceSpec.TemplatePaths...)
-	path = append(path, getPodSpec(workload), "hostPID")
+	path := commonworkload.ResolvePodSpecPath(resourceSpec, workload.SpecKind(), "hostPID")
 
 	resp, found, err := jobutils.NestedBool(obj.Object, path)
 	assert.NilError(t, err)
@@ -511,7 +491,7 @@ func checkLabels(t *testing.T, obj *unstructured.Unstructured, workload *v1.Work
 }
 
 func checkSelector(t *testing.T, obj *unstructured.Unstructured, workload *v1.Workload) {
-	path := []string{getPodSpec(workload), "selector", "matchLabels"}
+	path := []string{"spec", "selector", "matchLabels"}
 	labels, found, err := jobutils.NestedMap(obj.Object, path)
 	assert.NilError(t, err)
 	assert.Equal(t, found, true)
@@ -519,7 +499,7 @@ func checkSelector(t *testing.T, obj *unstructured.Unstructured, workload *v1.Wo
 }
 
 func checkStrategy(t *testing.T, obj *unstructured.Unstructured, workload *v1.Workload) {
-	path := []string{getPodSpec(workload), "strategy", "rollingUpdate"}
+	path := []string{"spec", "strategy", "rollingUpdate"}
 	labels, found, err := jobutils.NestedMap(obj.Object, path)
 	assert.NilError(t, err)
 	assert.Equal(t, found, true)
@@ -528,8 +508,7 @@ func checkStrategy(t *testing.T, obj *unstructured.Unstructured, workload *v1.Wo
 }
 
 func checkTolerations(t *testing.T, obj *unstructured.Unstructured, workload *v1.Workload, resourceSpec *v1.ResourceSpec) {
-	path := append(resourceSpec.PrePaths, resourceSpec.TemplatePaths...)
-	path = append(path, getPodSpec(workload), "tolerations")
+	path := commonworkload.ResolvePodSpecPath(resourceSpec, workload.SpecKind(), "tolerations")
 
 	tolerations, found, err := jobutils.NestedSlice(obj.Object, path)
 	assert.NilError(t, err)
@@ -561,8 +540,7 @@ func checkTolerations(t *testing.T, obj *unstructured.Unstructured, workload *v1
 }
 
 func checkPriorityClass(t *testing.T, obj *unstructured.Unstructured, workload *v1.Workload, resourceSpec *v1.ResourceSpec) {
-	path := append(resourceSpec.PrePaths, resourceSpec.TemplatePaths...)
-	path = append(path, getPodSpec(workload), "priorityClassName")
+	path := commonworkload.ResolvePodSpecPath(resourceSpec, workload.SpecKind(), "priorityClassName")
 	priorityClassName, found, err := jobutils.NestedString(obj.Object, path)
 	assert.NilError(t, err)
 	assert.Equal(t, found, true)
@@ -570,8 +548,7 @@ func checkPriorityClass(t *testing.T, obj *unstructured.Unstructured, workload *
 }
 
 func checkSecurityContext(t *testing.T, obj *unstructured.Unstructured, workload *v1.Workload, template *v1.ResourceSpec) {
-	containerPath := append(template.PrePaths, template.TemplatePaths...)
-	containerPath = append(containerPath, getPodSpec(workload), "containers")
+	containerPath := commonworkload.ResolvePodSpecPath(template, workload.SpecKind(), "containers")
 
 	values, found, err := jobutils.NestedSlice(obj.Object, containerPath)
 	assert.NilError(t, err)
@@ -602,8 +579,7 @@ func checkSecurityContext(t *testing.T, obj *unstructured.Unstructured, workload
 }
 
 func checkImageSecrets(t *testing.T, obj *unstructured.Unstructured, workload *v1.Workload, resourceSpec *v1.ResourceSpec) {
-	secretPath := append(resourceSpec.PrePaths, resourceSpec.TemplatePaths...)
-	secretPath = append(secretPath, getPodSpec(workload), "imagePullSecrets")
+	secretPath := commonworkload.ResolvePodSpecPath(resourceSpec, workload.SpecKind(), "imagePullSecrets")
 
 	secrets, found, err := jobutils.NestedSlice(obj.Object, secretPath)
 	assert.NilError(t, err)
@@ -618,9 +594,7 @@ func checkImageSecrets(t *testing.T, obj *unstructured.Unstructured, workload *v
 }
 
 func getEnvs(t *testing.T, obj *unstructured.Unstructured, workload *v1.Workload, resourceSpec *v1.ResourceSpec) []interface{} {
-	containerPath := append(resourceSpec.PrePaths, resourceSpec.TemplatePaths...)
-	podSpec := getPodSpec(workload)
-	containerPath = append(containerPath, podSpec, "containers")
+	containerPath := commonworkload.ResolvePodSpecPath(resourceSpec, workload.SpecKind(), "containers")
 
 	values, found, err := jobutils.NestedSlice(obj.Object, containerPath)
 	assert.NilError(t, err)
@@ -636,8 +610,7 @@ func getEnvs(t *testing.T, obj *unstructured.Unstructured, workload *v1.Workload
 }
 
 func getContainer(obj *unstructured.Unstructured, name string, workload *v1.Workload, resourceSpec *v1.ResourceSpec) map[string]interface{} {
-	containerPath := append(resourceSpec.PrePaths, resourceSpec.TemplatePaths...)
-	containerPath = append(containerPath, getPodSpec(workload), "containers")
+	containerPath := commonworkload.ResolvePodSpecPath(resourceSpec, workload.SpecKind(), "containers")
 
 	values, found, err := jobutils.NestedSlice(obj.Object, containerPath)
 	if err != nil || !found {
@@ -838,8 +811,11 @@ func TestModifyHostPid(t *testing.T) {
 				}
 			}
 
-			templatePath := []string{"spec", "template"}
-			err := modifyHostPid(obj, workload, templatePath)
+			resourceSpec := &v1.ResourceSpec{
+				PrePaths:     []string{"spec"},
+				PodSpecPaths: []string{"template", "spec"},
+			}
+			err := modifyHostPid(obj, workload, resourceSpec)
 			assert.NilError(t, err)
 
 			hostPID, foundPID, _ := jobutils.NestedBool(obj.Object, []string{"spec", "template", "spec", "hostPID"})

--- a/SaFE/job-manager/pkg/dispatcher/dispatcher_help_test.go
+++ b/SaFE/job-manager/pkg/dispatcher/dispatcher_help_test.go
@@ -1808,6 +1808,57 @@ func TestUpdateContainersPreservesInferaCommand(t *testing.T) {
 	assert.Assert(t, main["resources"] != nil)
 }
 
+// TestUpdateContainersBuildsInferaCommandOnCreate is the create-path half of
+// TestUpdateContainersPreservesInferaCommand. generateK8sObject runs
+// applyWorkloadSpecToObject before normalizeInferaIDEP, and the shipped IDEP
+// template declares no command on containers[main], so buildCommands is the
+// only writer of one: an IDEP container that arrives without a command gets the
+// launcher form that normalizeInferaIDEP then appends its flags to.
+func TestUpdateContainersBuildsInferaCommandOnCreate(t *testing.T) {
+	workload := newInferaWorkload([]string{"frontend"}, nil, []int{1})
+	// EntryPoints carries the base64 payload launcher.sh decodes, which is the
+	// form appendLauncherArgs rewrites.
+	workload.Spec.EntryPoints = []string{stringutil.Base64Encode("serve --model /models/m")}
+
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "infera.amd.com/v1alpha1",
+		"kind":       common.InferaDeploymentKind,
+		"spec": map[string]interface{}{
+			"services": map[string]interface{}{
+				"role0": map[string]interface{}{
+					"replicas": int64(1),
+					"extraPodSpec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{"name": "main"},
+						},
+					},
+				},
+			},
+		},
+	}}
+
+	resourceSpec := v1.ResourceSpec{
+		PrePaths:      []string{"spec", "services", "role0"},
+		TemplatePaths: []string{"extraPodSpec"},
+		PodSpecPaths:  []string{"extraPodSpec"},
+		ReplicasPaths: []string{"replicas"},
+	}
+
+	assert.NilError(t, updateContainers(workload, obj, resourceSpec, 0))
+
+	containers, _, err := jobutils.NestedSlice(obj.Object,
+		[]string{"spec", "services", "role0", "extraPodSpec", "containers"})
+	assert.NilError(t, err)
+	main := containers[0].(map[string]interface{})
+	assert.DeepEqual(t, main["command"], buildCommands(workload, 0))
+
+	// appendLauncherArgs needs the three-element launcher form to graft the
+	// disaggregation and multi-node flags onto; a container left without a
+	// command would silently keep none.
+	_, ok := appendLauncherArgs(main["command"].([]interface{}), "--nnodes 2")
+	assert.Assert(t, ok)
+}
+
 // TestIsEntrypointChangedSkipsInfera is the read-side half of the same
 // exemption: the rendered command is a deliberate superset of the workload's
 // entrypoint, so reporting drift would re-sync on every reconcile.

--- a/SaFE/job-manager/pkg/utils/test_data.go
+++ b/SaFE/job-manager/pkg/utils/test_data.go
@@ -1201,3 +1201,106 @@ var (
 		},
 	}
 )
+
+// InferaDeployment / DynamoDeployment slot pod specs embed a core/v1 PodSpec
+// inline, so containers and volumes sit directly under extraPodSpec with no
+// nested "spec" wrapper. Fixture mirrors a rendered two-role IDEP.
+var (
+	TestInferaDeploymentData = `
+apiVersion: infera.amd.com/v1alpha1
+kind: InferaDeployment
+metadata:
+  name: infera-test
+  namespace: primus-safe
+  annotations:
+    primus-safe.workload.main.container: main
+spec:
+  services:
+    role0:
+      replicas: 1
+      role: frontend
+      extraPodSpec:
+        containers:
+          - name: main
+            image: infera:router
+            command:
+              - /bin/sh
+              - -c
+              - exec /bin/sh launcher.sh Um91dGVy
+            env:
+              - name: NATS_SERVER
+                value: nats://nats.primus-safe.svc:4222
+            resources:
+              limits:
+                cpu: "4"
+                ephemeral-storage: 50Gi
+                memory: 16Gi
+              requests:
+                cpu: "4"
+                ephemeral-storage: 50Gi
+                memory: 16Gi
+        volumes:
+          - emptyDir:
+              medium: Memory
+              sizeLimit: 20Gi
+            name: shared-memory
+    role1:
+      replicas: 1
+      role: prefill
+      extraPodSpec:
+        containers:
+          - name: main
+            image: infera:engine
+            command:
+              - /bin/sh
+              - -c
+              - exec /bin/sh launcher.sh UHJlZmlsbA==
+            env:
+              - name: NATS_SERVER
+                value: nats://nats.primus-safe.svc:4222
+            resources:
+              limits:
+                cpu: "64"
+                ephemeral-storage: 100Gi
+                memory: 256Gi
+                amd.com/gpu: "8"
+              requests:
+                cpu: "64"
+                ephemeral-storage: 100Gi
+                memory: 256Gi
+                amd.com/gpu: "8"
+        volumes:
+          - emptyDir:
+              medium: Memory
+              sizeLimit: 200Gi
+            name: shared-memory
+      `
+
+	TestInferaResourceTemplate = &v1.ResourceTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "infera-deployment",
+			Labels: map[string]string{
+				v1.WorkloadVersionLabel: "v1",
+			},
+			Annotations: map[string]string{
+				v1.WorkloadKindLabel: common.InferaDeploymentKind,
+			},
+		},
+		Spec: v1.ResourceTemplateSpec{
+			GroupVersionKind: v1.GroupVersionKind{
+				Group:   "infera.amd.com",
+				Version: "v1alpha1",
+				Kind:    common.InferaDeploymentKind,
+			},
+			ResourceSpecs: []v1.ResourceSpec{{
+				PrePaths:      []string{"spec", "services", "role0"},
+				TemplatePaths: []string{"extraPodSpec"},
+				ReplicasPaths: []string{"replicas"},
+			}, {
+				PrePaths:      []string{"spec", "services", "role1"},
+				TemplatePaths: []string{"extraPodSpec"},
+				ReplicasPaths: []string{"replicas"},
+			}},
+		},
+	}
+)

--- a/SaFE/job-manager/pkg/utils/test_data.go
+++ b/SaFE/job-manager/pkg/utils/test_data.go
@@ -657,10 +657,12 @@ var (
 			ResourceSpecs: []v1.ResourceSpec{{
 				PrePaths:      []string{"spec", "pytorchReplicaSpecs", "Master"},
 				TemplatePaths: []string{"template"},
+				PodSpecPaths:  []string{"template", "spec"},
 				ReplicasPaths: []string{"replicas"},
 			}, {
 				PrePaths:      []string{"spec", "pytorchReplicaSpecs", "Worker"},
 				TemplatePaths: []string{"template"},
+				PodSpecPaths:  []string{"template", "spec"},
 				ReplicasPaths: []string{"replicas"},
 			}},
 			ResourceStatus: v1.ResourceStatus{
@@ -719,6 +721,7 @@ var (
 			ResourceSpecs: []v1.ResourceSpec{{
 				PrePaths:         []string{"spec"},
 				TemplatePaths:    []string{"template"},
+				PodSpecPaths:     []string{"template", "spec"},
 				ReplicasPaths:    []string{"parallelism"},
 				MinReplicasPaths: []string{"completions"},
 			}},
@@ -786,6 +789,7 @@ var (
 			},
 			ResourceSpecs: []v1.ResourceSpec{{
 				PrePaths:      []string{"spec"},
+				PodSpecPaths:  []string{"podTemplate"},
 				ReplicasPaths: []string{"replicas"},
 			}},
 		},
@@ -810,6 +814,7 @@ var (
 			ResourceSpecs: []v1.ResourceSpec{{
 				PrePaths:      []string{"spec"},
 				TemplatePaths: []string{"template"},
+				PodSpecPaths:  []string{"template", "spec"},
 				ReplicasPaths: []string{"replicas"},
 			}},
 			ResourceStatus: v1.ResourceStatus{
@@ -863,6 +868,7 @@ var (
 			ResourceSpecs: []v1.ResourceSpec{{
 				PrePaths:      []string{"spec"},
 				TemplatePaths: []string{"template"},
+				PodSpecPaths:  []string{"template", "spec"},
 				ReplicasPaths: []string{"replicas"},
 			}},
 			ActiveReplica: v1.ActiveReplica{
@@ -891,6 +897,7 @@ var (
 			ResourceSpecs: []v1.ResourceSpec{{
 				PrePaths:      []string{"spec"},
 				TemplatePaths: []string{"template"},
+				PodSpecPaths:  []string{"template", "spec"},
 			}},
 		},
 	}
@@ -912,7 +919,8 @@ var (
 				Kind:    "EphemeralRunner",
 			},
 			ResourceSpecs: []v1.ResourceSpec{{
-				PrePaths: []string{"spec"},
+				PrePaths:     []string{"spec"},
+				PodSpecPaths: []string{"spec"},
 			}},
 			ResourceStatus: v1.ResourceStatus{
 				PrePaths:     []string{"status"},
@@ -962,18 +970,22 @@ var (
 			ResourceSpecs: []v1.ResourceSpec{{
 				PrePaths:      []string{"spec"},
 				TemplatePaths: []string{"submitterPodTemplate"},
+				PodSpecPaths:  []string{"submitterPodTemplate", "spec"},
 			}, {
 				PrePaths:      []string{"spec", "rayClusterSpec", "headGroupSpec"},
 				TemplatePaths: []string{"template"},
+				PodSpecPaths:  []string{"template", "spec"},
 			}, {
 				PrePaths:         []string{"spec", "rayClusterSpec", "workerGroupSpecs", "0"},
 				TemplatePaths:    []string{"template"},
+				PodSpecPaths:     []string{"template", "spec"},
 				ReplicasPaths:    []string{"replicas"},
 				MinReplicasPaths: []string{"minReplicas"},
 				MaxReplicasPaths: []string{"maxReplicas"},
 			}, {
 				PrePaths:         []string{"spec", "rayClusterSpec", "workerGroupSpecs", "1"},
 				TemplatePaths:    []string{"template"},
+				PodSpecPaths:     []string{"template", "spec"},
 				ReplicasPaths:    []string{"replicas"},
 				MinReplicasPaths: []string{"minReplicas"},
 				MaxReplicasPaths: []string{"maxReplicas"},
@@ -1197,6 +1209,7 @@ var (
 			ResourceSpecs: []v1.ResourceSpec{{
 				PrePaths:      []string{"spec"},
 				TemplatePaths: []string{"podTemplate"},
+				PodSpecPaths:  []string{"podTemplate", "spec"},
 			}},
 		},
 	}
@@ -1317,10 +1330,12 @@ spec:
 			ResourceSpecs: []v1.ResourceSpec{{
 				PrePaths:      []string{"spec", "services", "role0"},
 				TemplatePaths: []string{"extraPodSpec"},
+				PodSpecPaths:  []string{"extraPodSpec"},
 				ReplicasPaths: []string{"replicas"},
 			}, {
 				PrePaths:      []string{"spec", "services", "role1"},
 				TemplatePaths: []string{"extraPodSpec"},
+				PodSpecPaths:  []string{"extraPodSpec"},
 				ReplicasPaths: []string{"replicas"},
 			}},
 		},

--- a/SaFE/job-manager/pkg/utils/test_data.go
+++ b/SaFE/job-manager/pkg/utils/test_data.go
@@ -1213,7 +1213,7 @@ metadata:
   name: infera-test
   namespace: primus-safe
   annotations:
-    primus-safe.workload.main.container: main
+    primus-safe.main.container: main
 spec:
   services:
     role0:
@@ -1221,6 +1221,28 @@ spec:
       role: frontend
       extraPodSpec:
         containers:
+          # Deliberately ordered before "main" so the getters have to select by
+          # the main-container annotation rather than falling back to
+          # containers[0]. Its command/env/resources differ from main's so a
+          # broken selection fails the assertions instead of passing by luck.
+          - name: sidecar
+            image: infera:sidecar
+            command:
+              - /sidecar
+            env:
+              - name: SIDECAR_A
+                value: "a"
+              - name: SIDECAR_B
+                value: "b"
+            resources:
+              limits:
+                cpu: "1"
+                ephemeral-storage: 10Gi
+                memory: 2Gi
+              requests:
+                cpu: "1"
+                ephemeral-storage: 10Gi
+                memory: 2Gi
           - name: main
             image: infera:router
             command:

--- a/SaFE/job-manager/pkg/utils/unstructured.go
+++ b/SaFE/job-manager/pkg/utils/unstructured.go
@@ -187,6 +187,15 @@ func convertUnstructuredToString(obj map[string]interface{}, paths []string) str
 	return stringutil.ConvertToString(result)
 }
 
+// containersPath resolves where a resource spec's containers live. Kinds whose
+// slot embeds a PodSpec inline (DynamoDeployment, InferaDeployment) keep
+// containers directly under the template path, so the segment must come from
+// the kind rather than being assumed to be "spec".
+func containersPath(t v1.ResourceSpec, kind string) []string {
+	return commonworkload.BuildPodSpecPath(t.TemplatePath(),
+		commonworkload.PodSpecSegment(kind), "containers")
+}
+
 // GetResources Retrieve the replica count and the resource specifications of the main container.
 func GetResources(unstructuredObj *unstructured.Unstructured,
 	rt *v1.ResourceTemplate, gpuName string, maxResource int) ([]int64, []corev1.ResourceList, error) {
@@ -209,9 +218,7 @@ func GetResources(unstructuredObj *unstructured.Unstructured,
 			}
 		}
 
-		path := t.PrePaths
-		path = append(path, t.TemplatePaths...)
-		path = append(path, "spec", "containers")
+		path := containersPath(t, rt.SpecKind())
 		containers, found, err := NestedSlice(unstructuredObj.Object, path)
 		if err != nil {
 			klog.ErrorS(err, "failed to find containers", "path", path)
@@ -260,9 +267,7 @@ func GetCommands(unstructuredObj *unstructured.Unstructured,
 		if i >= maxResource {
 			break
 		}
-		path := t.PrePaths
-		path = append(path, t.TemplatePaths...)
-		path = append(path, "spec", "containers")
+		path := containersPath(t, rt.SpecKind())
 		containers, found, err := NestedSlice(unstructuredObj.Object, path)
 		if err != nil {
 			klog.ErrorS(err, "failed to find containers", "path", path)
@@ -310,9 +315,7 @@ func GetImages(unstructuredObj *unstructured.Unstructured,
 		if i >= maxResource {
 			break
 		}
-		path := t.PrePaths
-		path = append(path, t.TemplatePaths...)
-		path = append(path, "spec", "containers")
+		path := containersPath(t, rt.SpecKind())
 		containers, found, err := NestedSlice(unstructuredObj.Object, path)
 		if err != nil {
 			klog.ErrorS(err, "failed to find containers", "path", path)
@@ -354,9 +357,8 @@ func GetMemoryStorageSize(unstructuredObj *unstructured.Unstructured, rt *v1.Res
 		if i >= maxResource {
 			break
 		}
-		path := t.PrePaths
-		path = append(path, t.TemplatePaths...)
-		path = append(path, "spec", "volumes")
+		path := commonworkload.BuildPodSpecPath(t.TemplatePath(),
+			commonworkload.PodSpecSegment(rt.SpecKind()), "volumes")
 		volumes, found, err := NestedSlice(unstructuredObj.Object, path)
 		if err != nil {
 			klog.ErrorS(err, "failed to find volumes", "path", path)
@@ -545,8 +547,7 @@ func GetEnv(unstructuredObj *unstructured.Unstructured,
 		if i >= maxResource {
 			break
 		}
-		templatePath := t.TemplatePath()
-		path := append(templatePath, "spec", "containers")
+		path := containersPath(t, rt.SpecKind())
 		containers, found, err := NestedSlice(unstructuredObj.Object, path)
 		if err != nil {
 			klog.ErrorS(err, "failed to find containers", "path", path)

--- a/SaFE/job-manager/pkg/utils/unstructured.go
+++ b/SaFE/job-manager/pkg/utils/unstructured.go
@@ -187,13 +187,10 @@ func convertUnstructuredToString(obj map[string]interface{}, paths []string) str
 	return stringutil.ConvertToString(result)
 }
 
-// containersPath resolves where a resource spec's containers live. Kinds whose
-// slot embeds a PodSpec inline (DynamoDeployment, InferaDeployment) keep
-// containers directly under the template path, so the segment must come from
-// the kind rather than being assumed to be "spec".
+// containersPath resolves where a resource spec's containers live, from the
+// pod spec path the ResourceTemplate declares.
 func containersPath(t v1.ResourceSpec, kind string) []string {
-	return commonworkload.BuildPodSpecPath(t.TemplatePath(),
-		commonworkload.PodSpecSegment(kind), "containers")
+	return commonworkload.ResolvePodSpecPath(&t, kind, "containers")
 }
 
 // GetResources Retrieve the replica count and the resource specifications of the main container.
@@ -356,8 +353,7 @@ func GetMemoryStorageSize(unstructuredObj *unstructured.Unstructured, rt *v1.Res
 		if i >= maxResource {
 			break
 		}
-		path := commonworkload.BuildPodSpecPath(t.TemplatePath(),
-			commonworkload.PodSpecSegment(rt.SpecKind()), "volumes")
+		path := commonworkload.ResolvePodSpecPath(&t, rt.SpecKind(), "volumes")
 		volumes, found, err := NestedSlice(unstructuredObj.Object, path)
 		if err != nil {
 			klog.ErrorS(err, "failed to find volumes", "path", path)
@@ -441,11 +437,9 @@ func GetPriorityClassName(unstructuredObj *unstructured.Unstructured, rt *v1.Res
 		if i >= maxResource {
 			break
 		}
-		// Resolves the segment the way updatePriorityClass writes it: directly
-		// under the template path for inline-PodSpec kinds, under "spec"
-		// otherwise.
-		path := commonworkload.BuildPodSpecPath(t.TemplatePath(),
-			commonworkload.PodSpecSegment(rt.SpecKind()), "priorityClassName")
+		// Resolves the pod spec path the way updatePriorityClass writes it,
+		// through the ResourceTemplate's podSpecPaths.
+		path := commonworkload.ResolvePodSpecPath(&t, rt.SpecKind(), "priorityClassName")
 		name, found, err := NestedString(unstructuredObj.Object, path)
 		if err != nil {
 			klog.ErrorS(err, "failed to find priorityClassName", "path", path)

--- a/SaFE/job-manager/pkg/utils/unstructured.go
+++ b/SaFE/job-manager/pkg/utils/unstructured.go
@@ -365,7 +365,13 @@ func GetMemoryStorageSize(unstructuredObj *unstructured.Unstructured, rt *v1.Res
 
 		shareMemory := GetMemoryStorageVolume(volumes)
 		if shareMemory != nil {
-			result = append(result, shareMemory["sizeLimit"].(string))
+			// A template may pre-declare the memory-backed volume without a
+			// sizeLimit; updateSharedMemory fills one in only when the workload
+			// asks for shared memory. Report the absent limit as the empty size
+			// the workload spec carries in that case, which keeps the drift
+			// check quiet instead of comparing against a missing key.
+			sizeLimit, _ := shareMemory["sizeLimit"].(string)
+			result = append(result, sizeLimit)
 		} else {
 			result = append(result, "0")
 		}

--- a/SaFE/job-manager/pkg/utils/unstructured.go
+++ b/SaFE/job-manager/pkg/utils/unstructured.go
@@ -206,8 +206,7 @@ func GetResources(unstructuredObj *unstructured.Unstructured,
 			break
 		}
 		if len(t.ReplicasPaths) > 0 {
-			path := t.PrePaths
-			path = append(path, t.ReplicasPaths...)
+			path := t.ReplicasPath()
 			replica, found, err := NestedInt64(unstructuredObj.Object, path)
 			if err != nil {
 				klog.ErrorS(err, "failed to find replicas", "path", path)
@@ -442,9 +441,11 @@ func GetPriorityClassName(unstructuredObj *unstructured.Unstructured, rt *v1.Res
 		if i >= maxResource {
 			break
 		}
-		path := t.PrePaths
-		path = append(path, t.TemplatePaths...)
-		path = append(path, "spec", "priorityClassName")
+		// Resolves the segment the way updatePriorityClass writes it: directly
+		// under the template path for inline-PodSpec kinds, under "spec"
+		// otherwise.
+		path := commonworkload.BuildPodSpecPath(t.TemplatePath(),
+			commonworkload.PodSpecSegment(rt.SpecKind()), "priorityClassName")
 		name, found, err := NestedString(unstructuredObj.Object, path)
 		if err != nil {
 			klog.ErrorS(err, "failed to find priorityClassName", "path", path)
@@ -526,9 +527,7 @@ func getIntValueByName(objects map[string]interface{}, name string) (int64, bool
 
 // GetLabels retrieves the labels from Unstructured object.
 func GetLabels(unstructuredObj *unstructured.Unstructured, resourceSpec v1.ResourceSpec) (map[string]interface{}, error) {
-	path := resourceSpec.PrePaths
-	path = append(path, resourceSpec.TemplatePaths...)
-	path = append(path, "metadata", "labels")
+	path := append(resourceSpec.TemplatePath(), "metadata", "labels")
 	labels, found, err := NestedMap(unstructuredObj.Object, path)
 	if err != nil {
 		klog.ErrorS(err, "failed to find labels", "path", path)

--- a/SaFE/job-manager/pkg/utils/unstructured_test.go
+++ b/SaFE/job-manager/pkg/utils/unstructured_test.go
@@ -681,3 +681,64 @@ func TestSetNestedField(t *testing.T) {
 	err = SetNestedField(obj, "test", []string{"spec", "workerGroupSpecs", "10", "name"})
 	assert.Assert(t, err != nil)
 }
+
+// InferaDeployment slot pod specs embed PodSpec inline (containers directly
+// under extraPodSpec). The getters used to hardcode a "spec" segment after the
+// template path, so every lookup missed and drift detection silently treated
+// a changed entrypoint as unchanged.
+func TestGetInlinePodSpecCommands(t *testing.T) {
+	idep, err := jsonutils.ParseYamlToJson(TestInferaDeploymentData)
+	assert.NilError(t, err)
+	rt := TestInferaResourceTemplate.DeepCopy()
+
+	commands, err := GetCommands(idep, rt, 2)
+	assert.NilError(t, err)
+	assert.Equal(t, len(commands), 2)
+	assert.Equal(t, len(commands[0]), 3)
+	assert.Equal(t, commands[0][2], "exec /bin/sh launcher.sh Um91dGVy")
+	assert.Equal(t, commands[1][2], "exec /bin/sh launcher.sh UHJlZmlsbA==")
+}
+
+func TestGetInlinePodSpecImages(t *testing.T) {
+	idep, err := jsonutils.ParseYamlToJson(TestInferaDeploymentData)
+	assert.NilError(t, err)
+	rt := TestInferaResourceTemplate.DeepCopy()
+
+	images, err := GetImages(idep, rt, 2)
+	assert.NilError(t, err)
+	assert.Equal(t, len(images), 2)
+	assert.Equal(t, images[0], "infera:router")
+	assert.Equal(t, images[1], "infera:engine")
+}
+
+func TestGetInlinePodSpecResources(t *testing.T) {
+	idep, err := jsonutils.ParseYamlToJson(TestInferaDeploymentData)
+	assert.NilError(t, err)
+	rt := TestInferaResourceTemplate.DeepCopy()
+
+	replicaList, resourceList, err := GetResources(idep, rt, common.AmdGpu, 2)
+	assert.NilError(t, err)
+	assert.Equal(t, len(replicaList), 2)
+	assert.Equal(t, len(resourceList), 2)
+	assert.Equal(t, resourceList[0].Cpu().Value(), int64(4))
+	assert.Equal(t, resourceList[1].Cpu().Value(), int64(64))
+	gpuQuantity, ok := resourceList[1][common.AmdGpu]
+	assert.Equal(t, ok, true)
+	assert.Equal(t, gpuQuantity.Value(), int64(8))
+}
+
+func TestGetInlinePodSpecEnvAndSharedMemory(t *testing.T) {
+	idep, err := jsonutils.ParseYamlToJson(TestInferaDeploymentData)
+	assert.NilError(t, err)
+	rt := TestInferaResourceTemplate.DeepCopy()
+
+	envs, err := GetEnv(idep, rt, 2)
+	assert.NilError(t, err)
+	assert.Equal(t, len(envs), 1)
+
+	sizes, err := GetMemoryStorageSize(idep, rt, 2)
+	assert.NilError(t, err)
+	assert.Equal(t, len(sizes), 2)
+	assert.Equal(t, sizes[0], "20Gi")
+	assert.Equal(t, sizes[1], "200Gi")
+}

--- a/SaFE/job-manager/pkg/utils/unstructured_test.go
+++ b/SaFE/job-manager/pkg/utils/unstructured_test.go
@@ -742,3 +742,44 @@ func TestGetInlinePodSpecEnvAndSharedMemory(t *testing.T) {
 	assert.Equal(t, sizes[0], "20Gi")
 	assert.Equal(t, sizes[1], "200Gi")
 }
+
+// TestGetMemoryStorageSizeWithoutSizeLimit covers a template that pre-declares
+// the memory-backed volume with no sizeLimit, which is the shape an
+// InferaDeployment carries whenever the workload asks for no shared memory:
+// updateSharedMemory returns before filling one in. The absent limit reads back
+// as the empty size the workload spec holds, so isSharedMemoryChanged sees no
+// drift.
+func TestGetMemoryStorageSizeWithoutSizeLimit(t *testing.T) {
+	idep := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "infera.amd.com/v1alpha1",
+		"kind":       common.InferaDeploymentKind,
+		"spec": map[string]interface{}{
+			"services": map[string]interface{}{
+				"role0": map[string]interface{}{
+					"extraPodSpec": map[string]interface{}{
+						"volumes": []interface{}{
+							map[string]interface{}{
+								"name":     "shared-memory",
+								"emptyDir": map[string]interface{}{"medium": "Memory"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}}
+	rt := &v1.ResourceTemplate{
+		Spec: v1.ResourceTemplateSpec{
+			GroupVersionKind: v1.GroupVersionKind{Kind: common.InferaDeploymentKind},
+			ResourceSpecs: []v1.ResourceSpec{{
+				PrePaths:     []string{"spec", "services", "role0"},
+				PodSpecPaths: []string{"extraPodSpec"},
+			}},
+		},
+	}
+
+	sizes, err := GetMemoryStorageSize(idep, rt, 1)
+	assert.NilError(t, err)
+	assert.Equal(t, len(sizes), 1)
+	assert.Equal(t, sizes[0], "")
+}


### PR DESCRIPTION
## Summary

The drift-detection readers in `job-manager/pkg/utils/unstructured.go` hardcoded a `"spec"` segment after a `ResourceSpec`'s template path, while the writer resolved that segment from the workload kind via `getPodSpec`. The two disagreed for every kind whose slot does not wrap its pod in a `PodTemplateSpec`.

For an `InferaDeployment`, containers live at `spec.services.role0.extraPodSpec.containers`, but the readers looked for `spec.services.role0.extraPodSpec.spec.containers`:

```
failed to find containers, path: [spec services role0 extraPodSpec spec containers]
```

`MonarchMesh` has the same shape: the writer resolves `spec.podTemplate.containers`, the readers looked in `spec.spec.containers`.

## Impact

Every reader on the sync path is affected, not just the entrypoint one — `isEntrypointChanged`, `isImagesChanged`, `isResourceChanged`, `isEnvChanged` and `isSharedMemoryChanged` all resolve containers through the same helper. They do not fail the same way, and that is what makes the bug destructive rather than inert:

- `GetCommands` / `GetImages` return an error that is logged and swallowed into `return false`, and `GetResources` `continue`s past the miss so its result is short and the comparison is skipped — these read as "nothing changed".
- `GetMemoryStorageSize` and `GetPriorityClassName` return an error too, but `isSharedMemoryChanged` and `isPriorityClassChanged` translate an error into `return true` — "everything changed".

The second group wins. For an `InferaDeployment` on `main`, `isSharedMemoryChanged` fires on **every** reconcile, so `applyWorkloadSpecToObject` re-runs every time. The writers resolve their paths correctly, so the re-apply lands — and rewrites the command from `Workload.Spec.EntryPoints` alone. **The sglang flags `normalizeInferaIDEP` injected at create time are stripped on the first reconcile, silently degrading a PD deployment to aggregated**, and a multi-node role's pinned `replicas: 1` is overwritten with the node count, turning one LeaderWorkerSet group of N nodes into N groups.

So the user-visible effect is not a dropped edit; it is a deployment that breaks itself shortly after it is created, with nothing in the log beyond the path error.

`DynamoDeployment` has the same path bug, but `syncWorkloadToObject` returns early for it, so nothing observable changes there. `MonarchMesh` shares the bug in the readers, but `syncWorkloadToObject` is only reached for `IsApplication()` or `IsCICDScalingRunnerSet()` workloads and MonarchMesh is neither, so its paths are fixed here without any behavior change today.

## What changed

- **`podSpecPaths` on `ResourceSpec`**, declared for every template the chart ships. The pod spec location is now data on the CR rather than two independent derivations in code. `ResolvePodSpecPath` prefers the declaration and falls back to the kind-derived default, so an out-of-date `ResourceTemplate` keeps working.
- **`commonworkload.PodSpecSegment` / `BuildPodSpecPath`** — the fallback, extracted from the logic the writer already had. Both the readers and `dispatcher_help.go`'s `getPodSpec` / `buildPodSpecPath` now go through it, so a reader and a writer can no longer drift apart. The resolved paths for existing kinds are unchanged.
- **Path accessors return fresh slices** (`joinPrePaths`). `TemplatePath` used to append onto `PrePaths`' backing array, which could write through and corrupt the cached `ResourceTemplate` for later reads.
- **`InferaDeployment` command handling** — see below.

## Why the InferaDeployment command needs its own handling

Fixing the readers alone would regress Infera. `syncWorkloadToObject` re-derives each command from `Workload.Spec.EntryPoints`, but `normalizeInferaIDEP` appends the sglang disaggregation and multi-node args to the IDEP's launcher payload **without** writing them back to the Workload. With drift detection working, the first reconcile would strip `--disaggregation-mode` / `--disaggregation-transfer-backend` / `--disaggregation-bootstrap-port` and silently degrade a PD deployment to aggregated.

An earlier revision of this branch handled that by exempting the command for `InferaDeployment` as a whole (`d514dbc3`, `10c29afc`). That was too coarse. The injected flags only exist for the roles that get them: `prefill`/`decode` via `applyInferaRoleFields`, and a multi-node role with more than one node via `appendSglangMultinodeArgs`. A `frontend`, or a `worker` that is not multi-node — which is the **default** `[frontend, worker]` shape `GetInferaServiceRoles` falls back to — gets neither, so the exemption dropped a legitimate entrypoint edit for exactly the most common deployment. That is a regression against `main`, where the edit at least failed loudly in the log.

`aa9d78b3` replaces the exemption with a rebuild. `inferaLauncherFlags` reproduces exactly the flags `normalizeInferaIDEP` grafts for a given role, and `expectedCommands` / `expectedEntryPoint` wrap `buildCommands` / `buildEntryPoint` with them, so read side and write side compute the same string. The result:

- an `entryPoints` edit reaches every role, including the flagless ones;
- a steady-state IDEP reports no drift, so there is no reconcile churn;
- the create path is byte-identical — the flags land first and `normalizeInferaIDEP`'s per-flag dedup (`stripUserDeclaredFlags`) makes its second pass a no-op.

Rebuilding `--nnodes` on sync exposed a second half of the same problem: a multi-node role's node count also lives in the slot's flat `numberOfNodes` field, which `normalizeInferaIDEP` wrote on create only. Scaling the role would have moved the flag and left the field behind, giving a LeaderWorkerSet group of the old size a rendezvous for the new one — and since `replicas` stays pinned at 1, no drift check would ever have fired on it. `updateInferaNodeCount` writes the field next to `replicas`, and removes it when the role scales to a single node or leaves `multinode-roles`.

The condition for simplifying all of this later is unchanged: have the injected flags round-trip into the Workload.

## Behavior changes on upgrade

- **`InferaDeployment`**: the reconcile stops rewriting the command from `EntryPoints` alone, so an existing PD or multi-node deployment keeps its injected flags and its `replicas: 1` pinning instead of losing them. An IDEP that `main` has already degraded is repaired on the first reconcile after this rolls out, which restarts its pods — that is the intended repair, but it is a restart.
- **`MonarchMesh`**: paths are corrected, but the readers are never reached for this kind (see Impact), so there is no behavior change.
- **Everything else** (`PyTorchJob`, `Deployment`, `RayJob`, `Job`, …) resolves to the same paths as before and is unaffected.

## Test plan

- [x] Reproduction tests in `job-manager/pkg/utils/unstructured_test.go` over a rendered two-role IDEP fixture, covering commands, images, resources, env and shared memory. All fail on `main` with the path error above.
- [x] `TestShippedResourceTemplatesDeclarePodSpecPaths` parses the real chart, and asserts every shipped `resourceSpec` declares `podSpecPaths` that resolve to the same path as the code default — for the CR's own kind and every kind in its `primus-safe.workload.kind` annotation. A future template that forgets the declaration, or declares a wrong one, fails here.
- [x] Infera command coverage in `dispatcher_help_test.go`: `inferaLauncherFlags` over all role shapes; the `[frontend, worker]` regression (a stale command must be rebuilt); flag re-graft for a multi-node decode role, asserted byte-exact on the decoded payload; create-path idempotency against `normalizeInferaIDEP`; `isEntrypointChanged` for flagless and injected roles.
- [x] `updateInferaNodeCount` covered for scale-up (field and `--nnodes` must agree), scale-down to one node, a role leaving `multinode-roles`, and a non-Infera object left alone — plus a test asserting the sync write lands on the same path `normalizeInferaIDEP` uses on create.
- [x] `appendLauncherFlags` covered for bare, single-quoted and double-quoted payloads, asserting the entry's prefix and trailing quote both survive the splice.
- [x] `expectedReplica` pinned at both production call sites (`isResourceChanged`, `updateReplica`), and `updateMetadata`'s Infera early return covered with a PyTorchJob control.
- [x] Every new assertion mutation-tested — reverting each fix in turn produces exactly the expected failure.
- [x] `go build` and `go vet` clean on the touched modules; `go test ./apis/... ./common/... ./job-manager/... -gcflags=all=-l` fully green. Without `-gcflags=all=-l` two tests fail (`TestPlatformKeyForUser`, `TestServerStartInited`); both are gomonkey patches defeated by inlining, both reproduce identically on a clean `main`, and neither is touched by this branch.

## Notes for the reviewer

- The branch touches 13 files, above the usual limit, but the reader fix and the Infera command handling cannot land separately: shipping the former without the latter is the flag-stripping regression described above.
- `appendLauncherFlags`'s lost trailing quote predates this branch — it was in `appendLauncherArgs` all along. Extracting the string half for the read side is what made it worth fixing here rather than separately.
- `isEntrypointChanged` and its siblings still treat a read error as "unchanged", while `isSharedMemoryChanged` and `isPriorityClassChanged` treat the same error as "changed". That inconsistency is the design flaw that turned a path bug into a self-destructing deployment; making them all surface the error is a larger behavioral change and deliberately out of scope here.

Made with [Cursor](https://cursor.com)
