### PR TITLE
fix(resource-manager): keep a node bound to a single workspace

### DIFF
--- a/SaFE/charts/primus-safe/templates/configmap/stateful_set_template.yaml
+++ b/SaFE/charts/primus-safe/templates/configmap/stateful_set_template.yaml
@@ -62,7 +62,7 @@ data:
                - name: NCCL_CHECKS_DISABLE
                  value: "1"
                - name: NCCL_IB_SL
-                 value: "0
+                 value: "0"
                - name: POD_IP
                  valueFrom:
                    fieldRef:

--- a/SaFE/resource-manager/pkg/resource/node_controller.go
+++ b/SaFE/resource-manager/pkg/resource/node_controller.go
@@ -176,6 +176,11 @@ func (r *NodeReconciler) delete(ctx context.Context, adminNode *v1.Node) (ctrlru
 }
 
 // getK8sNode retrieves the Kubernetes Node object in the data plane associated with the admin Node.
+//
+// Deliberately the uncached read: what this returns is written back -- Nodes().Update,
+// Nodes().UpdateStatus, and a patch body carrying its resourceVersion. kubelet moves that
+// version every few seconds with its heartbeat, so an informer copy would make all three
+// conflict periodically and drop taint/label/condition syncing into backoff.
 func (r *NodeReconciler) getK8sNode(ctx context.Context, adminNode *v1.Node) (*corev1.Node, ctrlruntime.Result, error) {
 	clusterName := getClusterId(adminNode)
 	k8sNodeName := adminNode.GetK8sNodeName()
@@ -186,7 +191,7 @@ func (r *NodeReconciler) getK8sNode(ctx context.Context, adminNode *v1.Node) (*c
 	if err != nil || !k8sClients.IsValid() {
 		return nil, ctrlruntime.Result{RequeueAfter: time.Second}, nil
 	}
-	k8sNode, err := getNodeByInformer(ctx, k8sClients, k8sNodeName)
+	k8sNode, err := getDataPlaneNode(ctx, k8sClients, k8sNodeName)
 	return k8sNode, ctrlruntime.Result{}, err
 }
 

--- a/SaFE/resource-manager/pkg/resource/node_helper.go
+++ b/SaFE/resource-manager/pkg/resource/node_helper.go
@@ -15,6 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apitypes "k8s.io/apimachinery/pkg/types"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -25,8 +26,39 @@ import (
 	"github.com/AMD-AIG-AIMA/SAFE/resource-manager/pkg/utils"
 )
 
-// getNodeByInformer retrieves a Kubernetes node by name using the informer client.
-func getNodeByInformer(ctx context.Context, k8sClients *commonclient.ClientFactory, nodeName string) (*corev1.Node, error) {
+// dataPlaneNodeLister returns the data plane's node lister, but only once that informer is
+// actually running and its cache has filled.
+//
+// The distinction matters because a lister that has not synced answers NotFound for every
+// node in the cluster, and a caller that reads NotFound as "the node is gone" would take that
+// for an empty cluster. Nothing guarantees the ordering either: the informer is attached by
+// NodeK8sReconciler when its cluster comes up, so a workspace reconcile can perfectly well
+// run first. Handing back nil until HasSynced is what keeps a cold cache from answering.
+//
+// Asking the factory for the Nodes informer registers one as a side effect on clusters whose
+// NodeK8sReconciler has not attached yet. That is inert: a registered informer does not run
+// until StartInformer, which only that attach path calls, and the attach is handed this same
+// shared instance -- with the event handlers and watch error handler it adds to it.
+func dataPlaneNodeLister(k8sClients *commonclient.ClientFactory) corev1listers.NodeLister {
+	factory := k8sClients.SharedInformerFactory()
+	if factory == nil {
+		return nil
+	}
+	nodes := factory.Core().V1().Nodes()
+	if !nodes.Informer().HasSynced() {
+		return nil
+	}
+	return nodes.Lister()
+}
+
+// getDataPlaneNode reads a node straight from the data plane's apiserver.
+//
+// This is the read for callers that cannot accept a stale answer: ones that write the object
+// back -- a full Update, or a patch carrying the resourceVersion, either of which starts
+// failing on a cached copy as soon as kubelet's next heartbeat lands -- and ones that treat
+// NotFound as a permanent verdict rather than as something to look at again next round.
+// Where a lagging miss only costs a round, use getCachedDataPlaneNode.
+func getDataPlaneNode(ctx context.Context, k8sClients *commonclient.ClientFactory, nodeName string) (*corev1.Node, error) {
 	if nodeName == "" {
 		return nil, fmt.Errorf("the node name is empty")
 	}
@@ -35,6 +67,35 @@ func getNodeByInformer(ctx context.Context, k8sClients *commonclient.ClientFacto
 		return nil, err
 	}
 	return result.DeepCopy(), nil
+}
+
+// getCachedDataPlaneNode reads the shared informer's cache, and falls back to the apiserver
+// when that cache is not live yet.
+//
+// It exists for the paths that were paying a serial apiserver round trip per node -- once per
+// candidate in the scale-up scan, once per admin Node event -- on the goroutine holding the
+// work queue item, while the informer NodeK8sReconciler already runs was holding exactly
+// those objects.
+//
+// The price is that a node the cache has not caught up on reads as NotFound. Only take it
+// where that costs a round and no more: the scale-up scan picks the node up on its next
+// reconcile, and the node-event path is re-driven by the very events that fill the cache. It
+// is the wrong read wherever absence is acted on as a verdict -- isK8sNodePresent refuses a
+// binding on it, permanently, and clears the request that asked for it.
+func getCachedDataPlaneNode(ctx context.Context, k8sClients *commonclient.ClientFactory, nodeName string) (*corev1.Node, error) {
+	if nodeName == "" {
+		return nil, fmt.Errorf("the node name is empty")
+	}
+	if lister := dataPlaneNodeLister(k8sClients); lister != nil {
+		// The lister hands out pointers into the shared cache; callers here mutate or store
+		// what they get back, so the copy is not optional.
+		result, err := lister.Get(nodeName)
+		if err != nil {
+			return nil, err
+		}
+		return result.DeepCopy(), nil
+	}
+	return getDataPlaneNode(ctx, k8sClients, nodeName)
 }
 
 // isNeedAuthorization If the SSH secret of the cluster is the same as that of the node, no authorization is required.

--- a/SaFE/resource-manager/pkg/resource/node_k8s_controller.go
+++ b/SaFE/resource-manager/pkg/resource/node_k8s_controller.go
@@ -383,7 +383,7 @@ func (r *NodeK8sReconciler) handleNodeUpdate(ctx context.Context, message *nodeQ
 	if err != nil || !k8sClients.IsValid() {
 		return fmt.Errorf("the cluster(%s) clients is not ready", message.clusterName)
 	}
-	k8sNode, err := getNodeByInformer(ctx, k8sClients, message.k8sNodeName)
+	k8sNode, err := getCachedDataPlaneNode(ctx, k8sClients, message.k8sNodeName)
 	if err != nil {
 		return err
 	}
@@ -403,7 +403,19 @@ func (r *NodeK8sReconciler) handleNodeUpdate(ctx context.Context, message *nodeQ
 func (r *NodeK8sReconciler) syncK8sMetadata(ctx context.Context, adminNode *v1.Node, k8sNode *corev1.Node) error {
 	shouldUpdate := false
 	for _, k := range concernedK8sLabelKeys {
-		if v, ok := k8sNode.Labels[k]; ok {
+		v, ok := k8sNode.Labels[k]
+		// Which workspace owns a node is decided in the admin plane; the data plane label is
+		// only the confirmation that the binding landed. A value that disagrees with
+		// spec.workspace is therefore stale or was edited by hand, and copying it back would
+		// make the admin plane report an ownership nobody asked for. Leave the admin node as
+		// it is and let NodeReconciler push the right value back down; the label is removed
+		// through the branch below, once the data plane no longer carries it at all.
+		if ok && k == v1.WorkspaceIdLabel && v != adminNode.GetSpecWorkspace() {
+			klog.Warningf("ignore workspace label %s on k8s node %s, the node is bound to %q",
+				v, k8sNode.Name, adminNode.GetSpecWorkspace())
+			continue
+		}
+		if ok {
 			if v1.SetLabel(adminNode, k, v) {
 				shouldUpdate = true
 			}

--- a/SaFE/resource-manager/pkg/resource/register.go
+++ b/SaFE/resource-manager/pkg/resource/register.go
@@ -37,7 +37,7 @@ func SetupControllers(ctx context.Context, mgr manager.Manager) error {
 	if err := SetupNodeK8sController(ctx, mgr); err != nil {
 		return fmt.Errorf("failed to set up k8s-node controller: %v", err)
 	}
-	if err := SetupWorkspaceController(mgr, &defaultWorkspaceOption); err != nil {
+	if err := SetupWorkspaceController(ctx, mgr, &defaultWorkspaceOption); err != nil {
 		return fmt.Errorf("failed to set up workspace controller: %v", err)
 	}
 	if err := SetupFaultController(mgr, &defaultFaultOption); err != nil {

--- a/SaFE/resource-manager/pkg/resource/setup_probe_test.go
+++ b/SaFE/resource-manager/pkg/resource/setup_probe_test.go
@@ -54,7 +54,7 @@ func TestSetupResourceControllersProbe(t *testing.T) {
 	run("cluster", func() error { return SetupClusterController(mgr) })
 	run("node", func() error { return SetupNodeController(mgr) })
 	run("nodek8s", func() error { return SetupNodeK8sController(ctx, mgr) })
-	run("workspace", func() error { return SetupWorkspaceController(mgr, &defaultWorkspaceOption) })
+	run("workspace", func() error { return SetupWorkspaceController(ctx, mgr, &defaultWorkspaceOption) })
 	run("fault", func() error { return SetupFaultController(mgr, &defaultFaultOption) })
 	run("addon", func() error { return SetupAddonController(mgr) })
 	run("addontemplate", func() error { return SetupAddonTemplateController(mgr) })

--- a/SaFE/resource-manager/pkg/resource/workspace_controller.go
+++ b/SaFE/resource-manager/pkg/resource/workspace_controller.go
@@ -21,6 +21,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
 	ctrlruntime "sigs.k8s.io/controller-runtime"
@@ -46,6 +48,16 @@ import (
 
 type WorkspaceReconciler struct {
 	*ClusterBaseReconciler
+	// apiReader reads straight from the apiserver, bypassing the manager's cache. Reserved
+	// for the one place a stale read would defeat the point of reading at all: re-checking
+	// ownership after losing an optimistic-lock conflict, where the whole question is what
+	// the writer that just beat us stored.
+	apiReader client.Reader
+	// recorder puts the refusals on the Workspace itself. Every one of them is a request a
+	// user made through the API that this controller then declined -- the REST call has long
+	// since returned 200, the annotation carrying it is cleared on the way out, and a line in
+	// the resource-manager log is not somewhere a user can look.
+	recorder record.EventRecorder
 	// holds all data-plane Kubernetes clients, with the key being cluster.id
 	clientManager *commonutils.ObjectManager
 	sync.RWMutex
@@ -60,14 +72,39 @@ type WorkspaceReconcilerOption struct {
 	nodeWait    time.Duration
 }
 
+// workspaceClusterIndex indexes Workspaces by the cluster they belong to, so reservedNodes can
+// ask the cache for one cluster's workspaces instead of receiving every workspace in the admin
+// plane and discarding all but one cluster's worth on the way out.
+const workspaceClusterIndex = "spec.cluster"
+
+// indexWorkspaceByCluster is the index function behind workspaceClusterIndex. It is a named
+// function because tests have to register the same one on their fake client: an unregistered
+// index there is an error, not a silent fall back to listing everything.
+func indexWorkspaceByCluster(object client.Object) []string {
+	workspace, ok := object.(*v1.Workspace)
+	if !ok {
+		return nil
+	}
+	// The empty cluster is indexed rather than skipped. The loop this replaced compared the
+	// field directly, so a workspace with no cluster matched another with no cluster, and an
+	// index that dropped them would quietly change that.
+	return []string{workspace.Spec.Cluster}
+}
+
 // SetupWorkspaceController initializes and registers the WorkspaceReconciler with the controller manager.
-func SetupWorkspaceController(mgr manager.Manager, opt *WorkspaceReconcilerOption) error {
+func SetupWorkspaceController(ctx context.Context, mgr manager.Manager, opt *WorkspaceReconcilerOption) error {
+	if err := mgr.GetFieldIndexer().IndexField(ctx,
+		&v1.Workspace{}, workspaceClusterIndex, indexWorkspaceByCluster); err != nil {
+		return fmt.Errorf("failed to setup field indexer for workspace cluster: %v", err)
+	}
 	baseReconciler, err := newClusterBaseReconciler(mgr)
 	if err != nil {
 		return err
 	}
 	r := &WorkspaceReconciler{
 		ClusterBaseReconciler: baseReconciler,
+		apiReader:             mgr.GetAPIReader(),
+		recorder:              mgr.GetEventRecorderFor("workspace-controller"),
 		clientManager:         commonutils.NewObjectManagerSingleton(),
 		expectations:          make(map[string]sets.Set),
 		option:                opt,
@@ -117,14 +154,21 @@ func (r *WorkspaceReconciler) handleNodeEvent() handler.EventHandler {
 		}
 		return false
 	}
-	enqueue := func(q v1.RequestWorkQueue, nodeName, workspaceId string, doObserve bool) {
+	enqueue := func(q v1.RequestWorkQueue, workspaceId string) {
 		if workspaceId == "" {
 			return
 		}
-		if doObserve {
-			r.observeNode(workspaceId, nodeName)
-		}
 		q.Add(reconcile.Request{NamespacedName: apitypes.NamespacedName{Name: workspaceId}})
+	}
+	// observe settles the node against every workspace waiting on it, not just the one the
+	// node currently points at. Ownership can change hands between the moment an expectation
+	// is registered and the moment the event arrives, and the event only carries the new (or
+	// an empty) workspace id, so crediting the expectation by that id alone would leave the
+	// original workspace waiting on a node it no longer owns, forever.
+	observe := func(q v1.RequestWorkQueue, nodeName string) {
+		for _, workspaceId := range r.observeNodeForAll(nodeName) {
+			enqueue(q, workspaceId)
+		}
 	}
 	return handler.Funcs{
 		CreateFunc: func(ctx context.Context, evt event.CreateEvent, q v1.RequestWorkQueue) {
@@ -132,7 +176,8 @@ func (r *WorkspaceReconciler) handleNodeEvent() handler.EventHandler {
 			if !ok {
 				return
 			}
-			enqueue(q, node.Name, v1.GetWorkspaceId(node), true)
+			observe(q, node.Name)
+			enqueue(q, v1.GetWorkspaceId(node))
 		},
 		UpdateFunc: func(ctx context.Context, evt event.UpdateEvent, q v1.RequestWorkQueue) {
 			oldNode, ok1 := evt.ObjectOld.(*v1.Node)
@@ -141,10 +186,11 @@ func (r *WorkspaceReconciler) handleNodeEvent() handler.EventHandler {
 				return
 			}
 			if v1.GetWorkspaceId(oldNode) != v1.GetWorkspaceId(newNode) {
-				enqueue(q, newNode.Name, v1.GetWorkspaceId(oldNode), true)
-				enqueue(q, newNode.Name, v1.GetWorkspaceId(newNode), true)
+				observe(q, newNode.Name)
+				enqueue(q, v1.GetWorkspaceId(oldNode))
+				enqueue(q, v1.GetWorkspaceId(newNode))
 			} else if isRelevantFieldChanged(oldNode, newNode) {
-				enqueue(q, newNode.Name, v1.GetWorkspaceId(newNode), false)
+				enqueue(q, v1.GetWorkspaceId(newNode))
 			}
 		},
 		DeleteFunc: func(ctx context.Context, evt event.DeleteEvent, q v1.RequestWorkQueue) {
@@ -152,7 +198,8 @@ func (r *WorkspaceReconciler) handleNodeEvent() handler.EventHandler {
 			if !ok {
 				return
 			}
-			enqueue(q, node.Name, v1.GetWorkspaceId(node), true)
+			observe(q, node.Name)
+			enqueue(q, v1.GetWorkspaceId(node))
 		},
 	}
 }
@@ -335,16 +382,126 @@ func (r *WorkspaceReconciler) removeExpectations(workspaceId string) {
 	delete(r.expectations, workspaceId)
 }
 
+// settle drops a node from a Workspace's outstanding expectations and reports whether it was
+// there to drop. Callers hold the write lock.
+//
+// An emptied entry is deleted rather than left as an empty set. `meetExpectations` reads the
+// two the same way, so nothing downstream can tell them apart -- but observeNodeForAll walks
+// this map under the write lock on every admin Node event, and NodeK8sReconciler mirrors
+// kubelet's conditions onto those nodes every few seconds. Kept, the empties accumulate one
+// per workspace ever scaled, and every heartbeat in the cluster pays to walk past all of
+// them. Only the delete path ever removed an entry, and a workspace that is merely running
+// never reaches it.
+func (r *WorkspaceReconciler) settle(workspaceId, nodeName string) bool {
+	leftNodeNames, ok := r.expectations[workspaceId]
+	if !ok || !leftNodeNames.Has(nodeName) {
+		return false
+	}
+	// sets.Set is a map, so this lands in the stored set; there is nothing to write back.
+	leftNodeNames.Delete(nodeName)
+	if leftNodeNames.Len() == 0 {
+		delete(r.expectations, workspaceId)
+	}
+	return true
+}
+
 // observeNode marks a node operation as completed for a Workspace.
 func (r *WorkspaceReconciler) observeNode(workspaceId, nodeName string) {
 	r.Lock()
 	defer r.Unlock()
-	leftNodeNames, ok := r.expectations[workspaceId]
-	if !ok || !leftNodeNames.Has(nodeName) {
-		return
+	r.settle(workspaceId, nodeName)
+}
+
+// observeNodeForAll marks a node operation as completed for every Workspace that is waiting
+// on that node, and returns the ids of the workspaces it settled so they can be re-queued.
+func (r *WorkspaceReconciler) observeNodeForAll(nodeName string) []string {
+	r.Lock()
+	defer r.Unlock()
+	var workspaceIds []string
+	for workspaceId := range r.expectations {
+		if r.settle(workspaceId, nodeName) {
+			workspaceIds = append(workspaceIds, workspaceId)
+		}
 	}
-	leftNodeNames.Delete(nodeName)
-	r.expectations[workspaceId] = leftNodeNames
+	return workspaceIds
+}
+
+// reservedNodes returns the nodes another Workspace is already laying claim to: nodes with a
+// binding still in flight, and nodes named by a nodes-action annotation that has not been
+// processed yet. Explicit bindings are what users asked for, so they take precedence over
+// automatic scaling and scale-up must leave these nodes alone.
+func (r *WorkspaceReconciler) reservedNodes(ctx context.Context, workspace *v1.Workspace) (sets.Set, error) {
+	workspaceId := workspace.Name
+	reserved := sets.NewSet()
+
+	workspaceList := &v1.WorkspaceList{}
+	if err := r.List(ctx, workspaceList,
+		client.MatchingFields{workspaceClusterIndex: workspace.Spec.Cluster}); err != nil {
+		// Better to skip a round of scaling up than to race an explicit binding. Returning
+		// the partial set instead would have done the opposite of what that reads like:
+		// every node claimed by an annotation we could not read becomes fair game.
+		klog.ErrorS(err, "failed to list workspaces, skipping this round of scaling up")
+		return nil, err
+	}
+	deleting := sets.NewSet()
+	for i := range workspaceList.Items {
+		other := &workspaceList.Items[i]
+		if other.Name == workspaceId {
+			continue
+		}
+		// A workspace under deletion never processes its annotation -- Reconcile hands it
+		// straight to delete() -- so its claims are not pending, they are abandoned. Left
+		// in, they would reserve those nodes against every other workspace forever.
+		if !other.GetDeletionTimestamp().IsZero() {
+			deleting.Insert(other.Name)
+			continue
+		}
+		raw := v1.GetWorkspaceNodesAction(other)
+		if raw == "" {
+			continue
+		}
+		var actions map[string]string
+		if err := json.Unmarshal([]byte(raw), &actions); err != nil {
+			continue
+		}
+		for nodeName, action := range actions {
+			if action != v1.NodeActionRemove {
+				reserved.Insert(nodeName)
+			}
+		}
+	}
+
+	r.RLock()
+	for id, nodeNames := range r.expectations {
+		if id == workspaceId {
+			continue
+		}
+		// Same reasoning as the annotation scan, and it has to be applied here too or the
+		// two disagree: a workspace being deleted holds unbinds, not binds, and reserving
+		// the nodes it is releasing keeps them out of everyone's reach for as long as the
+		// entry survives -- which, if its deletion is itself stuck behind an expectation
+		// that never settles, is the life of the process.
+		//
+		// `deleting` only covers this cluster, because the list it is built from does. That
+		// makes no difference for the same reason the loop below is not cluster-filtered:
+		// another cluster's names match nothing in this cluster's candidate list.
+		if deleting.Has(id) {
+			continue
+		}
+		// Not filtered by cluster, unlike the list above: an expectation is keyed by
+		// workspace alone, and looking each one's cluster up costs more than carrying the
+		// few node names an in-flight bind can hold. It cannot over-reserve either way --
+		// admin Node names are unique across the admin plane, and the candidate list is
+		// already restricted to this cluster, so a name from elsewhere matches nothing.
+		//
+		// A workspace absent from the list altogether stays reserved: the list is served
+		// from the manager's cache, so absence is as likely to mean "created a moment ago"
+		// as "gone", and the safe reading of an in-flight bind we cannot attribute is that
+		// somebody owns it.
+		reserved.Insert(nodeNames.UnsortedList()...)
+	}
+	r.RUnlock()
+	return reserved, nil
 }
 
 // processWorkspace handles the main processing logic for a Workspace resource
@@ -359,7 +516,7 @@ func (r *WorkspaceReconciler) processWorkspace(ctx context.Context, workspace *v
 	}
 
 	if v1.GetWorkspaceNodesAction(workspace) != "" {
-		isUpdated, err := r.processNodesAction(ctx, workspace)
+		isUpdated, err := r.processNodesAction(ctx, workspace, k8sClients)
 		if err != nil || isUpdated {
 			return ctrlruntime.Result{}, err
 		}
@@ -446,6 +603,10 @@ func (r *WorkspaceReconciler) getNodesForScalingUp(ctx context.Context, workspac
 	if err != nil {
 		return nil, err
 	}
+	reserved, err := r.reservedNodes(ctx, workspace)
+	if err != nil {
+		return nil, err
+	}
 	k8sNodes := make([]*corev1.Node, 0, len(nodeList.Items))
 	adminNodeMap := make(map[string]*v1.Node)
 	for i, n := range nodeList.Items {
@@ -455,10 +616,14 @@ func (r *WorkspaceReconciler) getNodesForScalingUp(ctx context.Context, workspac
 		if n.GetSpecWorkspace() != "" || v1.GetWorkspaceId(&n) != "" {
 			continue
 		}
+		if reserved.Has(n.Name) {
+			klog.V(4).Infof("skip node %s for scaling up %s, another workspace is processing it", n.Name, workspace.Name)
+			continue
+		}
 		if v1.GetNodeFlavorId(&n) != workspace.Spec.NodeFlavor {
 			continue
 		}
-		k8sNode, err := getNodeByInformer(ctx, k8sClients, n.GetK8sNodeName())
+		k8sNode, err := getCachedDataPlaneNode(ctx, k8sClients, n.GetK8sNodeName())
 		if err != nil {
 			klog.ErrorS(err, "failed to get k8sNode")
 			continue
@@ -577,8 +742,51 @@ func (r *WorkspaceReconciler) syncWorkspace(ctx context.Context, workspace *v1.W
 	return nil
 }
 
+// k8sNodeUnavailableReason says why the node cannot take a binding, or "" if it can. The
+// string is user-facing: it goes into the Workspace event that explains the dropped request.
+//
+// A transient failure to answer counts as available. Refusing is permanent here -- the add is
+// dropped and the annotation carrying it cleared -- so it must only happen on a definite no.
+//
+// Which is also why this one reads the apiserver rather than the informer cache, unlike the
+// scan in getNodesForScalingUp. A node the cache has not caught up on -- one that just joined,
+// or one whose watch dropped -- would make a user's binding request disappear.
+//
+// The definite noes are kept apart, because they send whoever reads the event to different
+// places. An empty k8s node name is about the admin plane not knowing what to look for yet,
+// because neither status.machineStatus.hostName nor spec.hostname is set. "Not in the cluster"
+// is about the data plane not having the node at all. "Being deleted" is about it having it
+// for a little longer -- reporting that one as either of the others sends the reader looking
+// for a registration problem that is not there.
+//
+// Deleting counts as a definite no for the same reason updateSingleNodeBinding refuses one:
+// the bind would hand this workspace a reference to something that is on its way out, and the
+// admin Node follows the k8s Node down. Checking only NotFound here caught the node one moment
+// too late -- after the object was gone, but not while it was going.
+func (r *WorkspaceReconciler) k8sNodeUnavailableReason(ctx context.Context,
+	k8sClients *commonclient.ClientFactory, node *v1.Node) string {
+	k8sNodeName := node.GetK8sNodeName()
+	if k8sNodeName == "" {
+		return "its k8s node name is not known yet"
+	}
+	k8sNode, err := getDataPlaneNode(ctx, k8sClients, k8sNodeName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Sprintf("its k8s node %s is not in the cluster", k8sNodeName)
+		}
+		klog.ErrorS(err, "failed to get k8s node, assuming it is present",
+			"node", node.Name, "k8sNode", k8sNodeName)
+		return ""
+	}
+	if !k8sNode.GetDeletionTimestamp().IsZero() {
+		return fmt.Sprintf("its k8s node %s is being deleted", k8sNodeName)
+	}
+	return ""
+}
+
 // processNodesAction processes node binding/unbinding actions for a Workspace.
-func (r *WorkspaceReconciler) processNodesAction(ctx context.Context, workspace *v1.Workspace) (bool, error) {
+func (r *WorkspaceReconciler) processNodesAction(ctx context.Context, workspace *v1.Workspace,
+	k8sClients *commonclient.ClientFactory) (bool, error) {
 	var actions map[string]string
 	if err := json.Unmarshal([]byte(v1.GetWorkspaceNodesAction(workspace)), &actions); err != nil || len(actions) == 0 {
 		if err != nil {
@@ -593,7 +801,11 @@ func (r *WorkspaceReconciler) processNodesAction(ctx context.Context, workspace 
 	adminNodes := make([]*v1.Node, 0, len(actions))
 	for key, val := range actions {
 		node := &v1.Node{}
-		if err := r.Get(ctx, client.ObjectKey{Name: key}, node); err != nil {
+		// Uncached, for the same reason updateSingleNodeBinding re-reads: what this loop
+		// decides is irreversible. A refusal drops the entry, clears the annotation and
+		// leaves an event -- there is no retry. Judging that off a cache still showing a
+		// release that already happened turns a valid request into a permanent no.
+		if err := r.apiReader.Get(ctx, client.ObjectKey{Name: key}, node); err != nil {
 			if apierrors.IsNotFound(err) {
 				continue
 			}
@@ -602,19 +814,38 @@ func (r *WorkspaceReconciler) processNodesAction(ctx context.Context, workspace 
 		if !node.GetDeletionTimestamp().IsZero() {
 			continue
 		}
+		target := workspace.Name
 		if val == v1.NodeActionRemove {
-			// Desired state (spec) already unbound; label sync is handled elsewhere.
-			if node.GetSpecWorkspace() == "" {
-				continue
-			}
-			newActions[node.Name] = ""
-		} else {
-			// Desired state (spec) already targets this workspace; no further action here.
-			if node.GetSpecWorkspace() == workspace.Name {
-				continue
-			}
-			newActions[node.Name] = workspace.Name
+			target = ""
 		}
+		switch verdict, reason := judgeNodeBinding(node.GetSpecWorkspace(), target, workspace.Name); verdict {
+		case bindSettled:
+			// Desired state (spec) already reads the way the action asks for; the data
+			// plane's label sync is handled elsewhere.
+			continue
+		case bindRefused:
+			// Dropped rather than retried, so the annotation clears instead of asking again
+			// forever for a change that must not happen; the node has to be released by the
+			// workspace holding it first.
+			klog.Warningf("skip %s of node %s requested by %s: %s",
+				val, node.Name, workspace.Name, reason)
+			r.recorder.Eventf(workspace, corev1.EventTypeWarning, eventNodeBindRefused,
+				"cannot %s node %s: %s", val, node.Name, reason)
+			continue
+		}
+		// The binding is only settled once the workspace label makes the round trip through
+		// the data plane, so a node whose k8s Node is gone would leave this workspace
+		// waiting on it forever. Drop the request; the annotation clears and the binding can
+		// be asked for again once the node is back in the cluster.
+		if target != "" {
+			if reason := r.k8sNodeUnavailableReason(ctx, k8sClients, node); reason != "" {
+				klog.Warningf("skip adding node %s to %s: %s", node.Name, workspace.Name, reason)
+				r.recorder.Eventf(workspace, corev1.EventTypeWarning, eventNodeUnavailable,
+					"cannot add node %s: %s", node.Name, reason)
+				continue
+			}
+		}
+		newActions[node.Name] = target
 		adminNodes = append(adminNodes, node)
 	}
 	if len(adminNodes) == 0 {
@@ -640,6 +871,54 @@ func (r *WorkspaceReconciler) removeNodesAction(ctx context.Context, workspace *
 	return nil
 }
 
+const (
+	// eventNodeBindRefused: the single-owner rule said no.
+	eventNodeBindRefused = "NodeBindRefused"
+	// eventNodeUnavailable: the node cannot take a binding right now -- it is on its way out,
+	// or the data plane does not have it.
+	eventNodeUnavailable = "NodeUnavailable"
+)
+
+// nodeBindVerdict is what the admin plane's single-owner rule says about one requested
+// change to a node's binding.
+type nodeBindVerdict int
+
+const (
+	// bindProceed: the change is allowed, and the node does not read that way yet.
+	bindProceed nodeBindVerdict = iota
+	// bindSettled: spec already says what the request asks for; there is nothing to write.
+	bindSettled
+	// bindRefused: applying it would take a node away from the workspace that holds it.
+	bindRefused
+)
+
+// judgeNodeBinding applies the one rule the admin plane has about node ownership -- a node
+// belongs to at most one workspace, and only its owner may release it -- to a single change
+// requested by `requester`, taking the node from `current` to `target`.
+//
+// It lives here rather than at each call site because the rule was previously written out
+// three times, in three shapes, and the shapes did not agree: the bind checks all keyed on a
+// non-empty target, so an unbind -- whose target is always "" -- slipped past every one of
+// them, and posting {"n":"remove"} for someone else's node was a supported way to take it.
+// One predicate is also the only way the unbind half gets enforced at the layer that writes,
+// rather than only at the layer that happened to remember it.
+func judgeNodeBinding(current, target, requester string) (nodeBindVerdict, string) {
+	if current == target {
+		return bindSettled, ""
+	}
+	if target != "" {
+		if current != "" {
+			return bindRefused, fmt.Sprintf("it is already bound to %s", current)
+		}
+		return bindProceed, ""
+	}
+	// An unbind, and current is not "" or the case above would have caught it.
+	if current != requester {
+		return bindRefused, fmt.Sprintf("it is bound to %s, which is not the workspace asking", current)
+	}
+	return bindProceed, ""
+}
+
 // updateNodesBinding updates the binding of nodes to a Workspace.
 func (r *WorkspaceReconciler) updateNodesBinding(ctx context.Context,
 	workspace *v1.Workspace, nodes []*v1.Node, targets map[string]string) error {
@@ -658,8 +937,24 @@ func (r *WorkspaceReconciler) updateNodesBinding(ctx context.Context,
 	r.setExpectations(workspace.Name, nodeNames)
 	success, err := concurrent.Exec(count, func() error {
 		n := <-ch
-		ok, err := r.updateSingleNodeBinding(ctx, n, targets[n.Name])
-		if !ok || err != nil {
+		target := targets[n.Name]
+		ok, err := r.updateSingleNodeBinding(ctx, workspace, n, target)
+		// An expectation is a wait for the workspace label to make the round trip through
+		// the data plane, and handleNodeEvent only credits it on a *change* of that label.
+		// So a node whose label already reads the target has nothing left to wait for, and
+		// waiting anyway wedges the workspace forever: no admin Node write is coming to
+		// carry a transition that has already happened.
+		//
+		// The way in is a workspace deleted while a bind is still in flight. The bind set
+		// spec.workspace and NodeReconciler pushed the label down, but before syncK8sMetadata
+		// copied it back up the workspace was deleted, so delete() cleared spec.workspace
+		// again. Now every party agrees the node is unbound -- admin label empty, spec
+		// empty -- and the only thing that could have moved the label is syncK8sMetadata,
+		// which correctly refuses to copy a data-plane value that disagrees with spec. The
+		// Workspace then sits in Terminating for the life of the process.
+		//
+		// n is the object updateSingleNodeBinding read through, so its labels are fresh.
+		if !ok || err != nil || v1.GetWorkspaceId(n) == target {
 			r.observeNode(workspace.Name, n.Name)
 		}
 		return err
@@ -673,24 +968,134 @@ func (r *WorkspaceReconciler) updateNodesBinding(ctx context.Context,
 }
 
 // updateSingleNodeBinding updates the binding of a single node to a Workspace.
-func (r *WorkspaceReconciler) updateSingleNodeBinding(ctx context.Context, node *v1.Node, target string) (bool, error) {
-	if node.Spec.Workspace != nil && *node.Spec.Workspace == target {
-		return false, nil
-	}
-	patch := client.MergeFrom(node.DeepCopy())
-	node.Spec.Workspace = pointer.String(target)
+//
+// Every attempt starts from an uncached read. What the callers hand over came out of the
+// manager's cache, and the patch below carries its resourceVersion under an optimistic lock,
+// so a cached copy is two problems at once: the ownership check runs against state that may
+// already have changed, and the patch is rejected for a version that was stale before it was
+// sent. Admin Nodes are not quiet objects either -- NodeK8sReconciler mirrors the data plane's
+// conditions, heartbeat timestamp and all, onto every one of them every few seconds -- so
+// stale-by-a-moment is the ordinary case here, not the unlucky one. One GET per node buys the
+// check real state to judge and keeps the retry budget for actual contention.
+//
+// The optimistic lock still earns its place on top of that: it closes the window between this
+// read and the patch. Losing it means somebody else got there first, which is what the retry
+// is for -- read again, judge again, and the second look may well say the work is already
+// done, or that the node now belongs to someone else.
+//
+// Settled and refused are not errors; nothing is wrong, the answer is just no. Running out of
+// retries is one, deliberately: the caller settles the node's expectation on !updated, so a
+// silent give-up would let a workspace deletion read "we stopped trying" as "the node is
+// released" and drop its finalizer with the node still pointing at it -- a node no later
+// binding can rescue, because the only workspace allowed to release it no longer exists.
+// concurrent.Exec runs every node in the batch whatever any one of them returns, so the error
+// costs nothing beyond the rate-limited requeue it is asking for.
+func (r *WorkspaceReconciler) updateSingleNodeBinding(ctx context.Context,
+	workspace *v1.Workspace, node *v1.Node, target string) (bool, error) {
+	requester := workspace.Name
 	action := "bind"
 	if target == "" {
 		action = "unbind"
 	}
-	if err := r.Patch(ctx, node, patch); err != nil {
-		klog.ErrorS(err, "failed to update node", "target", target)
-		rmmetrics.WorkspaceNodeBindingTotal.WithLabelValues(action, "failed").Inc()
-		return false, err
+	updated := false
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		updated = false
+		// A failed read ends the retry: returning a non-conflict error is how RetryOnConflict
+		// is told to give up, and there is nothing left to judge against anyway.
+		//
+		// NotFound ends it without an error. A node that no longer exists is an answer, not a
+		// failure: nothing is left for this workspace to hold a reference to, so updated=false
+		// is already the honest report, and the caller settles the expectation on it either
+		// way. This is not the silent give-up the doc comment above warns about -- that one
+		// leaves a node still naming the workspace, and here there is no node. Reporting it as
+		// an error only made concurrent.Exec fail the batch, buying a rate-limited requeue and
+		// an error log every round for a request the next pass drops anyway.
+		if getErr := r.apiReader.Get(ctx, client.ObjectKeyFromObject(node), node); getErr != nil {
+			if apierrors.IsNotFound(getErr) {
+				klog.Warningf("skip %s of node %s requested by %s: it no longer exists",
+					action, node.Name, requester)
+				return nil
+			}
+			klog.ErrorS(getErr, "failed to read node before updating its binding", "node", node.Name)
+			return getErr
+		}
+		// The callers filter deleting nodes out before handing them over, but the read above
+		// can bring one back, and the ownership rule below is only about ownership. Binding a
+		// node on its way out leaves the workspace holding a reference to something that is
+		// about to stop existing.
+		//
+		// Binds only. An unbind of a deleting node is the one thing that must still go
+		// through: delete() collects every node whose spec.workspace names the workspace,
+		// deleting ones included, and settles each node's expectation on !updated. Refusing
+		// here answered "nothing to do", which let meetExpectations pass and the finalizer
+		// come off with the node's spec.workspace still naming a Workspace that no longer
+		// exists -- and no later bind can clear it, because judgeNodeBinding refuses every
+		// workspace except the one that is gone. The same unrescuable state the give-up path
+		// above exists to prevent, reached by the other door.
+		//
+		// Letting it through does not reintroduce the wedge on the other side. The unbind
+		// patch touches spec, so the expectation does not settle on it -- the workspace waits
+		// for the workspace label, which is not coming -- but handleNodeEvent's DeleteFunc
+		// observes the node when the object finally goes, and the wait ends there. Worst case
+		// the Workspace outlives the node it was holding, which is what it is supposed to do.
+		if target != "" && !node.GetDeletionTimestamp().IsZero() {
+			klog.Warningf("skip %s of node %s requested by %s: it is being deleted",
+				action, node.Name, requester)
+			r.recorder.Eventf(workspace, corev1.EventTypeWarning, eventNodeUnavailable,
+				"cannot %s node %s: it is being deleted", action, node.Name)
+			return nil
+		}
+		verdict, reason := judgeNodeBinding(node.GetSpecWorkspace(), target, requester)
+		if verdict == bindSettled {
+			// Already where it should be, including the case of an unbind against a nil
+			// Spec.Workspace -- which reads as "" and so judges as settled. Writing "" over
+			// the nil anyway, to make the release explicit in spec, is the tempting move
+			// and it wedges the workspace. Nothing reads that pointer except
+			// GetSpecWorkspace(), which maps nil to "", so the write changes no behaviour;
+			// what it does change is that this returns updated=true, which stops the caller
+			// from settling the expectation. And the write cannot settle it either --
+			// handleNodeEvent only observes on a change of the workspace *label*, and this
+			// touches spec alone. The expectation would then never clear, meetExpectations
+			// never pass, and every later reconcile of that workspace return early,
+			// including the one that would have deleted it. That is precisely the wedge
+			// this path exists to avoid.
+			return nil
+		}
+		if verdict == bindRefused {
+			klog.Warningf("skip %s of node %s requested by %s: %s", action, node.Name, requester, reason)
+			r.recorder.Eventf(workspace, corev1.EventTypeWarning, eventNodeBindRefused,
+				"cannot %s node %s: %s", action, node.Name, reason)
+			// Its own bucket rather than "conflict": this is a permanent answer about who
+			// owns the node, not a race a retry could win. Folded together, the two were
+			// indistinguishable -- a workspace losing a race read the same as one reaching
+			// for a node that belongs to somebody else.
+			rmmetrics.WorkspaceNodeBindingTotal.WithLabelValues(action, "refused").Inc()
+			return nil
+		}
+		patch := client.MergeFromWithOptions(node.DeepCopy(), client.MergeFromWithOptimisticLock{})
+		node.Spec.Workspace = pointer.String(target)
+		err := r.Patch(ctx, node, patch)
+		if err == nil {
+			updated = true
+			klog.Infof("updateSingleNodeBinding, node: %s, target: %s", node.Name, target)
+			rmmetrics.WorkspaceNodeBindingTotal.WithLabelValues(action, "success").Inc()
+			return nil
+		}
+		if !apierrors.IsConflict(err) {
+			klog.ErrorS(err, "failed to update node", "target", target)
+			rmmetrics.WorkspaceNodeBindingTotal.WithLabelValues(action, "failed").Inc()
+			return err
+		}
+		klog.Warningf("conflict while trying to %s node %s, target: %s. it will be retried", action, node.Name, target)
+		return err
+	})
+	if err != nil && apierrors.IsConflict(err) {
+		// Out of attempts. Counted once here rather than once per attempt: a counter that
+		// climbs with the retry budget measures the budget, not the contention.
+		rmmetrics.WorkspaceNodeBindingTotal.WithLabelValues(action, "conflict").Inc()
+		klog.Warningf("gave up trying to %s node %s after repeated conflicts", action, node.Name)
 	}
-	klog.Infof("updateSingleNodeBinding, node: %s, target: %s", node.Name, target)
-	rmmetrics.WorkspaceNodeBindingTotal.WithLabelValues(action, "success").Inc()
-	return true, nil
+	return updated, err
 }
 
 // resetWorkspaceStatus resets the status of a Workspace when no node flavor is specified.

--- a/SaFE/resource-manager/pkg/resource/workspace_controller_test.go
+++ b/SaFE/resource-manager/pkg/resource/workspace_controller_test.go
@@ -19,14 +19,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	ctrlruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
@@ -39,11 +40,29 @@ import (
 	"github.com/AMD-AIG-AIMA/SAFE/utils/pkg/sets"
 )
 
+// newWorkspaceClientBuilder is fake.NewClientBuilder with the spec.cluster index reservedNodes
+// lists through. SetupWorkspaceController registers it on the manager; on a fake client an
+// unregistered index is an error rather than an unfiltered list, so every builder feeding a
+// reconciler that can reach a scale-up has to start here. The scheme goes on first because the
+// builder resolves the indexed object's kind at registration and panics without it.
+func newWorkspaceClientBuilder(s *runtime.Scheme) *fake.ClientBuilder {
+	return fake.NewClientBuilder().WithScheme(s).
+		WithIndex(&v1.Workspace{}, workspaceClusterIndex, indexWorkspaceByCluster)
+}
+
 func newMockWorkspaceReconciler(adminClient client.Client) WorkspaceReconciler {
 	return WorkspaceReconciler{
 		ClusterBaseReconciler: &ClusterBaseReconciler{
 			Client: adminClient,
 		},
+		// The real one is mgr.GetAPIReader(). A fake client serves both roles here; tests
+		// that care about the difference between cached and uncached override this.
+		apiReader: adminClient,
+		// Built by hand rather than with NewFakeRecorder: that one's channel send blocks
+		// once the buffer fills, so a reconciler that emits more events than a test thought
+		// to size for would deadlock it. A nil channel discards. Tests that assert on
+		// events install their own.
+		recorder:      &record.FakeRecorder{},
 		option:        &defaultWorkspaceOption,
 		expectations:  make(map[string]sets.Set),
 		clientManager: commonutils.NewObjectManagerSingleton(),
@@ -81,8 +100,8 @@ func TestDeleteWorkspace(t *testing.T) {
 	metav1.SetMetaDataLabel(&adminNode1.ObjectMeta, v1.WorkspaceIdLabel, workspace.Name)
 	adminNode2.Spec.Workspace = ptr.To(workspace.Name)
 	metav1.SetMetaDataLabel(&adminNode2.ObjectMeta, v1.WorkspaceIdLabel, workspace.Name)
-	adminClient := fake.NewClientBuilder().WithObjects(workspace, adminNode1, adminNode2).
-		WithStatusSubresource(workspace).WithScheme(scheme.Scheme).Build()
+	adminClient := newWorkspaceClientBuilder(scheme.Scheme).WithObjects(workspace, adminNode1, adminNode2).
+		WithStatusSubresource(workspace).Build()
 
 	var err error
 	err = adminClient.Get(context.Background(), client.ObjectKey{Name: workspace.Name}, workspace)
@@ -130,8 +149,8 @@ func TestReconcile(t *testing.T) {
 
 	testScheme := scheme.Scheme
 	_ = corev1.AddToScheme(testScheme)
-	adminClient := fake.NewClientBuilder().WithObjects(adminNode1, adminNode2, workspace, cluster, nodeFlavor).
-		WithStatusSubresource(workspace).WithScheme(testScheme).Build()
+	adminClient := newWorkspaceClientBuilder(testScheme).WithObjects(adminNode1, adminNode2, workspace, cluster, nodeFlavor).
+		WithStatusSubresource(workspace).Build()
 	r := newMockWorkspaceReconciler(adminClient)
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -161,8 +180,8 @@ func TestScaleUpWorkspace(t *testing.T) {
 	adminNode1.Status.ClusterStatus.Phase = v1.NodeManaged
 	adminNode2 := genMockAdminNode("node2", clusterName, nodeFlavor)
 	workspace := genMockWorkspace(clusterName, nodeFlavor.Name, 1)
-	adminClient := fake.NewClientBuilder().WithObjects(adminNode1, adminNode2, workspace).
-		WithStatusSubresource(workspace).WithScheme(scheme.Scheme).Build()
+	adminClient := newWorkspaceClientBuilder(scheme.Scheme).WithObjects(adminNode1, adminNode2, workspace).
+		WithStatusSubresource(workspace).Build()
 
 	k8sNode1 := genMockK8sNode(adminNode1.Name, clusterName, nodeFlavor.Name, workspace.Name)
 	k8sNode2 := genMockK8sNode(adminNode2.Name, clusterName, nodeFlavor.Name, workspace.Name)
@@ -191,8 +210,8 @@ func TestScaleDownWorkspace(t *testing.T) {
 	metav1.SetMetaDataLabel(&adminNode1.ObjectMeta, v1.WorkspaceIdLabel, workspace.Name)
 	adminNode2.Spec.Workspace = ptr.To(workspace.Name)
 	metav1.SetMetaDataLabel(&adminNode2.ObjectMeta, v1.WorkspaceIdLabel, workspace.Name)
-	adminClient := fake.NewClientBuilder().WithObjects(adminNode1, adminNode2, workspace).
-		WithStatusSubresource(workspace).WithScheme(scheme.Scheme).Build()
+	adminClient := newWorkspaceClientBuilder(scheme.Scheme).WithObjects(adminNode1, adminNode2, workspace).
+		WithStatusSubresource(workspace).Build()
 
 	r := newMockWorkspaceReconciler(adminClient)
 	_, err := r.scaleDown(context.Background(), workspace, 1)
@@ -220,11 +239,11 @@ func TestWorkspaceNodesAction(t *testing.T) {
 	metav1.SetMetaDataAnnotation(&workspace.ObjectMeta,
 		v1.WorkspaceNodesAction, string(jsonutils.MarshalSilently(actions)))
 
-	adminClient := fake.NewClientBuilder().WithObjects(adminNode1, adminNode2, workspace).
-		WithScheme(scheme.Scheme).Build()
+	adminClient := newWorkspaceClientBuilder(scheme.Scheme).WithObjects(adminNode1, adminNode2, workspace).
+		Build()
 	r := newMockWorkspaceReconciler(adminClient)
 
-	_, err := r.processNodesAction(context.Background(), workspace)
+	_, err := r.processNodesAction(context.Background(), workspace, clusterNodes(adminNode1.Name, adminNode2.Name))
 	assert.NilError(t, err)
 	err = adminClient.Get(context.Background(), client.ObjectKey{Name: adminNode1.Name}, adminNode1)
 	assert.NilError(t, err)
@@ -261,8 +280,8 @@ func TestSyncWorkspace(t *testing.T) {
 	adminNode2.Status.Unschedulable = true
 	metav1.SetMetaDataLabel(&adminNode2.ObjectMeta, v1.WorkspaceIdLabel, workspace.Name)
 
-	adminClient := fake.NewClientBuilder().WithObjects(adminNode1, adminNode2, workspace, nodeFlavor).
-		WithStatusSubresource(workspace).WithScheme(scheme.Scheme).Build()
+	adminClient := newWorkspaceClientBuilder(scheme.Scheme).WithObjects(adminNode1, adminNode2, workspace, nodeFlavor).
+		WithStatusSubresource(workspace).Build()
 	r := newMockWorkspaceReconciler(adminClient)
 
 	err := r.syncWorkspace(context.Background(), workspace)
@@ -519,8 +538,8 @@ func TestUpdatePhase(t *testing.T) {
 	workspace := genMockWorkspace(clusterName, nodeFlavor.Name, 1)
 	workspace.Status.Phase = v1.WorkspaceRunning
 
-	adminClient := fake.NewClientBuilder().WithObjects(workspace).
-		WithStatusSubresource(workspace).WithScheme(scheme.Scheme).Build()
+	adminClient := newWorkspaceClientBuilder(scheme.Scheme).WithObjects(workspace).
+		WithStatusSubresource(workspace).Build()
 	r := newMockWorkspaceReconciler(adminClient)
 
 	// Test phase change
@@ -886,14 +905,16 @@ func newWorkspaceReconcilerFull(t *testing.T, cs *k8sfake.Clientset, objs ...ctr
 	t.Helper()
 	scheme, err := genMockScheme()
 	testifyassert.NoError(t, err)
-	cl := ctrlfake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&v1.Workspace{}).WithObjects(objs...).Build()
+	cl := newWorkspaceClientBuilder(scheme).WithStatusSubresource(&v1.Workspace{}).WithObjects(objs...).Build()
 	mgr := commonutils.NewObjectManager()
 	_ = mgr.Add("c1", commonclient.NewClientFactoryWithOnlyClient(context.Background(), "c1", cs))
 	return &WorkspaceReconciler{
 		ClusterBaseReconciler: &ClusterBaseReconciler{Client: cl, clientSet: cs},
+		apiReader:             cl,
 		clientManager:         mgr,
 		expectations:          map[string]sets.Set{},
 		option:                &WorkspaceReconcilerOption{},
+		recorder:              &record.FakeRecorder{},
 	}
 }
 
@@ -1004,7 +1025,7 @@ spec:
 	}
 	scheme, err := genMockScheme()
 	testifyassert.NoError(t, err)
-	cl := ctrlfake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+	cl := newWorkspaceClientBuilder(scheme).WithObjects(cm).Build()
 
 	ws := wsForHelper("ws1")
 	v1.SetLabel(ws, v1.DisplayNameLabel, "wsdisp")
@@ -1024,7 +1045,7 @@ spec:
 func TestGetPvTemplateNoConfigMap(t *testing.T) {
 	scheme, err := genMockScheme()
 	testifyassert.NoError(t, err)
-	cl := ctrlfake.NewClientBuilder().WithScheme(scheme).Build()
+	cl := newWorkspaceClientBuilder(scheme).Build()
 	tmpl, err := getPvTemplate(context.Background(), cl, wsForHelper("ws1"))
 	testifyassert.NoError(t, err)
 	testifyassert.Nil(t, tmpl)
@@ -1048,20 +1069,20 @@ func TestWorkspaceRelevantChangePredicate(t *testing.T) {
 }
 
 func TestWorkspaceGetClientSetOfDataplaneEmpty(t *testing.T) {
-	r := newMockWorkspaceReconciler(fake.NewClientBuilder().WithScheme(scheme.Scheme).Build())
+	r := newMockWorkspaceReconciler(newWorkspaceClientBuilder(scheme.Scheme).Build())
 	cs, err := r.getClientSetOfDataplane(context.Background(), "")
 	testifyassert.NoError(t, err)
 	testifyassert.Nil(t, cs)
 }
 
 func TestWorkspaceGetClientSetOfDataplaneClusterMissing(t *testing.T) {
-	r := newMockWorkspaceReconciler(fake.NewClientBuilder().WithScheme(scheme.Scheme).Build())
+	r := newMockWorkspaceReconciler(newWorkspaceClientBuilder(scheme.Scheme).Build())
 	_, err := r.getClientSetOfDataplane(context.Background(), "missing")
 	testifyassert.Error(t, err)
 }
 
 func TestWorkspaceReconcileNotFound(t *testing.T) {
-	r := newMockWorkspaceReconciler(fake.NewClientBuilder().WithScheme(scheme.Scheme).Build())
+	r := newMockWorkspaceReconciler(newWorkspaceClientBuilder(scheme.Scheme).Build())
 	res, err := r.Reconcile(context.Background(), ctrlruntime.Request{NamespacedName: types.NamespacedName{Name: "missing"}})
 	testifyassert.NoError(t, err)
 	assert.Equal(t, ctrlruntime.Result{}, res)
@@ -1069,7 +1090,7 @@ func TestWorkspaceReconcileNotFound(t *testing.T) {
 
 func TestWorkspaceReconcileNoCluster(t *testing.T) {
 	ws := &v1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "ws1"}}
-	cl := fake.NewClientBuilder().WithScheme(scheme.Scheme).
+	cl := newWorkspaceClientBuilder(scheme.Scheme).
 		WithStatusSubresource(&v1.Workspace{}).WithObjects(ws).Build()
 	r := newMockWorkspaceReconciler(cl)
 	// No cluster -> clientSet nil -> nil result.
@@ -1085,7 +1106,7 @@ func TestWorkspaceDelete(t *testing.T) {
 		DeletionTimestamp: &now,
 		Finalizers:        []string{v1.WorkspaceFinalizer},
 	}}
-	cl := fake.NewClientBuilder().WithScheme(scheme.Scheme).
+	cl := newWorkspaceClientBuilder(scheme.Scheme).
 		WithStatusSubresource(&v1.Workspace{}).WithObjects(ws).Build()
 	r := newMockWorkspaceReconciler(cl)
 	// No nodes bound, no cluster -> deletes resources + removes finalizer.
@@ -1095,7 +1116,7 @@ func TestWorkspaceDelete(t *testing.T) {
 
 func TestWorkspaceUpdatePhase(t *testing.T) {
 	ws := &v1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "ws1"}}
-	cl := fake.NewClientBuilder().WithScheme(scheme.Scheme).
+	cl := newWorkspaceClientBuilder(scheme.Scheme).
 		WithStatusSubresource(&v1.Workspace{}).WithObjects(ws).Build()
 	r := newMockWorkspaceReconciler(cl)
 	err := r.updatePhase(context.Background(), ws, v1.WorkspaceDeleting)
@@ -1110,7 +1131,7 @@ func TestWorkspaceGuaranteeDataPlaneResources(t *testing.T) {
 	ws := &v1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "ws1"}}
 	mockScheme, err := genMockScheme()
 	testifyassert.NoError(t, err)
-	r := newMockWorkspaceReconciler(fake.NewClientBuilder().WithScheme(mockScheme).Build())
+	r := newMockWorkspaceReconciler(newWorkspaceClientBuilder(mockScheme).Build())
 	err = r.guaranteeDataPlaneResources(context.Background(), ws, cs)
 	testifyassert.NoError(t, err)
 	// Namespace should be created.
@@ -1120,7 +1141,7 @@ func TestWorkspaceGuaranteeDataPlaneResources(t *testing.T) {
 
 func TestWorkspaceDeleteDataPlaneResourcesNoCluster(t *testing.T) {
 	ws := &v1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "ws1"}}
-	r := newMockWorkspaceReconciler(fake.NewClientBuilder().WithScheme(scheme.Scheme).Build())
+	r := newMockWorkspaceReconciler(newWorkspaceClientBuilder(scheme.Scheme).Build())
 	// No cluster -> clientSet nil -> nil.
 	err := r.deleteDataPlaneResources(context.Background(), ws)
 	testifyassert.NoError(t, err)

--- a/SaFE/resource-manager/pkg/resource/workspace_node_ownership_test.go
+++ b/SaFE/resource-manager/pkg/resource/workspace_node_ownership_test.go
@@ -1,0 +1,1012 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+package resource
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"gotest.tools/assert"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
+	commonclient "github.com/AMD-AIG-AIMA/SAFE/common/pkg/k8sclient"
+	jsonutils "github.com/AMD-AIG-AIMA/SAFE/utils/pkg/json"
+	"github.com/AMD-AIG-AIMA/SAFE/utils/pkg/sets"
+)
+
+func ownedNode(name, workspace string) *v1.Node {
+	node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: map[string]string{}}}
+	if workspace != "" {
+		node.Spec.Workspace = ptr.To(workspace)
+		node.Labels[v1.WorkspaceIdLabel] = workspace
+	}
+	return node
+}
+
+// workspaceNamed is the requesting Workspace, reduced to the only thing
+// updateSingleNodeBinding reads off it: its name. It is also the object events
+// get attached to, so it has to be a real one and not nil.
+func workspaceNamed(name string) *v1.Workspace {
+	return &v1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"}}
+}
+
+// clusterNodes builds a client factory for a cluster holding exactly the named k8s nodes.
+func clusterNodes(names ...string) *commonclient.ClientFactory {
+	objs := make([]runtime.Object, 0, len(names))
+	for _, name := range names {
+		objs = append(objs, &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}})
+	}
+	return commonclient.NewClientFactoryWithOnlyClient(context.Background(), "c1", k8sfake.NewClientset(objs...))
+}
+
+func TestObserveNodeForAllReleasesEveryWaiter(t *testing.T) {
+	r := newMockWorkspaceReconciler(nil)
+	r.setExpectations("ws1", sets.NewSetByKeys("n1", "n2"))
+	r.setExpectations("ws2", sets.NewSetByKeys("n1"))
+	r.setExpectations("ws3", sets.NewSetByKeys("n3"))
+
+	released := r.observeNodeForAll("n1")
+	assert.Equal(t, len(released), 2)
+	assert.Equal(t, r.expectations["ws1"].Has("n1"), false)
+	assert.Equal(t, r.expectations["ws1"].Has("n2"), true)
+	assert.Equal(t, r.meetExpectations("ws2"), true)
+	assert.Equal(t, r.meetExpectations("ws3"), false)
+}
+
+// A node can be taken over between the moment a workspace registers an expectation on it and
+// the moment the node event arrives. The event then carries the new owner only, so the
+// original workspace must still be released or its reconcile is blocked for good.
+func TestHandleNodeEventReleasesStolenNode(t *testing.T) {
+	r := newMockWorkspaceReconciler(nil)
+	r.setExpectations("ws1", sets.NewSetByKeys("n1"))
+	h := r.handleNodeEvent().(genericEventHandler)
+	q := resWorkQueue()
+	defer q.ShutDown()
+
+	oldNode := ownedNode("n1", "")
+	newNode := ownedNode("n1", "ws2")
+	h.Update(context.Background(), event.UpdateEvent{ObjectOld: oldNode, ObjectNew: newNode}, q)
+
+	assert.Equal(t, r.meetExpectations("ws1"), true)
+	// ws1 is re-queued so it can pick a different node, ws2 because it now owns one more.
+	assert.Equal(t, q.Len(), 2)
+}
+
+func TestReservedNodesCoversInFlightAndPendingActions(t *testing.T) {
+	scheme, err := genMockScheme()
+	assert.NilError(t, err)
+	pending := &v1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "ws2", Annotations: map[string]string{
+		v1.WorkspaceNodesAction: string(jsonutils.MarshalSilently(map[string]string{
+			"n-add": v1.NodeActionAdd, "n-remove": v1.NodeActionRemove,
+		})),
+	}}}
+	own := &v1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "ws1", Annotations: map[string]string{
+		v1.WorkspaceNodesAction: string(jsonutils.MarshalSilently(map[string]string{"n-own": v1.NodeActionAdd})),
+	}}}
+	cl := newWorkspaceClientBuilder(scheme).WithObjects(pending, own).Build()
+	r := newMockWorkspaceReconciler(cl)
+	r.setExpectations("ws1", sets.NewSetByKeys("n-self"))
+	r.setExpectations("ws2", sets.NewSetByKeys("n-inflight"))
+
+	reserved, err := r.reservedNodes(context.Background(), &v1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "ws1"}})
+	assert.NilError(t, err)
+	assert.Equal(t, reserved.Has("n-inflight"), true)
+	assert.Equal(t, reserved.Has("n-add"), true)
+	// Unbinding frees a node up, and a workspace never reserves against itself.
+	assert.Equal(t, reserved.Has("n-remove"), false)
+	assert.Equal(t, reserved.Has("n-self"), false)
+	assert.Equal(t, reserved.Has("n-own"), false)
+}
+
+func TestUpdateSingleNodeBindingRefusesBoundNode(t *testing.T) {
+	scheme, err := genMockScheme()
+	assert.NilError(t, err)
+	node := ownedNode("n1", "ws2")
+	cl := newWorkspaceClientBuilder(scheme).WithObjects(node).Build()
+	r := newMockWorkspaceReconciler(cl)
+
+	updated, err := r.updateSingleNodeBinding(context.Background(), workspaceNamed("ws1"), node.DeepCopy(), "ws1")
+	assert.NilError(t, err)
+	assert.Equal(t, updated, false)
+
+	stored := &v1.Node{}
+	assert.NilError(t, cl.Get(context.Background(), ctrlclient.ObjectKey{Name: "n1"}, stored))
+	assert.Equal(t, stored.GetSpecWorkspace(), "ws2")
+}
+
+func TestUpdateSingleNodeBindingBindsFreeNodeAndUnbinds(t *testing.T) {
+	scheme, err := genMockScheme()
+	assert.NilError(t, err)
+	node := ownedNode("n1", "")
+	cl := newWorkspaceClientBuilder(scheme).WithObjects(node).Build()
+	r := newMockWorkspaceReconciler(cl)
+
+	free := &v1.Node{}
+	assert.NilError(t, cl.Get(context.Background(), ctrlclient.ObjectKey{Name: "n1"}, free))
+	updated, err := r.updateSingleNodeBinding(context.Background(), workspaceNamed("ws1"), free, "ws1")
+	assert.NilError(t, err)
+	assert.Equal(t, updated, true)
+
+	bound := &v1.Node{}
+	assert.NilError(t, cl.Get(context.Background(), ctrlclient.ObjectKey{Name: "n1"}, bound))
+	assert.Equal(t, bound.GetSpecWorkspace(), "ws1")
+
+	// Unbinding the owner is always allowed; that is how a node changes hands.
+	updated, err = r.updateSingleNodeBinding(context.Background(), workspaceNamed("ws1"), bound, "")
+	assert.NilError(t, err)
+	assert.Equal(t, updated, true)
+}
+
+// A node object we no longer hold the latest version of must never silently overwrite whoever
+// bound it in the meantime. The fresh read that opens every attempt catches this one before a
+// patch is ever built, so it ends as a refusal rather than as an error -- the same answer the
+// caller would have got had it read fresh state to begin with. The optimistic lock is still
+// there behind it, for the writes that land in the window between that read and the patch.
+func TestUpdateSingleNodeBindingRejectsStaleWrite(t *testing.T) {
+	scheme, err := genMockScheme()
+	assert.NilError(t, err)
+	node := ownedNode("n1", "")
+	cl := newWorkspaceClientBuilder(scheme).WithObjects(node).Build()
+	r := newMockWorkspaceReconciler(cl)
+
+	stale := &v1.Node{}
+	assert.NilError(t, cl.Get(context.Background(), ctrlclient.ObjectKey{Name: "n1"}, stale))
+	// Someone else moves the node on before our patch lands.
+	winner := &v1.Node{}
+	assert.NilError(t, cl.Get(context.Background(), ctrlclient.ObjectKey{Name: "n1"}, winner))
+	_, err = r.updateSingleNodeBinding(context.Background(), workspaceNamed("ws2"), winner, "ws2")
+	assert.NilError(t, err)
+
+	// Our copy still shows the node as free, but its resourceVersion is behind.
+	updated, err := r.updateSingleNodeBinding(context.Background(), workspaceNamed("ws1"), stale, "ws1")
+	assert.NilError(t, err)
+	assert.Equal(t, updated, false)
+
+	stored := &v1.Node{}
+	assert.NilError(t, cl.Get(context.Background(), ctrlclient.ObjectKey{Name: "n1"}, stored))
+	assert.Equal(t, stored.GetSpecWorkspace(), "ws2")
+}
+
+func TestProcessNodesActionSkipsNodeOwnedByAnotherWorkspace(t *testing.T) {
+	scheme, err := genMockScheme()
+	assert.NilError(t, err)
+	node := ownedNode("n1", "ws2")
+	workspace := &v1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "ws1", Annotations: map[string]string{
+		v1.WorkspaceNodesAction: string(jsonutils.MarshalSilently(map[string]string{"n1": v1.NodeActionAdd})),
+	}}}
+	cl := newWorkspaceClientBuilder(scheme).WithObjects(node, workspace).Build()
+	r := newMockWorkspaceReconciler(cl)
+
+	isUpdated, err := r.processNodesAction(context.Background(), workspace, clusterNodes("n1"))
+	assert.NilError(t, err)
+	assert.Equal(t, isUpdated, false)
+
+	stored := &v1.Node{}
+	assert.NilError(t, cl.Get(context.Background(), ctrlclient.ObjectKey{Name: "n1"}, stored))
+	assert.Equal(t, stored.GetSpecWorkspace(), "ws2")
+	// The action is cleared instead of being retried forever against a node we must not take.
+	assert.Equal(t, v1.GetWorkspaceNodesAction(workspace), "")
+}
+
+func TestProcessNodesActionSkipsNodeMissingFromCluster(t *testing.T) {
+	scheme, err := genMockScheme()
+	assert.NilError(t, err)
+	node := ownedNode("n1", "")
+	node.Spec.Hostname = ptr.To("n1")
+	workspace := &v1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "ws1", Annotations: map[string]string{
+		v1.WorkspaceNodesAction: string(jsonutils.MarshalSilently(map[string]string{"n1": v1.NodeActionAdd})),
+	}}}
+	cl := newWorkspaceClientBuilder(scheme).WithObjects(node, workspace).Build()
+	r := newMockWorkspaceReconciler(cl)
+
+	// The cluster holds no k8s node, so the workspace label could never come back and the
+	// expectation would never be settled.
+	isUpdated, err := r.processNodesAction(context.Background(), workspace, clusterNodes())
+	assert.NilError(t, err)
+	assert.Equal(t, isUpdated, false)
+
+	stored := &v1.Node{}
+	assert.NilError(t, cl.Get(context.Background(), ctrlclient.ObjectKey{Name: "n1"}, stored))
+	assert.Equal(t, stored.GetSpecWorkspace(), "")
+	assert.Equal(t, v1.GetWorkspaceNodesAction(workspace), "")
+	assert.Equal(t, r.meetExpectations("ws1"), true)
+}
+
+func TestProcessNodesActionBindsNodePresentInCluster(t *testing.T) {
+	scheme, err := genMockScheme()
+	assert.NilError(t, err)
+	node := ownedNode("n1", "")
+	node.Spec.Hostname = ptr.To("n1")
+	workspace := &v1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "ws1", Annotations: map[string]string{
+		v1.WorkspaceNodesAction: string(jsonutils.MarshalSilently(map[string]string{"n1": v1.NodeActionAdd})),
+	}}}
+	cl := newWorkspaceClientBuilder(scheme).WithObjects(node, workspace).Build()
+	r := newMockWorkspaceReconciler(cl)
+
+	isUpdated, err := r.processNodesAction(context.Background(), workspace, clusterNodes("n1"))
+	assert.NilError(t, err)
+	assert.Equal(t, isUpdated, true)
+
+	stored := &v1.Node{}
+	assert.NilError(t, cl.Get(context.Background(), ctrlclient.ObjectKey{Name: "n1"}, stored))
+	assert.Equal(t, stored.GetSpecWorkspace(), "ws1")
+}
+
+func TestSyncK8sMetadataIgnoresConflictingWorkspaceLabel(t *testing.T) {
+	r := newNodeK8sReconciler(t, ownedNode("n1", "ws1"))
+	adminNode := &v1.Node{}
+	assert.NilError(t, r.Get(context.Background(), ctrlclient.ObjectKey{Name: "n1"}, adminNode))
+	k8sNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name:   "n1",
+		Labels: map[string]string{v1.WorkspaceIdLabel: "ws2"},
+	}}
+
+	assert.NilError(t, r.syncK8sMetadata(context.Background(), adminNode, k8sNode))
+	// The data plane says ws2, the admin plane bound the node to ws1. The admin plane wins.
+	assert.Equal(t, v1.GetWorkspaceId(adminNode), "ws1")
+}
+
+func TestSyncK8sMetadataAcceptsConfirmedWorkspaceLabel(t *testing.T) {
+	node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1"}}
+	node.Spec.Workspace = ptr.To("ws1")
+	r := newNodeK8sReconciler(t, node)
+	adminNode := &v1.Node{}
+	assert.NilError(t, r.Get(context.Background(), ctrlclient.ObjectKey{Name: "n1"}, adminNode))
+	k8sNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name:   "n1",
+		Labels: map[string]string{v1.WorkspaceIdLabel: "ws1"},
+	}}
+
+	assert.NilError(t, r.syncK8sMetadata(context.Background(), adminNode, k8sNode))
+	assert.Equal(t, v1.GetWorkspaceId(adminNode), "ws1")
+}
+
+func TestSyncK8sMetadataClearsWorkspaceLabelDroppedByDataPlane(t *testing.T) {
+	node := ownedNode("n1", "ws1")
+	node.Spec.Workspace = nil
+	r := newNodeK8sReconciler(t, node)
+	adminNode := &v1.Node{}
+	assert.NilError(t, r.Get(context.Background(), ctrlclient.ObjectKey{Name: "n1"}, adminNode))
+	k8sNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1"}}
+
+	// Unbinding still works: the label goes away once the data plane no longer carries it.
+	assert.NilError(t, r.syncK8sMetadata(context.Background(), adminNode, k8sNode))
+	assert.Equal(t, v1.GetWorkspaceId(adminNode), "")
+}
+
+// The ownership guard has to be reachable on real, freshly-read state, not only on a node
+// object a test hand-built. Every caller filters bound nodes out before calling here, so
+// without the re-read between attempts the guard could only ever repeat the answer that
+// filter already gave -- an assertion, not a check.
+func TestUpdateSingleNodeBindingRetriesOnUnrelatedConflict(t *testing.T) {
+	scheme, err := genMockScheme()
+	assert.NilError(t, err)
+	node := ownedNode("n1", "")
+	conflicts := 0
+	cl := newWorkspaceClientBuilder(scheme).WithObjects(node).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, c ctrlclient.WithWatch, obj ctrlclient.Object,
+				patch ctrlclient.Patch, opts ...ctrlclient.PatchOption) error {
+				// NodeK8sReconciler mirrors kubelet's node conditions, whose heartbeat moves
+				// the admin Node's resourceVersion every few seconds. That is a conflict the
+				// binder must absorb, not a competing binder.
+				if conflicts == 0 {
+					conflicts++
+					return apierrors.NewConflict(schema.GroupResource{Resource: "nodes"}, obj.GetName(), errors.New("stale"))
+				}
+				return c.Patch(ctx, obj, patch, opts...)
+			},
+		}).Build()
+	r := newMockWorkspaceReconciler(cl)
+
+	free := &v1.Node{}
+	assert.NilError(t, cl.Get(context.Background(), ctrlclient.ObjectKey{Name: "n1"}, free))
+	updated, err := r.updateSingleNodeBinding(context.Background(), workspaceNamed("ws1"), free, "ws1")
+	assert.NilError(t, err)
+	assert.Equal(t, updated, true)
+	assert.Equal(t, conflicts, 1)
+
+	bound := &v1.Node{}
+	assert.NilError(t, cl.Get(context.Background(), ctrlclient.ObjectKey{Name: "n1"}, bound))
+	assert.Equal(t, bound.GetSpecWorkspace(), "ws1")
+}
+
+// The bind guards all key on a non-empty target, so before this check the unbind path was the
+// one way left to take a node from another workspace: post {"n1":"remove"} for a node you do
+// not own and it goes back to the pool.
+func TestProcessNodesActionRefusesToUnbindAnotherWorkspacesNode(t *testing.T) {
+	scheme, err := genMockScheme()
+	assert.NilError(t, err)
+	node := ownedNode("n1", "ws2")
+	workspace := &v1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "ws1", Annotations: map[string]string{
+		v1.WorkspaceNodesAction: string(jsonutils.MarshalSilently(map[string]string{"n1": v1.NodeActionRemove})),
+	}}}
+	cl := newWorkspaceClientBuilder(scheme).WithObjects(node, workspace).Build()
+	r := newMockWorkspaceReconciler(cl)
+
+	isUpdated, err := r.processNodesAction(context.Background(), workspace, clusterNodes("n1"))
+	assert.NilError(t, err)
+	assert.Equal(t, isUpdated, false)
+
+	stored := &v1.Node{}
+	assert.NilError(t, cl.Get(context.Background(), ctrlclient.ObjectKey{Name: "n1"}, stored))
+	assert.Equal(t, stored.GetSpecWorkspace(), "ws2")
+}
+
+// A workspace under deletion is handed straight to delete() and never processes its
+// annotation, so its claims are abandoned rather than pending. Honouring them would reserve
+// those nodes against every other workspace for as long as the object lingers.
+func TestReservedNodesIgnoresDeletingWorkspace(t *testing.T) {
+	scheme, err := genMockScheme()
+	assert.NilError(t, err)
+	deleting := &v1.Workspace{ObjectMeta: metav1.ObjectMeta{
+		Name:              "ws2",
+		DeletionTimestamp: &metav1.Time{Time: time.Unix(1, 0)},
+		Finalizers:        []string{"safe.amd.com/workspace"},
+		Annotations: map[string]string{
+			v1.WorkspaceNodesAction: string(jsonutils.MarshalSilently(map[string]string{"n-add": v1.NodeActionAdd})),
+		},
+	}}
+	cl := newWorkspaceClientBuilder(scheme).WithObjects(deleting).Build()
+	r := newMockWorkspaceReconciler(cl)
+
+	reserved, err := r.reservedNodes(context.Background(), &v1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "ws1"}})
+	assert.NilError(t, err)
+	assert.Equal(t, reserved.Has("n-add"), false)
+}
+
+// "Better to skip a round of scaling up than to race an explicit binding" is only true if the
+// round is actually skipped. Returning the partial set did the opposite of what it claimed:
+// every node claimed by an annotation we could not read became fair game.
+func TestReservedNodesFailsClosedWhenTheListFails(t *testing.T) {
+	scheme, err := genMockScheme()
+	assert.NilError(t, err)
+	boom := errors.New("apiserver unavailable")
+	cl := newWorkspaceClientBuilder(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c ctrlclient.WithWatch, list ctrlclient.ObjectList,
+				opts ...ctrlclient.ListOption) error {
+				if _, ok := list.(*v1.WorkspaceList); ok {
+					return boom
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).Build()
+	r := newMockWorkspaceReconciler(cl)
+
+	_, err = r.reservedNodes(context.Background(), &v1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "ws1"}})
+	assert.ErrorContains(t, err, "apiserver unavailable")
+
+	// And the scale-up round it feeds stops there rather than binding unreserved nodes.
+	workspace := &v1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{Name: "ws1"},
+		Spec:       v1.WorkspaceSpec{NodeFlavor: "flavor-a", Cluster: "c1"},
+	}
+	_, err = r.getNodesForScalingUp(context.Background(), workspace, clusterNodes("n1"), 1)
+	assert.ErrorContains(t, err, "apiserver unavailable")
+}
+
+func TestJudgeNodeBinding(t *testing.T) {
+	for _, tc := range []struct {
+		name                     string
+		current, target, request string
+		want                     nodeBindVerdict
+	}{
+		{"bind a free node", "", "ws1", "ws1", bindProceed},
+		{"bind what we already hold", "ws1", "ws1", "ws1", bindSettled},
+		// The rule the whole branch exists for, in both directions.
+		{"bind a node someone else holds", "ws2", "ws1", "ws1", bindRefused},
+		{"unbind our own node", "ws1", "", "ws1", bindProceed},
+		{"unbind someone else's node", "ws2", "", "ws1", bindRefused},
+		{"unbind a node nobody holds", "", "", "ws1", bindSettled},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			verdict, reason := judgeNodeBinding(tc.current, tc.target, tc.request)
+			assert.Equal(t, verdict, tc.want)
+			// A refusal that says nothing is a silent drop in the log.
+			assert.Equal(t, reason != "", tc.want == bindRefused)
+		})
+	}
+}
+
+// The rule now also holds at the layer that writes, not only at the layer that assembles the
+// request -- so an unbind that reached here from anywhere is still checked against the owner.
+func TestUpdateSingleNodeBindingRefusesUnbindByNonOwner(t *testing.T) {
+	scheme, err := genMockScheme()
+	assert.NilError(t, err)
+	node := ownedNode("n1", "ws2")
+	cl := newWorkspaceClientBuilder(scheme).WithObjects(node).Build()
+	r := newMockWorkspaceReconciler(cl)
+
+	owned := &v1.Node{}
+	assert.NilError(t, cl.Get(context.Background(), ctrlclient.ObjectKey{Name: "n1"}, owned))
+	updated, err := r.updateSingleNodeBinding(context.Background(), workspaceNamed("ws1"), owned, "")
+	assert.NilError(t, err)
+	assert.Equal(t, updated, false)
+
+	stored := &v1.Node{}
+	assert.NilError(t, cl.Get(context.Background(), ctrlclient.ObjectKey{Name: "n1"}, stored))
+	assert.Equal(t, stored.GetSpecWorkspace(), "ws2")
+}
+
+// Settling an expectation has to drop the map entry, not leave an empty set behind. Only the
+// delete path ever removed one, so a workspace that merely scaled kept its entry for the life
+// of the process -- and every admin Node event walks the whole map under the write lock.
+func TestObserveNodePrunesSettledExpectations(t *testing.T) {
+	r := newMockWorkspaceReconciler(nil)
+	r.setExpectations("ws1", sets.NewSetByKeys("n1", "n2"))
+	r.setExpectations("ws2", sets.NewSetByKeys("n1"))
+
+	r.observeNode("ws1", "n1")
+	_, stillTracked := r.expectations["ws1"]
+	assert.Equal(t, stillTracked, true, "ws1 is still waiting on n2")
+
+	r.observeNode("ws1", "n2")
+	_, stillTracked = r.expectations["ws1"]
+	assert.Equal(t, stillTracked, false)
+	assert.Equal(t, r.meetExpectations("ws1"), true)
+
+	// And the same through the path node events take.
+	assert.Equal(t, len(r.observeNodeForAll("n1")), 1)
+	assert.Equal(t, len(r.expectations), 0)
+}
+
+// Reservations are per cluster. A workspace elsewhere cannot be laying claim to this
+// cluster's nodes, and parsing its annotation to find that out is the bulk of the work.
+func TestReservedNodesIgnoresOtherClusters(t *testing.T) {
+	scheme, err := genMockScheme()
+	assert.NilError(t, err)
+	elsewhere := &v1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{Name: "ws-b", Annotations: map[string]string{
+			v1.WorkspaceNodesAction: string(jsonutils.MarshalSilently(map[string]string{"n-b": v1.NodeActionAdd})),
+		}},
+		Spec: v1.WorkspaceSpec{Cluster: "c2"},
+	}
+	sameCluster := &v1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{Name: "ws-a", Annotations: map[string]string{
+			v1.WorkspaceNodesAction: string(jsonutils.MarshalSilently(map[string]string{"n-a": v1.NodeActionAdd})),
+		}},
+		Spec: v1.WorkspaceSpec{Cluster: "c1"},
+	}
+	cl := newWorkspaceClientBuilder(scheme).WithObjects(elsewhere, sameCluster).Build()
+	r := newMockWorkspaceReconciler(cl)
+
+	reserved, err := r.reservedNodes(context.Background(), &v1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{Name: "ws1"},
+		Spec:       v1.WorkspaceSpec{Cluster: "c1"},
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, reserved.Has("n-a"), true)
+	assert.Equal(t, reserved.Has("n-b"), false)
+}
+
+// The informer is attached per cluster by NodeK8sReconciler, so a workspace reconcile can run
+// before there is any cache to read. Falling back to the apiserver is what keeps that from
+// reading as an empty cluster -- which here would mean "the node is gone".
+func TestGetCachedDataPlaneNodeFallsBackWhenThereIsNoInformer(t *testing.T) {
+	clients := clusterNodes("k8s-n1")
+	assert.Assert(t, dataPlaneNodeLister(clients) == nil)
+
+	node, err := getCachedDataPlaneNode(context.Background(), clients, "k8s-n1")
+	assert.NilError(t, err)
+	assert.Equal(t, node.Name, "k8s-n1")
+
+	_, err = getCachedDataPlaneNode(context.Background(), clients, "absent")
+	assert.Assert(t, apierrors.IsNotFound(err))
+}
+
+// clusterNodesWithInformer is clusterNodes with the shared informer the production factories
+// carry, started and synced. Without it every test here takes the fallback path, which is the
+// one branch that did not need testing.
+func clusterNodesWithInformer(t *testing.T, names ...string) (*commonclient.ClientFactory, *k8sfake.Clientset) {
+	t.Helper()
+	objs := make([]runtime.Object, 0, len(names))
+	for _, name := range names {
+		objs = append(objs, &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}})
+	}
+	clientSet := k8sfake.NewClientset(objs...)
+	clients := commonclient.NewClientFactoryForTestWithInformer("c1", clientSet)
+	// Registering has to happen before Start: the factory only runs the informers it has
+	// been asked for by then. This is what attachNodeInformer does in production.
+	clients.SharedInformerFactory().Core().V1().Nodes().Informer()
+	clients.StartInformer()
+	assert.Assert(t, clients.WaitForCacheSync(10*time.Second))
+	t.Cleanup(func() { _ = clients.Release() })
+	return clients, clientSet
+}
+
+// countGets records reads that reached the apiserver. The informer lists and watches, it
+// never gets, so this counts exactly the round trips the lister was meant to save.
+func countGets(clientSet *k8sfake.Clientset, n *int) {
+	clientSet.PrependReactor("get", "nodes", func(k8stesting.Action) (bool, runtime.Object, error) {
+		*n++
+		return false, nil, nil
+	})
+}
+
+func TestGetCachedDataPlaneNodeReadsTheInformerNotTheApiserver(t *testing.T) {
+	clients, clientSet := clusterNodesWithInformer(t, "k8s-n1")
+	assert.Assert(t, dataPlaneNodeLister(clients) != nil)
+	gets := 0
+	countGets(clientSet, &gets)
+
+	node, err := getCachedDataPlaneNode(context.Background(), clients, "k8s-n1")
+	assert.NilError(t, err)
+	assert.Equal(t, node.Name, "k8s-n1")
+	assert.Equal(t, gets, 0, "the whole point of the lister is that this costs no round trip")
+
+	// The lister hands out pointers into the shared cache, which every caller here goes on
+	// to mutate or store. Without the copy this scribbles on the informer's own object.
+	node.Labels = map[string]string{"scribbled": "on"}
+	again, err := getCachedDataPlaneNode(context.Background(), clients, "k8s-n1")
+	assert.NilError(t, err)
+	assert.Equal(t, len(again.Labels), 0)
+
+	_, err = getCachedDataPlaneNode(context.Background(), clients, "absent")
+	assert.Assert(t, apierrors.IsNotFound(err))
+}
+
+// The other half of the split. k8sNodeUnavailableReason and NodeReconciler.getK8sNode must keep
+// reaching the apiserver even where an informer is available -- one reads NotFound as a
+// permanent refusal, the other writes back what it reads.
+func TestGetDataPlaneNodeIgnoresTheInformer(t *testing.T) {
+	clients, clientSet := clusterNodesWithInformer(t, "k8s-n1")
+	assert.Assert(t, dataPlaneNodeLister(clients) != nil)
+	gets := 0
+	countGets(clientSet, &gets)
+
+	node, err := getDataPlaneNode(context.Background(), clients, "k8s-n1")
+	assert.NilError(t, err)
+	assert.Equal(t, node.Name, "k8s-n1")
+	assert.Equal(t, gets, 1)
+}
+
+func conflictOnPatch(count *int) interceptor.Funcs {
+	return interceptor.Funcs{
+		Patch: func(_ context.Context, _ ctrlclient.WithWatch, obj ctrlclient.Object,
+			_ ctrlclient.Patch, _ ...ctrlclient.PatchOption) error {
+			*count++
+			return apierrors.NewConflict(v1.Resource("nodes"), obj.GetName(),
+				errors.New("the object has been modified"))
+		},
+	}
+}
+
+// The re-read between attempts is the only thing that makes the ownership check a check, and
+// it is worth nothing if it is served from the same cache that produced the stale object. The
+// manager's typed client is exactly that cache, and one retry budget is ~150ms of backoff --
+// no basis for assuming a watch has delivered the write that just won.
+func TestUpdateSingleNodeBindingRereadsThroughTheUncachedReader(t *testing.T) {
+	scheme, err := genMockScheme()
+	assert.NilError(t, err)
+	patches := 0
+	// What the cache still shows: free, and so worth binding.
+	cached := newWorkspaceClientBuilder(scheme).
+		WithObjects(ownedNode("n1", "")).
+		WithInterceptorFuncs(conflictOnPatch(&patches)).Build()
+	r := newMockWorkspaceReconciler(cached)
+	// What is actually stored: ws2 got there first, which is why the patch conflicted.
+	r.apiReader = newWorkspaceClientBuilder(scheme).WithObjects(ownedNode("n1", "ws2")).Build()
+
+	updated, err := r.updateSingleNodeBinding(context.Background(), workspaceNamed("ws1"), ownedNode("n1", ""), "ws1")
+	assert.NilError(t, err)
+	assert.Equal(t, updated, false)
+	// Not one wasted patch: the read comes first, so the refusal happens before anything is
+	// written. Reading the cache instead would have kept saying "free" and burned the whole
+	// budget re-patching a node ws2 owns.
+	assert.Equal(t, patches, 0)
+}
+
+// A node that started deleting between the caller's filter and this retry must not be *bound*:
+// judgeNodeBinding only knows about ownership, so the check has to live here.
+//
+// Note this is the bind half. The unbind half is the test below, and the two cannot share a
+// guard -- see TestUpdateSingleNodeBindingReleasesANodeThatStartedDeleting.
+func TestUpdateSingleNodeBindingSkipsANodeThatStartedDeleting(t *testing.T) {
+	scheme, err := genMockScheme()
+	assert.NilError(t, err)
+	deleting := ownedNode("n1", "")
+	deleting.DeletionTimestamp = &metav1.Time{Time: time.Unix(1, 0)}
+	deleting.Finalizers = []string{"safe.amd.com/node"}
+	patches := 0
+	cached := newWorkspaceClientBuilder(scheme).
+		WithObjects(ownedNode("n1", "")).
+		WithInterceptorFuncs(conflictOnPatch(&patches)).Build()
+	r := newMockWorkspaceReconciler(cached)
+	r.apiReader = newWorkspaceClientBuilder(scheme).WithObjects(deleting).Build()
+
+	updated, err := r.updateSingleNodeBinding(context.Background(), workspaceNamed("ws1"), ownedNode("n1", ""), "ws1")
+	assert.NilError(t, err)
+	assert.Equal(t, updated, false)
+	assert.Equal(t, patches, 0)
+}
+
+// The unbind half, which the deletion guard above must not catch.
+//
+// delete() collects every node whose spec.workspace names the workspace -- a deleting node is
+// still one of them -- and settles each node's expectation on !updated. A refusal here answers
+// "nothing to do", so meetExpectations passes and the finalizer comes off with the node still
+// naming a Workspace that no longer exists. judgeNodeBinding then refuses every other
+// workspace for that node, forever, because the only one allowed to release it is gone.
+//
+// The release has to actually land, not merely be attempted: it is the spec write that stops
+// the node being unrescuable once the Workspace is collected.
+func TestUpdateSingleNodeBindingReleasesANodeThatStartedDeleting(t *testing.T) {
+	scheme, err := genMockScheme()
+	assert.NilError(t, err)
+	deleting := ownedNode("n1", "ws1")
+	deleting.DeletionTimestamp = &metav1.Time{Time: time.Unix(1, 0)}
+	deleting.Finalizers = []string{"safe.amd.com/node"}
+	cl := newWorkspaceClientBuilder(scheme).WithObjects(deleting).Build()
+	r := newMockWorkspaceReconciler(cl)
+
+	updated, err := r.updateSingleNodeBinding(context.Background(), workspaceNamed("ws1"), deleting.DeepCopy(), "")
+	assert.NilError(t, err)
+	assert.Equal(t, updated, true)
+
+	stored := &v1.Node{}
+	assert.NilError(t, cl.Get(context.Background(), ctrlclient.ObjectKey{Name: "n1"}, stored))
+	assert.Equal(t, stored.GetSpecWorkspace(), "")
+}
+
+// The same thing end to end, which is where it actually bit.
+//
+// The workspace is deleted while it still owns a node that has itself started deleting. Both
+// halves have to hold: the node is released, and the Workspace keeps its finalizer until that
+// release is confirmed. Settling on an unbind that never happened is what let the Workspace go
+// first and stranded the node.
+func TestDeleteReleasesANodeThatStartedDeleting(t *testing.T) {
+	scheme, err := genMockScheme()
+	assert.NilError(t, err)
+	node := ownedNode("n1", "ws1")
+	node.DeletionTimestamp = &metav1.Time{Time: time.Unix(1, 0)}
+	node.Finalizers = []string{"safe.amd.com/node"}
+	workspace := &v1.Workspace{ObjectMeta: metav1.ObjectMeta{
+		Name:       "ws1",
+		Finalizers: []string{v1.WorkspaceFinalizer},
+	}}
+	cl := newWorkspaceClientBuilder(scheme).
+		WithStatusSubresource(&v1.Workspace{}).
+		WithObjects(node, workspace).Build()
+	r := newMockWorkspaceReconciler(cl)
+
+	assert.NilError(t, r.delete(context.Background(), workspace))
+
+	stored := &v1.Node{}
+	assert.NilError(t, cl.Get(context.Background(), ctrlclient.ObjectKey{Name: "n1"}, stored))
+	assert.Equal(t, stored.GetSpecWorkspace(), "", "the node must not be left naming a workspace that is going away")
+
+	// Still held: the unbind moved spec, and the expectation waits for the workspace label,
+	// which handleNodeEvent's DeleteFunc will settle when the node object finally goes.
+	ws := &v1.Workspace{}
+	assert.NilError(t, cl.Get(context.Background(), ctrlclient.ObjectKey{Name: "ws1"}, ws))
+	assert.Equal(t, len(ws.Finalizers), 1, "the workspace must outlive the node it just released")
+}
+
+// Losing every conflict has to be reported. It costs nothing to report: concurrent.Exec runs
+// every goroutine to completion and returns the first error, so the other nodes in the same
+// scale-up all get their turn either way, and the error buys a rate-limited requeue.
+//
+// Swallowing it is what costs. updated=false with err=nil reads as "there was nothing to do",
+// which for a workspace being deleted means removeExpectations, then deleteDataPlaneResources,
+// then RemoveFinalizer -- with the node still pointing at a Workspace that no longer exists.
+// Nothing recovers that node afterwards: judgeNodeBinding refuses every other workspace, and
+// the only workspace allowed to release it is gone.
+func TestUpdateSingleNodeBindingReportsLosingEveryConflict(t *testing.T) {
+	scheme, err := genMockScheme()
+	assert.NilError(t, err)
+	patches := 0
+	cl := newWorkspaceClientBuilder(scheme).
+		WithObjects(ownedNode("n1", "")).
+		WithInterceptorFuncs(conflictOnPatch(&patches)).Build()
+	r := newMockWorkspaceReconciler(cl)
+
+	updated, err := r.updateSingleNodeBinding(context.Background(), workspaceNamed("ws1"), ownedNode("n1", ""), "ws1")
+	assert.Assert(t, apierrors.IsConflict(err), "giving up has to reach the caller: %v", err)
+	assert.Equal(t, updated, false)
+	assert.Equal(t, patches, 5, "retry.DefaultRetry gives five attempts")
+}
+
+// The wedge this whole branch exists to remove, reachable through a node that carries the
+// workspace label but no spec.workspace -- what a scaleDown or a delete() hands over after an
+// earlier unbind wrote the label and nothing wrote the pointer.
+//
+// Writing spec.workspace="" over the nil "to make the release explicit" changes no behaviour
+// (GetSpecWorkspace maps nil to "") but does report updated=true, which stops the caller from
+// settling the expectation -- and the write cannot settle it either, because handleNodeEvent
+// only observes on a change of the workspace *label*. The expectation then never clears and
+// every later reconcile of the workspace returns early, deletion included.
+func TestUnbindingANodeWithNoSpecWorkspaceSettlesItsExpectation(t *testing.T) {
+	scheme, err := genMockScheme()
+	assert.NilError(t, err)
+	node := &v1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name:   "n1",
+		Labels: map[string]string{v1.WorkspaceIdLabel: "ws1"},
+	}}
+	patches := 0
+	cl := newWorkspaceClientBuilder(scheme).WithObjects(node.DeepCopy()).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, c ctrlclient.WithWatch, obj ctrlclient.Object,
+				patch ctrlclient.Patch, opts ...ctrlclient.PatchOption) error {
+				patches++
+				return c.Patch(ctx, obj, patch, opts...)
+			},
+		}).Build()
+	r := newMockWorkspaceReconciler(cl)
+
+	err = r.updateNodesBinding(context.Background(),
+		&v1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "ws1"}},
+		[]*v1.Node{node.DeepCopy()}, map[string]string{"n1": ""})
+	assert.NilError(t, err)
+	assert.Equal(t, patches, 0, "there is nothing to release; nil already reads as unbound")
+	assert.Equal(t, r.meetExpectations("ws1"), true, "the workspace is wedged if this is false")
+}
+
+// A deleting workspace's in-flight operations are unbinds -- it is releasing these nodes, not
+// claiming them. Reserving them keeps them out of every other workspace's reach for as long as
+// the entry lives, which is the life of the process if its own deletion is stuck.
+func TestReservedNodesIgnoresADeletingWorkspacesExpectations(t *testing.T) {
+	scheme, err := genMockScheme()
+	assert.NilError(t, err)
+	deleting := &v1.Workspace{ObjectMeta: metav1.ObjectMeta{
+		Name:              "ws2",
+		DeletionTimestamp: &metav1.Time{Time: time.Unix(1, 0)},
+		Finalizers:        []string{"safe.amd.com/workspace"},
+	}}
+	live := &v1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "ws3"}}
+	cl := newWorkspaceClientBuilder(scheme).WithObjects(deleting, live).Build()
+	r := newMockWorkspaceReconciler(cl)
+	r.setExpectations("ws2", sets.NewSetByKeys("n-releasing"))
+	r.setExpectations("ws3", sets.NewSetByKeys("n-claiming"))
+	// Nobody by this name is in the list. Absence is served from a cache, so it is as likely
+	// to mean "created a moment ago" as "gone", and an unattributable bind stays reserved.
+	r.setExpectations("ws-unknown", sets.NewSetByKeys("n-mystery"))
+
+	reserved, err := r.reservedNodes(context.Background(), &v1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "ws1"}})
+	assert.NilError(t, err)
+	assert.Equal(t, reserved.Has("n-releasing"), false)
+	assert.Equal(t, reserved.Has("n-claiming"), true)
+	assert.Equal(t, reserved.Has("n-mystery"), true)
+}
+
+// What giving up silently used to cost, end to end.
+//
+// delete() unbinds every node the workspace still owns, and only once that is done does it
+// drop the finalizer and let the Workspace go. When updateSingleNodeBinding answered
+// "updated=false, err=nil" after losing all five conflicts, the node's expectation was
+// settled, meetExpectations said yes, and the finalizer came off with the node's
+// spec.workspace still naming a Workspace that no longer exists -- and no later bind can
+// clear it, because judgeNodeBinding refuses every workspace except the one that is gone.
+func TestDeleteKeepsItsFinalizerWhenANodeCannotBeReleased(t *testing.T) {
+	scheme, err := genMockScheme()
+	assert.NilError(t, err)
+	node := ownedNode("n1", "ws1")
+	workspace := &v1.Workspace{ObjectMeta: metav1.ObjectMeta{
+		Name:       "ws1",
+		Finalizers: []string{v1.WorkspaceFinalizer},
+	}}
+	patches := 0
+	cl := newWorkspaceClientBuilder(scheme).
+		WithStatusSubresource(&v1.Workspace{}).
+		WithObjects(node, workspace).
+		WithInterceptorFuncs(conflictOnPatch(&patches)).Build()
+	r := newMockWorkspaceReconciler(cl)
+
+	err = r.delete(context.Background(), workspace)
+	assert.Assert(t, apierrors.IsConflict(err), "the unbind failed and delete has to say so: %v", err)
+	assert.Equal(t, patches, 5)
+
+	stored := &v1.Workspace{}
+	assert.NilError(t, cl.Get(context.Background(), ctrlclient.ObjectKey{Name: "ws1"}, stored))
+	assert.Assert(t, len(stored.Finalizers) == 1, "the workspace must outlive the node it still owns")
+}
+
+// drainEvents reads whatever the recorder has buffered. FakeRecorder's send is blocking, so
+// nothing may be left in the channel by the time the test ends -- and nothing is, because
+// every emitter here runs to completion before the assertion.
+func drainEvents(recorder *record.FakeRecorder) []string {
+	var out []string
+	for {
+		select {
+		case e := <-recorder.Events:
+			out = append(out, e)
+		default:
+			return out
+		}
+	}
+}
+
+// A refusal is a decision about a request a user made through the API. That request already
+// returned 200, the annotation carrying it is cleared on the way out, and the resource-manager
+// log is not somewhere a user can look -- so the Workspace has to carry the answer.
+func TestUpdateSingleNodeBindingEventsTheRefusal(t *testing.T) {
+	scheme, err := genMockScheme()
+	assert.NilError(t, err)
+	cl := newWorkspaceClientBuilder(scheme).WithObjects(ownedNode("n1", "ws2")).Build()
+	r := newMockWorkspaceReconciler(cl)
+	recorder := record.NewFakeRecorder(4)
+	r.recorder = recorder
+
+	updated, err := r.updateSingleNodeBinding(context.Background(), workspaceNamed("ws1"), ownedNode("n1", ""), "ws1")
+	assert.NilError(t, err)
+	assert.Equal(t, updated, false)
+
+	events := drainEvents(recorder)
+	assert.Equal(t, len(events), 1)
+	assert.Assert(t, strings.Contains(events[0], eventNodeBindRefused), events[0])
+	assert.Assert(t, strings.Contains(events[0], "ws2"), "the event has to name who holds the node: %s", events[0])
+}
+
+// The other permanent drop on the bind path, and the one furthest from anything a user can
+// see: the node exists in the admin plane, so the request looks reasonable, but the cluster
+// has no k8s node to put the label on and the bind would wait forever.
+func TestProcessNodesActionEventsAMissingK8sNode(t *testing.T) {
+	scheme, err := genMockScheme()
+	assert.NilError(t, err)
+	node := ownedNode("n1", "")
+	node.Spec.Hostname = ptr.To("n1")
+	workspace := &v1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "ws1", Annotations: map[string]string{
+		v1.WorkspaceNodesAction: string(jsonutils.MarshalSilently(map[string]string{"n1": v1.NodeActionAdd})),
+	}}}
+	cl := newWorkspaceClientBuilder(scheme).WithObjects(node, workspace).Build()
+	r := newMockWorkspaceReconciler(cl)
+	recorder := record.NewFakeRecorder(4)
+	r.recorder = recorder
+
+	_, err = r.processNodesAction(context.Background(), workspace, clusterNodes())
+	assert.NilError(t, err)
+
+	events := drainEvents(recorder)
+	assert.Equal(t, len(events), 1)
+	assert.Assert(t, strings.Contains(events[0], eventNodeUnavailable), events[0])
+}
+
+// The two ways a node can be unbindable-for-now have to read differently, because they call
+// for different things: one is waited out, the other is a node that was never registered with
+// the cluster it claims to be in.
+func TestK8sNodeUnavailableReason(t *testing.T) {
+	r := newMockWorkspaceReconciler(nil)
+	clients := clusterNodes("k8s-n1")
+
+	present := ownedNode("n1", "")
+	present.Spec.Hostname = ptr.To("k8s-n1")
+	assert.Equal(t, r.k8sNodeUnavailableReason(context.Background(), clients, present), "")
+
+	absent := ownedNode("n2", "")
+	absent.Spec.Hostname = ptr.To("k8s-n2")
+	assert.Assert(t, strings.Contains(
+		r.k8sNodeUnavailableReason(context.Background(), clients, absent), "not in the cluster"))
+
+	// No hostname yet: the node has not finished registering, so there is nothing to look up.
+	// Distinct from the above -- this one resolves on its own.
+	unnamed := ownedNode("n3", "")
+	assert.Assert(t, strings.Contains(
+		r.k8sNodeUnavailableReason(context.Background(), clients, unnamed), "not known yet"))
+}
+
+// A k8s node on its way out is a third answer, not a variant of "not in the cluster". The
+// object is still there, so NotFound never fires, and the guard in updateSingleNodeBinding
+// only reads the admin Node -- which is still healthy at this point, because it is deleted in
+// response to its k8s node going away, not alongside it. Without this check the window in
+// between is a bind that succeeds against a node that is about to stop existing.
+func TestK8sNodeUnavailableReasonRefusesADeletingK8sNode(t *testing.T) {
+	r := newMockWorkspaceReconciler(nil)
+	going := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name:              "k8s-n1",
+		DeletionTimestamp: &metav1.Time{Time: time.Now()},
+		Finalizers:        []string{"safe.amd.com/test"},
+	}}
+	clients := commonclient.NewClientFactoryWithOnlyClient(
+		context.Background(), "c1", k8sfake.NewClientset(going))
+
+	node := ownedNode("n1", "")
+	node.Spec.Hostname = ptr.To("k8s-n1")
+	reason := r.k8sNodeUnavailableReason(context.Background(), clients, node)
+	assert.Assert(t, strings.Contains(reason, "being deleted"), reason)
+	// Distinguishable from the node that was never registered: same drop, different fix.
+	assert.Assert(t, !strings.Contains(reason, "not in the cluster"), reason)
+}
+
+// An admin Node that is gone by the time updateSingleNodeBinding reads it is an answer, not a
+// failure. There is no reference left for the workspace to hold, so updated=false is the whole
+// truth and the caller settles the expectation on it. Reporting NotFound as an error made
+// concurrent.Exec fail the batch instead, so a deleting workspace paid a rate-limited requeue
+// and an error log every round for a node that had already stopped existing.
+func TestUpdateNodesBindingSettlesAVanishedNodeWithoutAnError(t *testing.T) {
+	scheme, err := genMockScheme()
+	assert.NilError(t, err)
+	// Nothing in the store: the object handed over is a leftover from a cached list.
+	cl := newWorkspaceClientBuilder(scheme).Build()
+	r := newMockWorkspaceReconciler(cl)
+	gone := ownedNode("n1", "ws1")
+
+	err = r.updateNodesBinding(context.Background(), workspaceNamed("ws1"),
+		[]*v1.Node{gone}, map[string]string{"n1": ""})
+	assert.NilError(t, err)
+	// Settled, so the workspace's next pass is free to drop its finalizer -- which is safe
+	// here precisely because the node it would have pointed at is gone.
+	assert.Equal(t, r.meetExpectations("ws1"), true)
+}
+
+// The wedge from the other side: a node that is already in the state the action asks for as
+// far as the *label* is concerned.
+//
+// An expectation waits for the workspace label to make the round trip through the data plane,
+// and handleNodeEvent credits it only on a change of that label. A workspace deleted while a
+// bind was still in flight leaves the node with spec.workspace cleared and the label never
+// set, so the unbind's expectation is waiting for a transition that already happened. Nothing
+// writes the admin Node again -- syncK8sMetadata correctly refuses to copy back a data-plane
+// label that disagrees with spec -- and the Workspace sits in Terminating until the process
+// restarts.
+func TestUpdateNodesBindingSettlesANodeWhoseLabelAlreadyReadsTheTarget(t *testing.T) {
+	scheme, err := genMockScheme()
+	assert.NilError(t, err)
+	// The bind wrote spec.workspace; the label never came back. delete() now unbinds, which
+	// is a real patch (updated=true) -- and then waits for a label that is already gone.
+	node := ownedNode("n1", "ws1")
+	delete(node.Labels, v1.WorkspaceIdLabel)
+	cl := newWorkspaceClientBuilder(scheme).WithObjects(node).Build()
+	r := newMockWorkspaceReconciler(cl)
+
+	assert.NilError(t, r.updateNodesBinding(context.Background(), workspaceNamed("ws1"),
+		[]*v1.Node{node.DeepCopy()}, map[string]string{"n1": ""}))
+	assert.Equal(t, r.meetExpectations("ws1"), true,
+		"nothing is going to move the label, so delete() would wait forever")
+}
+
+// And the ordinary case still waits: the label has to come back before the bind counts.
+func TestUpdateNodesBindingStillWaitsForTheLabelRoundTrip(t *testing.T) {
+	scheme, err := genMockScheme()
+	assert.NilError(t, err)
+	node := ownedNode("n1", "")
+	cl := newWorkspaceClientBuilder(scheme).WithObjects(node).Build()
+	r := newMockWorkspaceReconciler(cl)
+
+	assert.NilError(t, r.updateNodesBinding(context.Background(), workspaceNamed("ws1"),
+		[]*v1.Node{node.DeepCopy()}, map[string]string{"n1": "ws1"}))
+	assert.Equal(t, r.meetExpectations("ws1"), false)
+}
+
+// processNodesAction refuses, clears the annotation and emits an event -- none of which is
+// retried. Deciding that from the manager's cache means a cache that has not yet caught up
+// with a release turns a request the user is entitled to make into a permanent no.
+func TestProcessNodesActionJudgesOwnershipUncached(t *testing.T) {
+	scheme, err := genMockScheme()
+	assert.NilError(t, err)
+	node := ownedNode("n1", "")
+	node.Spec.Hostname = ptr.To("n1")
+	workspace := &v1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "ws1", Annotations: map[string]string{
+		v1.WorkspaceNodesAction: string(jsonutils.MarshalSilently(map[string]string{"n1": v1.NodeActionAdd})),
+	}}}
+	// The cache is behind: it still shows ws2 holding a node ws2 has already given up.
+	stale := ownedNode("n1", "ws2")
+	stale.Spec.Hostname = ptr.To("n1")
+	cl := newWorkspaceClientBuilder(scheme).WithObjects(stale, workspace).Build()
+	r := newMockWorkspaceReconciler(cl)
+	r.apiReader = newWorkspaceClientBuilder(scheme).WithObjects(node, workspace).Build()
+	recorder := record.NewFakeRecorder(4)
+	r.recorder = recorder
+
+	isUpdated, err := r.processNodesAction(context.Background(), workspace, clusterNodes("n1"))
+	assert.NilError(t, err)
+	assert.Equal(t, isUpdated, true)
+	assert.Equal(t, len(drainEvents(recorder)), 0, "the node is free; there is nothing to refuse")
+}

