### PR TITLE
fix(apiserver): repair CICD GitHub auth secret lifecycle

### DIFF
--- a/SaFE/apiserver/pkg/handlers/resources/cicd.go
+++ b/SaFE/apiserver/pkg/handlers/resources/cicd.go
@@ -15,6 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
 
 	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
@@ -64,55 +65,129 @@ func (h *Handler) createCICDSecret(ctx context.Context,
 	return secret, nil
 }
 
-// updateCICDSecret updates the CICD secret by creating a new secret and deleting the old one.
-// This replaces the existing GitHub auth secret with a new one for CICD scaling runner workloads.
-func (h *Handler) updateCICDSecret(ctx context.Context,
-	workload *v1.Workload, requestUser *v1.User, auth *view.GitHubAuthRequest) error {
+// cicdSecretRotation describes a CICD GitHub auth secret that updateCICDSecret created
+// but whose workload annotation the caller has not persisted yet.
+//
+// SupersededSecretId is empty when the workload had no usable secret before, which is
+// why this is a struct and not a bare id: "no previous secret to drop" and "no rotation
+// happened at all" need different handling and a single empty string cannot tell them
+// apart.
+type cicdSecretRotation struct {
+	// NewSecretId is the replacement secret, already created and referenced by the
+	// in-memory workload annotation.
+	NewSecretId string
+	// SupersededSecretId is the secret the replacement displaced, still present in the
+	// cluster so a failed persist can fall back to it. Empty when there was none.
+	SupersededSecretId string
+}
+
+// updateCICDSecret rotates the CICD GitHub auth secret: it creates the replacement
+// secret and repoints the workload annotation at it, both in memory.
+//
+// It deliberately does NOT delete the superseded secret. The annotation is only
+// persisted by the caller, after this returns; deleting the old secret here would mean
+// a failed persist leaves the stored annotation pointing at a secret that no longer
+// exists, which breaks the ARC githubConfigSecret with no way back. Instead the caller
+// gets both ids and settles them once the annotation is durable -- see
+// deleteSupersededCICDSecret and discardRolledBackCICDSecret.
+//
+// A nil rotation means the submitted credentials already match the current secret and
+// nothing was created or changed.
+func (h *Handler) updateCICDSecret(ctx context.Context, workload *v1.Workload,
+	requestUser *v1.User, auth *view.GitHubAuthRequest) (*cicdSecretRotation, error) {
 	if err := validateCICDGitHubAuth(auth); err != nil {
-		return err
+		return nil, err
 	}
 	oldSecretId := v1.GetGithubSecretId(workload)
 	if oldSecretId != "" {
 		oldSecret, err := h.getAdminSecret(ctx, oldSecretId)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
+				// The annotation is stale; there is nothing to fall back to or delete.
 				oldSecretId = ""
 			} else {
-				return fmt.Errorf("failed to get existing CICD GitHub secret %q: %w", oldSecretId, err)
+				return nil, fmt.Errorf("failed to get existing CICD GitHub secret %q: %w", oldSecretId, err)
 			}
 		} else if cicdSecretDataMatchesAuth(oldSecret, auth) {
-			return nil
+			return nil, nil
 		}
 	}
 
 	newSecret, err := h.createCICDSecret(ctx, workload, requestUser, auth)
 	if err != nil {
-		return err
-	}
-	if oldSecretId != "" {
-		if err = h.deleteSecretImpl(ctx, oldSecretId, requestUser); err != nil {
-			h.deleteSecretImpl(ctx, newSecret.Name, requestUser)
-			return err
-		}
+		return nil, err
 	}
 
 	v1.SetAnnotation(workload, v1.GithubSecretIdAnnotation, newSecret.Name)