--- a/SaFE/webhooks/pkg/workspace_webhook.go
+++ b/SaFE/webhooks/pkg/workspace_webhook.go
@@ -724,6 +724,25 @@ func (v *WorkspaceValidator) validateNodesAction(ctx context.Context, newWorkspa
 		if n == nil {
 			return commonerrors.NewNotFound(v1.NodeKind, key)
 		}
+		// Onboarding has to finish before a node can be handed to a workspace, and this is
+		// the only place that can say so in a way the caller sees. Accepting the request and
+		// letting the resource-manager sort it out is not equivalent: it drops the entry,
+		// clears the annotation and leaves an event, so a 200 here becomes a node that just
+		// never joins.
+		//
+		// Ahead of the cluster check on purpose. The write in NodeReconciler.manage that
+		// stamps ClusterIdLabel is the same one that sets Managed, so an unmanaged node has
+		// no cluster label and fails that check instead -- reporting a cluster mismatch that
+		// does not exist and sending whoever reads it to look at cluster configuration for a
+		// node that is simply not done onboarding.
+		//
+		// Add only. A remove has to stay possible for a node that ended up bound and then
+		// lost its managed state, which is exactly when it needs releasing.
+		if val == v1.NodeActionAdd && !n.IsManaged() {
+			return commonerrors.NewResourceProcessing(fmt.Sprintf(
+				"the node(%s) is not managed yet(phase %s). it can't be added",
+				key, n.Status.ClusterStatus.Phase))
+		}
 		if v1.GetClusterId(n) != newWorkspace.Spec.Cluster {
 			return fmt.Errorf("the node %s and workspace %s are not in the same cluster", n.Name, newWorkspace.Name)
 		}

--- a/SaFE/webhooks/pkg/workspace_webhook_test.go
+++ b/SaFE/webhooks/pkg/workspace_webhook_test.go
@@ -7,11 +7,13 @@ package webhooks
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"gotest.tools/assert"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
@@ -587,6 +589,7 @@ func TestWorkspaceValidateNodesActionErrors(t *testing.T) {
 	bound := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{Name: "n1", Labels: map[string]string{v1.ClusterIdLabel: "cluster1"}},
 		Spec:       v1.NodeSpec{Workspace: pointer.String("other")},
+		Status:     v1.NodeStatus{ClusterStatus: v1.NodeClusterStatus{Phase: v1.NodeManaged}},
 	}
 	c1 := fake.NewClientBuilder().WithScheme(scheme).WithObjects(bound).Build()
 	v1v := &WorkspaceValidator{Client: c1}
@@ -604,12 +607,51 @@ func TestWorkspaceValidateNodesActionErrors(t *testing.T) {
 	// cluster mismatch
 	wrongCluster := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{Name: "n2", Labels: map[string]string{v1.ClusterIdLabel: "other"}},
+		Status:     v1.NodeStatus{ClusterStatus: v1.NodeClusterStatus{Phase: v1.NodeManaged}},
 	}
 	c3 := fake.NewClientBuilder().WithScheme(scheme).WithObjects(wrongCluster).Build()
 	v3 := &WorkspaceValidator{Client: c3}
 	ws3 := &v1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "ws1"}, Spec: v1.WorkspaceSpec{Cluster: "cluster1"}}
 	v1.SetAnnotation(ws3, v1.WorkspaceNodesAction, `{"n2":"add"}`)
 	assert.Assert(t, v3.validateNodesAction(context.Background(), ws3, &v1.Workspace{}) != nil)
+}
+
+// A node that has not finished onboarding is refused here, with its own message.
+//
+// Downstream cannot recover this one: processNodesAction drops the entry and clears the
+// annotation, so an accepted request turns into a node that silently never joins. And the
+// cluster check alone would not do -- it reports a mismatch, which is the wrong place to send
+// whoever has to act on it.
+func TestWorkspaceValidateNodesActionRefusesAnUnmanagedNode(t *testing.T) {
+	scheme := newScheme(t)
+	// Cluster label already stamped, so the only thing standing between this node and the
+	// binding is that it is still being managed.
+	managing := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "n1", Labels: map[string]string{v1.ClusterIdLabel: "cluster1"}},
+		Status:     v1.NodeStatus{ClusterStatus: v1.NodeClusterStatus{Phase: v1.NodeManaging}},
+	}
+	v := &WorkspaceValidator{Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(managing).Build()}
+	ws := &v1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "ws1"}, Spec: v1.WorkspaceSpec{Cluster: "cluster1"}}
+	v1.SetAnnotation(ws, v1.WorkspaceNodesAction, `{"n1":"add"}`)
+
+	err := v.validateNodesAction(context.Background(), ws, &v1.Workspace{})
+	assert.Assert(t, err != nil)
+	assert.Assert(t, strings.Contains(err.Error(), "not managed yet"), err.Error())
+	// Retryable, not a permanent rejection: the caller is being told to come back, not that
+	// the request was wrong.
+	assert.Assert(t, apierrors.IsConflict(err), err.Error())
+
+	// Releasing one stays possible: a node that lost its managed state while bound is
+	// precisely the one that needs to come out.
+	bound := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "n2", Labels: map[string]string{v1.ClusterIdLabel: "cluster1"}},
+		Spec:       v1.NodeSpec{Workspace: pointer.String("ws1")},
+		Status:     v1.NodeStatus{ClusterStatus: v1.NodeClusterStatus{Phase: v1.NodeManagedFailed}},
+	}
+	vr := &WorkspaceValidator{Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(bound).Build()}
+	wsr := &v1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "ws1"}, Spec: v1.WorkspaceSpec{Cluster: "cluster1"}}
+	v1.SetAnnotation(wsr, v1.WorkspaceNodesAction, `{"n2":"remove"}`)
+	assert.NilError(t, vr.validateNodesAction(context.Background(), wsr, &v1.Workspace{}))
 }
 
 // TestWorkspaceMutateNodesActionErrors covers node action mutation error branches.