-	return nil
+	return &cicdSecretRotation{NewSecretId: newSecret.Name, SupersededSecretId: oldSecretId}, nil
+}
+
+// deleteSupersededCICDSecret drops the secret a rotation replaced, once the new
+// annotation has been persisted. A failure here leaks a secret but does not invalidate
+// the rotation that already succeeded, so it is logged rather than returned: reporting
+// an error would push the caller into retrying a rotation that is already live. The
+// leaked secret still carries the workload's owner label, so the scheduler's
+// owner-label sweep collects it when the workload is deleted.
+func (h *Handler) deleteSupersededCICDSecret(ctx context.Context,
+	rotation *cicdSecretRotation, requestUser *v1.User) {
+	if rotation == nil || rotation.SupersededSecretId == "" {
+		return
+	}
+	if err := h.deleteSecretImpl(ctx, rotation.SupersededSecretId, requestUser); err != nil {
+		klog.ErrorS(err, "failed to delete superseded CICD GitHub secret", "secret", rotation.SupersededSecretId)
+	}
+}
+
+// discardRolledBackCICDSecret undoes a rotation whose annotation the caller could not
+// persist. The stored workload still refers to the superseded secret, so the
+// replacement is unreachable and is deleted, and the in-memory annotation is put back
+// to match what is actually stored.
+func (h *Handler) discardRolledBackCICDSecret(ctx context.Context,
+	workload *v1.Workload, rotation *cicdSecretRotation, requestUser *v1.User) {
+	if rotation == nil {
+		return
+	}
+	if rotation.NewSecretId != "" {
+		if err := h.deleteSecretImpl(ctx, rotation.NewSecretId, requestUser); err != nil {
+			klog.ErrorS(err, "failed to delete unreferenced CICD GitHub secret", "secret", rotation.NewSecretId)
+		}
+	}
+	if rotation.SupersededSecretId != "" {
+		v1.SetAnnotation(workload, v1.GithubSecretIdAnnotation, rotation.SupersededSecretId)
+		return
+	}
+	delete(workload.Annotations, v1.GithubSecretIdAnnotation)
 }
 
 // cleanupCICDSecrets deletes secrets created for CICD scaling runner set workloads.
 // This is called when workload creation fails to ensure orphaned secrets are cleaned up.