### PR DESCRIPTION
## Problem

A node could be bound to two workspaces at once, and the workspace that lost the race was left wedged for the lifetime of the process — no scaling, no nodes actions, no status sync — until the leader was restarted.

Observed in the field: `crsuse2-m2m-237` was bound to `control-plane-hyperloom`, then taken over by `control-plane-spur-quarantine` a few hundred milliseconds later. `hyperloom` never reconciled again, and a later request to bind `crsuse2-m2m-172` to it sat unprocessed.

Two independent defects combine to produce that:

1. **The binding patch carries no precondition.** `client.MergeFrom` produces a JSON merge patch with no resourceVersion, so two binders that each read the same free node from their caches both succeed and the last writer wins. No error, no conflict, no signal.

2. **Expectations are credited by the wrong key.** A workspace registers an expectation on every node it is binding and refuses to reconcile until each one is observed. The observation was credited by the workspace id the node event carried, so once a node changed hands the workspace actually waiting on it was never credited. Its expectation stayed in the map and `processWorkspace` returned at the `meetExpectations` gate on every subsequent reconcile.

## Changes

**Refuse the second binder** — `updateSingleNodeBinding` rejects a bind whose target node is already owned by another workspace (it has to be unbound there first), and patches through `client.MergeFromWithOptimisticLock` so a concurrent binder that got there first produces a conflict instead of a silent overwrite. The nodes-action path drops such a request rather than retrying a binding that must not happen, so the annotation clears.