+//
+// Secrets are selected by owner label rather than by name: createCICDSecret names them
+// with commonutils.GenerateName, which appends a random suffix, so the workload's display
+// name never matches the object that was actually created. This mirrors how the
+// job-manager scheduler sweeps the same secrets when a workload is deleted -- but that
+// sweep only runs for a Workload that reached the API server, which is not the case for
+// every path that lands here.
 func (h *Handler) cleanupCICDSecrets(ctx context.Context, workload *v1.Workload) {
-	if !commonworkload.IsCICDScalingRunnerSet(workload) {
+	if workload == nil || !commonworkload.IsCICDScalingRunnerSet(workload) {
 		return
 	}
-	if err := h.clientSet.CoreV1().Secrets(common.PrimusSafeNamespace).Delete(
-		ctx, v1.GetDisplayName(workload), metav1.DeleteOptions{}); err != nil {
-		if !apierrors.IsNotFound(err) {
-			klog.ErrorS(err, "failed to delete secret", "name", v1.GetDisplayName(workload))
-		}
+	secrets, err := h.clientSet.CoreV1().Secrets(common.PrimusSafeNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(labels.Set{v1.OwnerLabel: workload.Name}).String(),
+	})
+	if err != nil {
+		klog.ErrorS(err, "failed to list CICD secrets", "workload", workload.Name)
+		return
 	}
-	klog.Infof("cleaned up CICD secret %s after workload %s creation failure", v1.GetDisplayName(workload), workload.Name)
+	for i := range secrets.Items {
+		name := secrets.Items[i].Name
+		if err = h.clientSet.CoreV1().Secrets(common.PrimusSafeNamespace).Delete(
+			ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			klog.ErrorS(err, "failed to delete secret", "name", name)
+			continue
+		}
+		klog.Infof("cleaned up CICD secret %s after workload %s creation failure", name, workload.Name)
+	}
 }
 
 // generateCICDScaleRunnerSet configures a workload for CICD scaling runner set.
@@ -151,11 +226,23 @@ func normalizeCICDGitHubAuth(auth *view.GitHubAuthRequest, env map[string]string
 	return nil
 }
 
+// cicdGitHubAuthType normalizes the submitted auth discriminator. The wire value is
+// whatever the caller typed, so "GITHUB_APP" and " Pat " have to select the same branch
+// as the canonical lowercase constants -- otherwise a GitHub App request is rejected as
+// an unsupported type. Every switch on the auth type goes through here so validation,
+// secret construction, and the idempotency check can never disagree about the branch.
+func cicdGitHubAuthType(auth *view.GitHubAuthRequest) string {
+	if auth == nil {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(auth.Type))
+}
+
 func validateCICDGitHubAuth(auth *view.GitHubAuthRequest) error {
 	if auth == nil {
 		return commonerrors.NewBadRequest("the github authentication is empty")
 	}
-	switch strings.TrimSpace(auth.Type) {
+	switch cicdGitHubAuthType(auth) {
 	case GitHubAuthTypeApp:
 		if strings.TrimSpace(auth.AppId) == "" ||
 			strings.TrimSpace(auth.InstallationId) == "" ||
@@ -173,7 +260,7 @@ func validateCICDGitHubAuth(auth *view.GitHubAuthRequest) error {
 }
 
 func buildCICDSecretParams(auth *view.GitHubAuthRequest) map[view.SecretParam]string {
-	switch strings.TrimSpace(auth.Type) {
+	switch cicdGitHubAuthType(auth) {
 	case GitHubAuthTypeApp:
 		return map[view.SecretParam]string{
 			GitHubAppId:             stringutil.Base64Encode(strings.TrimSpace(auth.AppId)),
@@ -190,7 +277,7 @@ func buildCICDSecretParams(auth *view.GitHubAuthRequest) map[view.SecretParam]st
 // cicdSecretDataMatchesAuth is an idempotency check that avoids rotating
 // credentials when the submitted values already match the existing ARC secret.
 func cicdSecretDataMatchesAuth(secret *corev1.Secret, auth *view.GitHubAuthRequest) bool {
-	switch strings.TrimSpace(auth.Type) {
+	switch cicdGitHubAuthType(auth) {
 	case GitHubAuthTypeApp:
 		return string(secret.Data[GitHubAppId]) == strings.TrimSpace(auth.AppId) &&
 			string(secret.Data[GitHubAppInstallationId]) == strings.TrimSpace(auth.InstallationId) &&

--- a/SaFE/apiserver/pkg/handlers/resources/cicd_test.go
+++ b/SaFE/apiserver/pkg/handlers/resources/cicd_test.go
@@ -123,10 +123,11 @@ func Test_updateCICDSecret_TokenUnchanged(t *testing.T) {
 	}
 
 	// Call updateCICDSecret with same token
-	err := h.updateCICDSecret(ctx, workload, user, patAuth(oldToken))
+	rotation, err := h.updateCICDSecret(ctx, workload, user, patAuth(oldToken))
 
 	// Should return nil without error (optimization kicks in)
 	assert.NilError(t, err)
+	assert.Assert(t, rotation == nil, "matching credentials should not rotate the secret")
 
 	// Verify the annotation is still pointing to old secret (not changed)
 	assert.Equal(t, v1.GetGithubSecretId(workload), secretName)
@@ -186,24 +187,170 @@ func Test_updateCICDSecret_TokenChanged(t *testing.T) {
 	}
 
 	// Call updateCICDSecret with new token
-	err := h.updateCICDSecret(ctx, workload, user, patAuth(newToken))
+	rotation, err := h.updateCICDSecret(ctx, workload, user, patAuth(newToken))
 
 	// Should succeed
 	assert.NilError(t, err)
+	assert.Assert(t, rotation != nil, "A changed token should produce a rotation")
 
 	// Verify annotation is updated to new secret
 	newSecretId := v1.GetGithubSecretId(workload)
 	assert.Assert(t, newSecretId != "", "New secret ID should be set")
 	assert.Assert(t, newSecretId != oldSecretName, "New secret ID should be different from old")
+	assert.Equal(t, rotation.NewSecretId, newSecretId)
+	assert.Equal(t, rotation.SupersededSecretId, oldSecretName)
 
 	// Verify new secret was created
 	newSecret, err := fakeClientSet.CoreV1().Secrets(common.PrimusSafeNamespace).Get(ctx, newSecretId, metav1.GetOptions{})
 	assert.NilError(t, err, "New secret should exist")
 	assert.Equal(t, string(newSecret.Data[GitHubToken]), newToken, "New secret should contain new token")
 
-	// Verify old secret is deleted (should not exist)
+	// The old secret must survive until the caller has persisted the annotation --
+	// deleting it here would strand the stored workload on a missing secret if the
+	// patch fails.
 	_, err = fakeClientSet.CoreV1().Secrets(common.PrimusSafeNamespace).Get(ctx, oldSecretName, metav1.GetOptions{})
-	assert.Assert(t, err != nil, "Old secret should be deleted")
+	assert.NilError(t, err, "Old secret should survive until the caller settles the rotation")
+
+	// Settling the rotation is what actually drops it.
+	h.deleteSupersededCICDSecret(ctx, rotation, user)
+	_, err = fakeClientSet.CoreV1().Secrets(common.PrimusSafeNamespace).Get(ctx, oldSecretName, metav1.GetOptions{})
+	assert.Assert(t, apierrors.IsNotFound(err), "Old secret should be deleted once the rotation is settled")
+}
+
+// Test_updateCICDSecret_UppercaseAuthType ensures the auth type discriminator is matched
+// case-insensitively: the wire value is whatever the caller typed, and a "GITHUB_APP"
+// request must build GitHub App keys rather than fall through to the PAT branch.
+func Test_updateCICDSecret_UppercaseAuthType(t *testing.T) {
+	ctx := context.Background()
+	workload := genMockWorkload("test-cluster", "test-workspace")
+	user := genMockUser()
+	role := genMockRole()
+
+	fakeCtrlClient := ctrlruntimefake.NewClientBuilder().
+		WithObjects(workload, user, role).
+		WithScheme(scheme.Scheme).
+		Build()
+	fakeClientSet := k8sfake.NewSimpleClientset()
+
+	h := Handler{
+		Client:           fakeCtrlClient,
+		clientSet:        fakeClientSet,
+		accessController: authority.NewAccessController(fakeCtrlClient),
+	}
+
+	auth := githubAppAuth("123456", "789012", "-----BEGIN RSA PRIVATE KEY-----\nkey\n-----END RSA PRIVATE KEY-----")
+	auth.Type = " GITHUB_APP "
+
+	rotation, err := h.updateCICDSecret(ctx, workload, user, auth)
+	assert.NilError(t, err)
+	assert.Assert(t, rotation != nil, "Uppercase github_app should be accepted and rotate")
+
+	secret, err := fakeClientSet.CoreV1().Secrets(common.PrimusSafeNamespace).Get(
+		ctx, rotation.NewSecretId, metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, string(secret.Data[GitHubAppId]), "123456")
+	assert.Equal(t, string(secret.Data[GitHubAppInstallationId]), "789012")
+	assert.Equal(t, string(secret.Data[GitHubAppPrivateKey]),
+		"-----BEGIN RSA PRIVATE KEY-----\nkey\n-----END RSA PRIVATE KEY-----")
+	_, hasToken := secret.Data[GitHubToken]
+	assert.Assert(t, !hasToken, "A github app secret must not carry a PAT key")
+
+	// The same values resubmitted with different casing must be recognised as unchanged.
+	sameAuth := githubAppAuth("123456", "789012",
+		"-----BEGIN RSA PRIVATE KEY-----\nkey\n-----END RSA PRIVATE KEY-----")
+	sameAuth.Type = "GitHub_App"
+	again, err := h.updateCICDSecret(ctx, workload, user, sameAuth)
+	assert.NilError(t, err)
+	assert.Assert(t, again == nil, "Unchanged github app credentials should not rotate")
+}
+
+// Test_discardRolledBackCICDSecret verifies the rollback path taken when the caller fails
+// to persist the annotation: the unreachable replacement is deleted and the in-memory
+// annotation is restored to whatever is actually stored.
+func Test_discardRolledBackCICDSecret(t *testing.T) {
+	ctx := context.Background()
+	user := genMockUser()
+	role := genMockRole()
+
+	t.Run("restores the superseded secret", func(t *testing.T) {
+		workload := genMockWorkload("test-cluster", "test-workspace")
+		oldSecretName := "old-secret-id"
+		oldSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      oldSecretName,
+				Namespace: common.PrimusSafeNamespace,
+				Labels: map[string]string{
+					v1.SecretTypeLabel: string(v1.SecretGeneral),
+					v1.UserIdLabel:     user.Name,
+					v1.OwnerLabel:      workload.Name,
+				},
+			},
+			Data: map[string][]byte{GitHubToken: []byte("old_token_123")},
+			Type: corev1.SecretTypeOpaque,
+		}
+		v1.SetAnnotation(workload, v1.GithubSecretIdAnnotation, oldSecretName)
+
+		fakeCtrlClient := ctrlruntimefake.NewClientBuilder().
+			WithObjects(workload, user, role).
+			WithScheme(scheme.Scheme).
+			Build()
+		fakeClientSet := k8sfake.NewSimpleClientset(oldSecret)
+		h := Handler{
+			Client:           fakeCtrlClient,
+			clientSet:        fakeClientSet,
+			accessController: authority.NewAccessController(fakeCtrlClient),
+		}
+
+		rotation, err := h.updateCICDSecret(ctx, workload, user, patAuth("new_token_456"))
+		assert.NilError(t, err)
+		assert.Assert(t, rotation != nil)
+
+		h.discardRolledBackCICDSecret(ctx, workload, rotation, user)
+
+		assert.Equal(t, v1.GetGithubSecretId(workload), oldSecretName,
+			"Annotation should be put back to the secret that is actually stored")
+		_, err = fakeClientSet.CoreV1().Secrets(common.PrimusSafeNamespace).Get(
+			ctx, rotation.NewSecretId, metav1.GetOptions{})
+		assert.Assert(t, apierrors.IsNotFound(err), "The unreachable replacement should be deleted")
+		_, err = fakeClientSet.CoreV1().Secrets(common.PrimusSafeNamespace).Get(
+			ctx, oldSecretName, metav1.GetOptions{})
+		assert.NilError(t, err, "The superseded secret should still be usable")
+	})
+
+	t.Run("clears the annotation when there was no previous secret", func(t *testing.T) {
+		workload := genMockWorkload("test-cluster", "test-workspace")
+		fakeCtrlClient := ctrlruntimefake.NewClientBuilder().
+			WithObjects(workload, user, role).
+			WithScheme(scheme.Scheme).
+			Build()
+		fakeClientSet := k8sfake.NewSimpleClientset()
+		h := Handler{
+			Client:           fakeCtrlClient,
+			clientSet:        fakeClientSet,
+			accessController: authority.NewAccessController(fakeCtrlClient),
+		}
+
+		rotation, err := h.updateCICDSecret(ctx, workload, user, patAuth("first_token"))
+		assert.NilError(t, err)
+		assert.Assert(t, rotation != nil)
+		assert.Equal(t, rotation.SupersededSecretId, "")
+
+		h.discardRolledBackCICDSecret(ctx, workload, rotation, user)
+
+		assert.Equal(t, v1.GetGithubSecretId(workload), "",
+			"Annotation should be cleared, there is nothing to fall back to")
+		_, err = fakeClientSet.CoreV1().Secrets(common.PrimusSafeNamespace).Get(
+			ctx, rotation.NewSecretId, metav1.GetOptions{})
+		assert.Assert(t, apierrors.IsNotFound(err), "The unreachable replacement should be deleted")
+	})
+
+	t.Run("is a no-op without a rotation", func(t *testing.T) {
+		workload := genMockWorkload("test-cluster", "test-workspace")
+		v1.SetAnnotation(workload, v1.GithubSecretIdAnnotation, "untouched-secret")
+		h := Handler{clientSet: k8sfake.NewSimpleClientset()}
+		h.discardRolledBackCICDSecret(ctx, workload, nil, user)
+		assert.Equal(t, v1.GetGithubSecretId(workload), "untouched-secret")
+	})
 }
 
 // Test_createCICDSecret_Success tests successful creation of CICD secret
@@ -544,14 +691,17 @@ func Test_updateCICDSecret_NoOldSecret(t *testing.T) {
 	}
 
 	// Call updateCICDSecret with new token
-	err := h.updateCICDSecret(ctx, workload, user, patAuth(newToken))
+	rotation, err := h.updateCICDSecret(ctx, workload, user, patAuth(newToken))
 
 	// Should succeed
 	assert.NilError(t, err)
+	assert.Assert(t, rotation != nil, "A first secret should still be reported as a rotation")
+	assert.Equal(t, rotation.SupersededSecretId, "", "There is no previous secret to drop")
 
 	// Verify annotation is set to new secret
 	newSecretId := v1.GetGithubSecretId(workload)
 	assert.Assert(t, newSecretId != "", "New secret ID should be set")
+	assert.Equal(t, rotation.NewSecretId, newSecretId)
 
 	// Verify new secret was created
 	newSecret, err := fakeClientSet.CoreV1().Secrets(common.PrimusSafeNamespace).Get(ctx, newSecretId, metav1.GetOptions{})
@@ -582,8 +732,11 @@ func Test_updateCICDSecret_MissingAnnotatedOldSecret(t *testing.T) {
 		accessController: authority.NewAccessController(fakeCtrlClient),
 	}
 
-	err := h.updateCICDSecret(ctx, workload, user, patAuth(newToken))
+	rotation, err := h.updateCICDSecret(ctx, workload, user, patAuth(newToken))
 	assert.NilError(t, err)
+	assert.Assert(t, rotation != nil)
+	assert.Equal(t, rotation.SupersededSecretId, "",
+		"A stale annotation points at nothing, so there is nothing to supersede")
 
 	newSecretId := v1.GetGithubSecretId(workload)
 	assert.Assert(t, newSecretId != "", "New secret ID should be set")
@@ -618,8 +771,9 @@ func Test_updateCICDSecret_OldSecretLookupError(t *testing.T) {
 		accessController: authority.NewAccessController(fakeCtrlClient),
 	}
 
-	err := h.updateCICDSecret(ctx, workload, user, patAuth("new_token_123"))
+	rotation, err := h.updateCICDSecret(ctx, workload, user, patAuth("new_token_123"))
 	assert.ErrorContains(t, err, "failed to get existing CICD GitHub secret")
+	assert.Assert(t, rotation == nil, "A failed lookup must not report a rotation to settle")
 	assert.Equal(t, v1.GetGithubSecretId(workload), "old-secret-id")
 }
 
@@ -723,21 +877,11 @@ func Test_generateCICDScaleRunnerSet_GitHubApp(t *testing.T) {
 	assert.Assert(t, !hasPAT, "GitHub App secret should not contain PAT key")
 }
 
-// Test_cleanupCICDSecrets_CICDWorkload tests cleanup deletes secret for CICD workload
-func Test_cleanupCICDSecrets_CICDWorkload(t *testing.T) {
-	ctx := context.Background()
-	workspaceId := "test-workspace"
-	clusterId := "test-cluster"
-
-	user := genMockUser()
-	role := genMockRole()
-
-	// Create a CICD scaling runner workload
+// genMockCICDWorkload returns a workload that satisfies IsCICDScalingRunnerSet.
+func genMockCICDWorkload(clusterId, workspaceId, name, displayName string) *v1.Workload {
 	workload := genMockWorkload(clusterId, workspaceId)
-	workload.Name = "cicd-runner-workload"
-	displayName := "CICD Runner"
+	workload.Name = name
 	v1.SetLabel(workload, v1.DisplayNameLabel, displayName)
-	// Set CICD specific fields
 	workload.Spec.GroupVersionKind = v1.GroupVersionKind{
 		Group:   "",
 		Version: "v1",
@@ -746,24 +890,41 @@ func Test_cleanupCICDSecrets_CICDWorkload(t *testing.T) {
 	workload.Spec.Env = map[string]string{
 		common.ScaleRunnerSetID: "test-runner-set",
 	}
+	return workload
+}
+
+// Test_cleanupCICDSecrets_CICDWorkload tests cleanup deletes the secrets a CICD workload
+// owns. The secrets are found by owner label, not by name: createCICDSecret names them
+// with commonutils.GenerateName, so the object in the cluster never has the workload's
+// display name and a name-based lookup would silently clean up nothing.
+func Test_cleanupCICDSecrets_CICDWorkload(t *testing.T) {
+	ctx := context.Background()
+	workspaceId := "test-workspace"
+	clusterId := "test-cluster"
+
+	user := genMockUser()
+	role := genMockRole()
+
+	workload := genMockCICDWorkload(clusterId, workspaceId, "cicd-runner-workload", "CICD Runner")
 
 	fakeCtrlClient := ctrlruntimefake.NewClientBuilder().
 		WithObjects(user, role, workload).
 		WithScheme(scheme.Scheme).
 		Build()
 
-	// Create the secret that should be cleaned up
-	secret := &corev1.Secret{
+	// A secret owned by a different workload must survive the sweep.
+	otherSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      displayName,
+			Name:      "other-workload-secret",
 			Namespace: common.PrimusSafeNamespace,
+			Labels: map[string]string{
+				v1.OwnerLabel: "some-other-workload",
+			},
 		},
-		Data: map[string][]byte{
-			GitHubToken: []byte("test-token"),
-		},
+		Data: map[string][]byte{GitHubToken: []byte("other-token")},
 	}
 
-	fakeClientSet := k8sfake.NewSimpleClientset(secret)
+	fakeClientSet := k8sfake.NewSimpleClientset(otherSecret)
 
 	h := Handler{
 		Client:           fakeCtrlClient,
@@ -771,14 +932,59 @@ func Test_cleanupCICDSecrets_CICDWorkload(t *testing.T) {
 		accessController: authority.NewAccessController(fakeCtrlClient),
 	}
 
-	// Verify secret exists before cleanup
-	_, err := fakeClientSet.CoreV1().Secrets(common.PrimusSafeNamespace).Get(ctx, displayName, metav1.GetOptions{})
-	assert.NilError(t, err, "Secret should exist before cleanup")
+	// Create the secret the same way the CICD path does, so its name carries the random
+	// suffix that GenerateName adds.
+	secret, err := h.createCICDSecret(ctx, workload, user, patAuth("test-token"))
+	assert.NilError(t, err)
+	assert.Assert(t, secret.Name != v1.GetDisplayName(workload),
+		"GenerateName must produce a name that differs from the display name")
+	assert.Equal(t, secret.Labels[v1.OwnerLabel], workload.Name)
 
 	// Call cleanupCICDSecrets on CICD workload
 	h.cleanupCICDSecrets(ctx, workload)
 
-	// Verify secret was deleted
-	_, err = fakeClientSet.CoreV1().Secrets(common.PrimusSafeNamespace).Get(ctx, displayName, metav1.GetOptions{})
-	assert.Assert(t, err != nil, "Secret should be deleted after cleanup")
+	// Verify the owned secret was deleted
+	_, err = fakeClientSet.CoreV1().Secrets(common.PrimusSafeNamespace).Get(ctx, secret.Name, metav1.GetOptions{})
+	assert.Assert(t, apierrors.IsNotFound(err), "Secret should be deleted after cleanup")
+
+	// Verify another workload's secret was left alone
+	_, err = fakeClientSet.CoreV1().Secrets(common.PrimusSafeNamespace).Get(
+		ctx, otherSecret.Name, metav1.GetOptions{})
+	assert.NilError(t, err, "Cleanup must not touch secrets owned by another workload")
+}
+
+// Test_cleanupCICDSecrets_Guards covers the inputs that must make cleanup a no-op: a nil
+// workload (cleanUpWorkloads calls this before its own nil check) and a non-CICD workload.
+func Test_cleanupCICDSecrets_Guards(t *testing.T) {
+	ctx := context.Background()
+	user := genMockUser()
+	role := genMockRole()
+
+	workload := genMockWorkload("test-cluster", "test-workspace")
+	workload.Name = "plain-workload"
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "plain-workload-secret",
+			Namespace: common.PrimusSafeNamespace,
+			Labels:    map[string]string{v1.OwnerLabel: workload.Name},
+		},
+	}
+
+	fakeCtrlClient := ctrlruntimefake.NewClientBuilder().
+		WithObjects(user, role, workload).
+		WithScheme(scheme.Scheme).
+		Build()
+	fakeClientSet := k8sfake.NewSimpleClientset(secret)
+	h := Handler{
+		Client:           fakeCtrlClient,
+		clientSet:        fakeClientSet,
+		accessController: authority.NewAccessController(fakeCtrlClient),
+	}
+
+	// Must not panic.
+	h.cleanupCICDSecrets(ctx, nil)
+
+	h.cleanupCICDSecrets(ctx, workload)
+	_, err := fakeClientSet.CoreV1().Secrets(common.PrimusSafeNamespace).Get(ctx, secret.Name, metav1.GetOptions{})
+	assert.NilError(t, err, "A non-CICD workload should not have its secrets swept")
 }

--- a/SaFE/apiserver/pkg/handlers/resources/workload.go
+++ b/SaFE/apiserver/pkg/handlers/resources/workload.go
@@ -608,14 +608,21 @@ func (h *Handler) updateWorkload(ctx context.Context,
 	if commonworkload.IsCICDScalingRunnerSet(adminWorkload) {
 		if auth := normalizeCICDGitHubAuth(req.GitHubAuth, requestEnv(req)); auth != nil {
 			patch := client.MergeFrom(adminWorkload.DeepCopy())
-			if err = h.updateCICDSecret(ctx, adminWorkload, requestUser, auth); err != nil {
-				klog.ErrorS(err, "failed to update cicd secret")
-				return err
+			rotation, secretErr := h.updateCICDSecret(ctx, adminWorkload, requestUser, auth)
+			if secretErr != nil {
+				klog.ErrorS(secretErr, "failed to update cicd secret")
+				return secretErr
 			}
+			// The rotation is only durable once the annotation lands. Until then the
+			// stored workload still points at the previous secret, so a failed patch
+			// discards the replacement and leaves the previous secret intact; the
+			// superseded one is dropped only after the patch succeeds.
 			if err = h.Patch(ctx, adminWorkload, patch); err != nil {
 				klog.ErrorS(err, "failed to patch workload")
+				h.discardRolledBackCICDSecret(ctx, adminWorkload, rotation, requestUser)
 				return err
 			}
+			h.deleteSupersededCICDSecret(ctx, rotation, requestUser)
 		}
 	}
 	return nil


### PR DESCRIPTION
## Background

A CICD runner-set workload authenticates to GitHub through a Kubernetes secret that ARC reads via `spec.githubConfigSecret`. Which keys that secret must carry depends on the auth type: a PAT needs `github_token`, a GitHub App needs `github_app_id`, `github_app_installation_id` and `github_app_private_key`. The apiserver builds that secret; the resource-manager mirrors it into the workspace namespace verbatim; the job-manager only ever writes the secret's *name* onto the `AutoscalingRunnerSet`, so it is auth-type agnostic. Nothing downstream inspects the contents.

That means the apiserver is the only place the GitHub App path can go wrong, and it is also the place where a wrong outcome is invisible: a malformed or missing secret does not fail the API call, it fails later inside ARC, as runners that never come up.

Reading that path end to end turned up three defects. All three exist for PAT auth too, but PAT is the case that has been exercised, and each one is worse for a GitHub App — an App secret is three keys instead of one, and it is the only thing standing between ARC and a working installation token.

## Changes

**Match the auth type case-insensitively.** `auth.Type` is whatever the caller put on the wire, but `validateCICDGitHubAuth`, `buildCICDSecretParams` and `cicdSecretDataMatchesAuth` each switched on the raw string against the lowercase constants. A `"GITHUB_APP"` request was therefore rejected outright as an unsupported type. Worse than the rejection is what the other two switches would have done had it slipped past validation: both have the PAT branch as their `default`, so they would have built a secret with a single `github_token` key base64-encoded from an empty `auth.Token`, and then `cicdSecretDataMatchesAuth` would have compared that empty token against itself and reported the credentials as unchanged forever. The three switches now go through one `cicdGitHubAuthType` helper that trims and lowercases, so validation, construction and the idempotency check cannot disagree about which branch they are on.

**Delete the superseded secret only once the annotation is durable.** `updateCICDSecret` deleted the old secret itself, before returning to a caller that had not yet persisted the annotation naming the new one. A failed `Patch` — a conflict, an apiserver blip — therefore left the *stored* workload pointing at a secret that no longer existed, and the new secret unreferenced. That state has no way back: the annotation is the only record of which secret a runner set uses, and it now names nothing.

The rotation is now reported to the caller rather than settled inside it. `updateCICDSecret` creates the replacement and repoints the in-memory annotation; `updateWorkload` settles the result — `deleteSupersededCICDSecret` after the patch lands, `discardRolledBackCICDSecret` if it does not, which deletes the unreachable replacement and puts the in-memory annotation back to what is actually stored.

The return is a `*cicdSecretRotation` struct and not a bare superseded-id string, because an empty string cannot distinguish "the submitted credentials already matched, nothing happened" from "a new secret was created and there was no previous one" — and those need opposite handling on the failure path. The first needs nothing; the second leaks a secret unless the replacement is deleted.

**Select secrets for cleanup by owner label.** `cleanupCICDSecrets` listed by the workload's display name, but `createCICDSecret` names secrets with `commonutils.GenerateName`, which appends a random suffix. The name it looked for is one the CICD path never creates, so the sweep matched nothing and every failed CICD workload creation leaked its credential secret — silently, since a failed delete is only logged. It now lists on `v1.OwnerLabel`, the key `generateSecret` already stamps and the same key the job-manager scheduler's `deleteRelatedSecrets` sweeps on when a workload is deleted.

It also guards against a nil workload: `cleanUpWorkloads` calls this before its own `mainWorkload != nil` check, so the nil case was reachable.

## Verification

- `go vet` and `gofmt` clean; `go test ./pkg/handlers/resources/...` passes
- The existing `Test_cleanupCICDSecrets_CICDWorkload` had to be rewritten rather than extended: it constructed a secret named literally `"CICD Runner"` with no owner label, which is an object the production path cannot produce, so it asserted the buggy behaviour was correct. It now creates the secret through `createCICDSecret` — the real name, with the real random suffix — and additionally asserts that a secret owned by a *different* workload survives the sweep
- New coverage for each fix in both directions: an uppercase `" GITHUB_APP "` builds App keys and no `github_token`, and the same values resubmitted as `"GitHub_App"` are recognised as unchanged; a changed token leaves the old secret in place until `deleteSupersededCICDSecret` runs; the rollback restores the previous annotation when there was a previous secret and clears it when there was not; cleanup is a no-op for a nil workload and for a non-CICD one
- `go build ./...` on the whole apiserver module fails in `containers/storage`'s btrfs cgo shim on a missing system header. Pre-existing and unrelated to this change — the packages this touches build and vet clean

## Not changed

The GitHub App support downstream of the secret is already correct and was checked rather than assumed: `credential_resolver.go` and `token_source.go` handle the JWT-then-installation-token exchange including PKCS1/PKCS8 keys and `\n`-literal PEMs, `buildSecretData` round-trips the base64 that `buildCICDSecretParams` writes, the key names match what ARC reads, and the data-plane mirror copies `Data` verbatim.