**Release the expectation by node, not by owner** — `observeNodeForAll` settles a node against every workspace waiting on it and re-queues each one so it can pick a different node. Both the refusal and the conflict path already run through `observeNode` in `updateNodesBinding`, so a failed bind no longer leaves a dangling expectation. No TTL and no `RequeueAfter` are involved.

**Let explicit bindings win over automatic scaling** — scale-up skips nodes another workspace is already processing, whether the binding is in flight or still sitting in an unprocessed nodes action.

**Do not accept a binding that can never settle** — a binding is only settled once the workspace label has made the round trip through the data plane. `updateK8sNode` returns early when the k8s Node is missing, so binding a node that has left the cluster would wait on a label that never arrives. The add path now checks the node is still there and drops the request otherwise. A data plane that fails to answer counts as present, since refusing here is permanent. Only the add path needs this — when a k8s Node disappears, `handleNodeUnmanaged` clears its admin labels and settles any unbind on its own.

**Stop the data plane from writing ownership** — the reverse metadata sync copied the workspace label off the k8s Node unconditionally, making the data plane a third writer of an ownership the admin plane is supposed to decide. A value that disagrees with `spec.workspace` is stale or was edited by hand, and copying it back makes the admin plane report an ownership nobody asked for — to every label selector, and to the ops-job webhook that validates node membership by it. Those values are now ignored and `NodeReconciler` pushes the right one back down. Unbinding is unaffected: the label still goes away through the removal branch once the data plane has dropped it.

## Behaviour change

Binding can now fail where it previously always "succeeded". This only happens in the contention case that used to corrupt ownership silently:

- ownership pre-check → `(false, nil)`, not an error: a warning, a `bind/conflict` metric, and the request is dropped.
- optimistic-lock conflict → error, propagated to `Reconcile` for the standard rate-limited requeue, re-evaluated against fresh state.

Uncontended binds are unchanged.

## Tests

12 new cases in `workspace_node_ownership_test.go`, including a regression for the exact `crsuse2-m2m-237` sequence and for a stale write being rejected by the optimistic lock. `TestWorkspaceNodesAction` and `TestSyncK8sMetadata` were adjusted for the new signature and still pass.

`go build ./resource-manager/...` is clean; `go vet` shows only the pre-existing `addon_helper.go:84` warning. Five failures remain in `resource-manager/pkg/resource` (`TestGuaranteeCICDClusterRoleBindingFull`, `TestGuaranteeForwardIngressFull`, `TestConstructDownloadJobFull`, `TestConstructCleanupJobFull`, `TestConstructLocalDownloadOpsJob`) — reproduced identically on a clean tree via `git stash -u`, unrelated to this change.

## Not included

Tightening `node_webhook.validateImmutableFields` to reject an `"" → X` ownership jump. With the reverse sync no longer writing ownership it is largely a redundant second line of defence; worth revisiting after this has run for a while.

🤖 Generated with [Claude Code](https://claude.com/claude-code)