### PR TITLE
fix(resource-manager): arm the requeue that reads an expectation's deadline

### DIFF
--- a/SaFE/resource-manager/pkg/metrics/metrics.go
+++ b/SaFE/resource-manager/pkg/metrics/metrics.go
@@ -145,6 +145,22 @@ var (
 		Help: "Total workspace node bind/unbind operations, by action and result.",
 	}, []string{"action", "result"})
 
+	// WorkspaceExpectationExpiredTotal counts node expectations abandoned because the label
+	// round trip never completed.
+	//
+	// This is the alert signal for the failure the deadline bounds. A non-zero rate means node
+	// bindings are being written whose label never makes it back to the admin plane, and each
+	// one cost the workspace a stalled reconcile until a prune cleared it. Counted per node,
+	// because that is the granularity a deadline is kept and dropped at.
+	//
+	// Unlabelled on purpose: the workspace and node names are in the warning log this is
+	// incremented next to, and workspaces come and go, so a label here would be unbounded
+	// cardinality for something already recorded elsewhere.
+	WorkspaceExpectationExpiredTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "safe_workspace_expectation_expired_total",
+		Help: "Total workspace node expectations abandoned after the label round trip timed out.",
+	})
+
 	// --- github workflow sync ---
 
 	// GithubSyncBacklog reports the number of unsynced GitHub workflow runs picked
@@ -183,6 +199,7 @@ func init() {
 		OpsJobTimeoutTotal,
 		WorkspacePhaseTotal,
 		WorkspaceNodeBindingTotal,
+		WorkspaceExpectationExpiredTotal,
 		GithubSyncBacklog,
 		GithubSyncTotal,
 	)

--- a/SaFE/resource-manager/pkg/resource/register.go
+++ b/SaFE/resource-manager/pkg/resource/register.go
@@ -18,8 +18,7 @@ import (
 
 var (
 	defaultWorkspaceOption = WorkspaceReconcilerOption{
-		processWait: 1 * time.Second,
-		nodeWait:    30 * time.Second,
+		nodeWait: 30 * time.Second,
 		// Long enough that a target busy with another node action, or a resource-manager
 		// restart, does not cut a migration short; short enough that a node released for a
 		// migration nobody can complete comes back into service the same day.

--- a/SaFE/resource-manager/pkg/resource/workspace_controller.go
+++ b/SaFE/resource-manager/pkg/resource/workspace_controller.go
@@ -532,8 +532,19 @@ func (r *WorkspaceReconciler) pruneExpectations(workspaceId string) {
 		if now.Before(deadline) {
 			continue
 		}
-		klog.Infof("workspace(%s) stopped waiting on node(%s) after %s",
-			workspaceId, nodeName, expectationTimeout.String())
+		// The elapsed wait, not the configured timeout. A deadline is only read when a
+		// reconcile reaches this function, so the wait can run past expectationTimeout by
+		// however long it took one to arrive -- and how far past is the interesting part of
+		// the report.
+		//
+		// Warning rather than Info, and counted: this is the branch that says a binding was
+		// written whose label never came back, which is a data plane fault the workspace has
+		// just stopped waiting on. Nothing else records it -- the annotation was cleared on
+		// the pass after the bind, so the request leaves no trace of having been given up on.
+		klog.Warningf("workspace(%s) stopped waiting on node(%s) after %s: the label round "+
+			"trip never completed for it; recounting from the claims instead",
+			workspaceId, nodeName, (expectationTimeout + now.Sub(deadline)).Truncate(time.Second))
+		rmmetrics.WorkspaceExpectationExpiredTotal.Inc()
 		delete(left.deadlines, nodeName)
 	}
 	if len(left.deadlines) == 0 {
@@ -665,9 +676,85 @@ func (r *WorkspaceReconciler) recordf(workspace *v1.Workspace, eventType, reason
 	r.recorder.Eventf(workspace, eventType, reason, format, args...)
 }
 
+// defaultExpectationRetry is the fallback for expectationRetry.
+const defaultExpectationRetry = 30 * time.Second
+
+// expectationRetry is how long to wait before returning to a workspace whose expectations are
+// still outstanding.
+//
+// It reads the same option the gate requeues on, and has a fallback of its own because a zero
+// here is not a harmless default: a RequeueAfter of zero is no requeue at all, which is the
+// exact behaviour this change exists to remove. A guard that disarms itself under a zero
+// option is not a guard.
+//
+// The zero only. option itself is never nil -- SetupWorkspaceController is the one production
+// construction and passes &defaultWorkspaceOption -- and the other readers of nodeWait do not
+// check, so checking here would say the field is sometimes absent and send the next reader
+// looking for the path where it is.
+func (r *WorkspaceReconciler) expectationRetry() time.Duration {
+	if r.option.nodeWait > 0 {
+		return r.option.nodeWait
+	}
+	return defaultExpectationRetry
+}
+
 // processWorkspace handles the main processing logic for a Workspace resource
 // include scaling up and scaling down nodes.
+//
+// The body is reconcileWorkspace; this wrapper exists to arm the requeue on every exit from
+// it. setExpectations is reached only from updateNodesBinding, which is reached only from
+// inside reconcileWorkspace -- and from delete, which removes expectations rather than
+// leaving them -- so this is the one boundary every new expectation crosses.
 func (r *WorkspaceReconciler) processWorkspace(ctx context.Context, workspace *v1.Workspace) (ctrlruntime.Result, error) {
+	result, err := r.reconcileWorkspace(ctx, workspace)
+	if err != nil {
+		// The work queue requeues an error with backoff and ignores RequeueAfter alongside
+		// one, so there is nothing to arm: the workspace is already coming back.
+		return result, err
+	}
+	return r.armExpectations(workspace.Name, result), nil
+}
+
+// armExpectations makes a reconcile that leaves expectations outstanding schedule its own way
+// back to the gate that can expire them.
+//
+// A deadline is only read by pruneExpectations and meetExpectations, and both are reached only
+// from reconcileWorkspace. So a deadline is worth nothing unless a later reconcile is
+// guaranteed to happen -- and after the pass that *creates* an expectation, none is. scaleUp
+// returns an empty Result once the bind succeeds; so does scaleDown when it found every node
+// it asked for; and processNodesAction returns before the gate on exactly the passes where it
+// applied something. The write updateSingleNodeBinding just made does not bring the workspace
+// back either: handleNodeEvent's UpdateFunc does not enqueue on a claim being written -- the
+// label is unchanged, which is the thing being waited for -- and isRelevantFieldChanged does
+// not look at Spec.Workspace. Nothing else does: the Workspace predicates reject a
+// generation-equal resync, and the manager sets no SyncPeriod.
+//
+// So the requeue has to be armed on the way out, not only on the way in. Without it the
+// deadline repairs the second and later visits to the gate but not the first, which is the
+// only visit the failure it exists for actually gets.
+func (r *WorkspaceReconciler) armExpectations(workspaceId string, result ctrlruntime.Result) ctrlruntime.Result {
+	if !result.IsZero() || r.meetExpectations(workspaceId) {
+		// Already coming back, or nothing is outstanding.
+		//
+		// Sooner than a deadline could ask for, too: the longest requeue reconcileWorkspace
+		// produces is option.nodeWait, well inside expectationTimeout. Deliberately said of
+		// reconcileWorkspace and not of the controller -- keepAlive's resyncPeriod is three
+		// times expectationTimeout, and it is applied to this function's *result*, above in
+		// Reconcile, never to its argument. Wiring a new exit through keepAlive first would
+		// hand this one a wait longer than the deadline it is arming for.
+		//
+		// IsZero rather than RequeueAfter == 0, because Result also carries the deprecated
+		// Requeue bool, which means "come back now, rate limited". Reading only RequeueAfter
+		// would take that for "asked for nothing" and quietly turn it into a wait.
+		return result
+	}
+	result.RequeueAfter = r.expectationRetry()
+	return result
+}
+
+// reconcileWorkspace is processWorkspace's body. Call processWorkspace, not this: a bind made
+// here leaves an expectation that only the wrapper schedules the way back to.
+func (r *WorkspaceReconciler) reconcileWorkspace(ctx context.Context, workspace *v1.Workspace) (ctrlruntime.Result, error) {
 	k8sClients, err := utils.GetK8sClientFactory(r.clientManager, workspace.Spec.Cluster)
 	if err != nil || !k8sClients.IsValid() {
 		return ctrlruntime.Result{RequeueAfter: time.Second}, nil
@@ -695,7 +782,7 @@ func (r *WorkspaceReconciler) processWorkspace(ctx context.Context, workspace *v
 		// Same reason: the event that settles this may never come, and the deadline that ends
 		// the wait is only read when something asks.
 		if actionResult.RequeueAfter == 0 {
-			actionResult.RequeueAfter = r.option.nodeWait
+			actionResult.RequeueAfter = r.expectationRetry()
 		}
 		return actionResult, nil
 	}

--- a/SaFE/resource-manager/pkg/resource/workspace_controller.go
+++ b/SaFE/resource-manager/pkg/resource/workspace_controller.go
@@ -70,8 +70,7 @@ type WorkspaceReconciler struct {
 }
 
 type WorkspaceReconcilerOption struct {
-	processWait time.Duration
-	nodeWait    time.Duration
+	nodeWait time.Duration
 	// migrateTimeout bounds how long a node may sit released for a migration that never
 	// completes. Past it the reservation is dropped and the node becomes an ordinary
 	// unassigned node. It is not handed back to the source, but the source's replica is:
@@ -323,24 +322,72 @@ func (r *WorkspaceReconciler) deleteDataPlaneResources(ctx context.Context, work
 	return nil
 }
 
+// resyncPeriod is the longest a live Workspace goes without being reconciled.
+//
+// Nothing else guarantees one. The predicates on this controller admit a nodes-action
+// appearing, a deletion timestamp appearing, and a generation change; the cache's own resync
+// produces a generation-equal Update that both of them reject, and the Workspace CRD has a
+// status subresource, so this controller's own status writes do not bump the generation
+// either. The manager sets no SyncPeriod. So every path out of Reconcile that leaves the
+// workspace alive and asks for nothing is a path where the next reconcile depends entirely on
+// somebody else's event -- and the failure this file exists to bound is exactly the one where
+// that event never comes.
+//
+// armExpectations is the tight bound for the case we can name: a bind whose label round trip
+// is outstanding, brought back in 30s so the deadline gets read. This is the loose bound for
+// the cases we cannot -- it costs one reconcile per workspace per quarter hour and removes
+// "wedged until the process restarts" as an outcome any single missed event can produce.
+const resyncPeriod = 15 * time.Minute
+
+// keepAlive gives a Workspace that asked for nothing a way back anyway.
+//
+// Applied to every exit from Reconcile that leaves a live Workspace behind, rather than to the
+// one that happened to be under the cursor. Two of them -- an absent Cluster object and a
+// workspace naming no cluster -- return before processWorkspace is called at all, and nothing
+// else brings a Workspace back: the controller does not watch Cluster, and setting the field
+// is the only other door in.
+//
+// What this does NOT do is expire anything. pruneExpectations is inside processWorkspace, so
+// an expectation held by a workspace parked on one of those two exits is not dropped there and
+// is not counted. That costs nothing: both exits mean there is no data plane to reach, and
+// scaling, status and the node action all need one, so an open gate would have nothing to open
+// onto. What the requeue buys is the pass after the Cluster returns -- which does reach
+// pruneExpectations -- happening within a quarter hour rather than never.
+//
+// Only fills a gap: any answer the caller already gave is kept, including the deprecated
+// Requeue bool, which is why this tests IsZero rather than RequeueAfter alone. Reading only
+// RequeueAfter would take "come back now, rate limited" for "asked for nothing".
+func keepAlive(result ctrlruntime.Result) ctrlruntime.Result {
+	if result.IsZero() {
+		result.RequeueAfter = resyncPeriod
+	}
+	return result
+}
+
 // Reconcile is the main control loop for Workspace resources.
 func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrlruntime.Request) (ctrlruntime.Result, error) {
 	workspace := new(v1.Workspace)
 	if err := r.Get(ctx, req.NamespacedName, workspace); err != nil {
+		// Nothing to keep alive: the object is gone, or the work queue is retrying the error.
 		return ctrlruntime.Result{}, client.IgnoreNotFound(err)
 	}
 	if !workspace.GetDeletionTimestamp().IsZero() {
+		// Nor here: delete ends by removing the finalizer, so a successful pass is the last
+		// one, and a failed one comes back through the work queue.
 		return ctrlruntime.Result{}, r.delete(ctx, workspace)
 	}
 	clientSet, err := r.getClientSetOfDataplane(ctx, workspace.Spec.Cluster)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return ctrlruntime.Result{}, nil
+			// The Cluster object is not there. Not watched, so nothing reports its return.
+			return keepAlive(ctrlruntime.Result{}), nil
 		}
 		return ctrlruntime.Result{RequeueAfter: time.Second}, nil
 	}
 	if clientSet == nil {
-		return ctrlruntime.Result{}, nil
+		// No cluster named yet. Setting one bumps the generation and enqueues on its own, but
+		// that is the only door in, and this workspace can be carrying expectations already.
+		return keepAlive(ctrlruntime.Result{}), nil
 	}
 	if err = r.guaranteeDataPlaneResources(ctx, workspace, clientSet); err != nil {
 		return ctrlruntime.Result{}, err
@@ -348,8 +395,9 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrlruntime.Req
 	result, err := r.processWorkspace(ctx, workspace)
 	if err != nil {
 		klog.ErrorS(err, "failed to process workspace", "name", workspace.Name)
+		return result, err
 	}
-	return result, err
+	return keepAlive(result), nil
 }
 
 // delete handles the deletion of a Workspace resource by unbinding nodes and removing finalizers.

--- a/SaFE/resource-manager/pkg/resource/workspace_controller_test.go
+++ b/SaFE/resource-manager/pkg/resource/workspace_controller_test.go
@@ -196,8 +196,12 @@ func TestReconcile(t *testing.T) {
 	req := ctrlruntime.Request{
 		NamespacedName: types.NamespacedName{Name: workspace.Name},
 	}
-	_, err := r.Reconcile(context.Background(), req)
+	res, err := r.Reconcile(context.Background(), req)
 	assert.NilError(t, err)
+	// Steady state -- 2 held against a spec of 2 -- so nothing below asked to come back, and
+	// this is the safety net doing it anyway. Without it a Workspace that reaches its target
+	// is never reconciled again until somebody else's event arrives.
+	assert.Equal(t, ctrlruntime.Result{RequeueAfter: resyncPeriod}, res)
 	err = adminClient.Get(context.Background(), client.ObjectKey{Name: workspace.Name}, workspace)
 	assert.NilError(t, err)
 	assert.Equal(t, workspace.Status.AvailableReplica, 1)
@@ -1135,10 +1139,43 @@ func TestWorkspaceReconcileNoCluster(t *testing.T) {
 	cl := fake.NewClientBuilder().WithScheme(scheme.Scheme).
 		WithStatusSubresource(&v1.Workspace{}).WithObjects(ws).Build()
 	r := newMockWorkspaceReconciler(cl)
-	// No cluster -> clientSet nil -> nil result.
+	// No cluster -> clientSet nil -> the exit that returns before processWorkspace, so neither
+	// pruneExpectations nor armExpectations is reached on it. Setting spec.cluster bumps the
+	// generation and enqueues on its own, but that is the only other door in.
 	res, err := r.Reconcile(context.Background(), ctrlruntime.Request{NamespacedName: types.NamespacedName{Name: "ws1"}})
 	testifyassert.NoError(t, err)
-	assert.Equal(t, ctrlruntime.Result{}, res)
+	assert.Equal(t, ctrlruntime.Result{RequeueAfter: resyncPeriod}, res)
+}
+
+// The same door, reached the other way, and the one that can strand an outstanding
+// expectation: a Workspace naming a Cluster object that is not there. This controller does not
+// watch Cluster, so nothing reports the Cluster coming back -- and the return is above
+// processWorkspace, so the deadline on the expectation is never read. That is the reported
+// wedge again with a different first step.
+func TestWorkspaceReconcileComesBackWhenItsClusterIsGone(t *testing.T) {
+	ws := &v1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "ws1"}, Spec: v1.WorkspaceSpec{Cluster: "vanished"}}
+	cl := fake.NewClientBuilder().WithScheme(scheme.Scheme).
+		WithStatusSubresource(&v1.Workspace{}).WithObjects(ws).Build()
+	r := newMockWorkspaceReconciler(cl)
+	r.setExpectations("ws1", sets.NewSetByKeys("n1"))
+
+	res, err := r.Reconcile(context.Background(), ctrlruntime.Request{NamespacedName: types.NamespacedName{Name: "ws1"}})
+	testifyassert.NoError(t, err)
+	assert.Equal(t, ctrlruntime.Result{RequeueAfter: resyncPeriod}, res)
+	// Not settled and not expired: this exit is above pruneExpectations, so the entry is still
+	// there. That is the point -- what is asserted is coming back at all, which is what lets
+	// the pass after the Cluster returns be the one that expires it.
+}
+
+// Only a gap-filler. A caller that already asked to come back sooner keeps its own answer --
+// armExpectations' 30s for an outstanding bind must not be stretched to a quarter hour.
+func TestKeepAliveKeepsASoonerRequeue(t *testing.T) {
+	assert.Equal(t, ctrlruntime.Result{RequeueAfter: 30 * time.Second},
+		keepAlive(ctrlruntime.Result{RequeueAfter: 30 * time.Second}))
+	// An immediate rate-limited retry is an answer too. Read as RequeueAfter alone it looks
+	// like no answer at all, and becomes a quarter-hour wait.
+	assert.Equal(t, ctrlruntime.Result{Requeue: true}, keepAlive(ctrlruntime.Result{Requeue: true}))
+	assert.Equal(t, ctrlruntime.Result{RequeueAfter: resyncPeriod}, keepAlive(ctrlruntime.Result{}))
 }
 
 func TestWorkspaceDelete(t *testing.T) {

--- a/SaFE/resource-manager/pkg/resource/workspace_node_owner_test.go
+++ b/SaFE/resource-manager/pkg/resource/workspace_node_owner_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 
@@ -18,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/pointer"
+	ctrlruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -762,7 +764,7 @@ func TestGetNodesForScalingUpStopsWhenTheClaimsCannotBeRead(t *testing.T) {
 	nodeFlavor := genMockNodeFlavor()
 	free := genMockAdminNode("node1", "cluster", nodeFlavor)
 	workspace := genMockWorkspace("cluster", nodeFlavor.Name, 1)
-	cli := fake.NewClientBuilder().WithObjects(free, workspace).WithScheme(scheme.Scheme).
+	cli := fake.NewClientBuilder().WithObjects(free, workspace, nodeFlavor).WithScheme(scheme.Scheme).
 		WithInterceptorFuncs(interceptor.Funcs{
 			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList,
 				opts ...client.ListOption) error {
@@ -929,4 +931,90 @@ func TestSyncWorkspaceCountsTheClaimNotTheLabel(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, len(idle), stored.CurrentReplica())
 	assert.Equal(t, idle[0].Name, "held")
+}
+
+// The pass that arms an expectation is the only one that can schedule the visit which reads
+// its deadline, and until this it did not: scaleUp returns an empty Result once the bind
+// succeeds, the claim it wrote re-enqueues nothing -- handleNodeEvent wants the label, which
+// is the thing being waited for -- the Workspace predicates reject a generation-equal resync,
+// and the manager sets no SyncPeriod. So the deadline repaired the second and later visits to
+// the gate and not the first, which is the only visit a lost label round trip ever gets.
+//
+// Driven through a real scaleUp rather than a hand-installed entry: the wedge is a property of
+// the pass that creates an expectation, and an entry put there by the test proves nothing
+// about it. The bind assertions are what keep this honest -- with no node taken, scaleUp
+// requeues on its own at :772 and the requeue below would be true for the wrong reason.
+func TestProcessWorkspaceArmsTheDeadlineItJustCreated(t *testing.T) {
+	nodeFlavor := genMockNodeFlavor()
+	free := genMockAdminNode("node1", "cluster", nodeFlavor)
+	free.Status.ClusterStatus.Phase = v1.NodeManaged
+	workspace := genMockWorkspace("cluster", nodeFlavor.Name, 1)
+	cli := fake.NewClientBuilder().WithObjects(free, workspace, nodeFlavor).
+		WithStatusSubresource(workspace).WithScheme(scheme.Scheme).Build()
+	r := newMockWorkspaceReconciler(cli)
+	r.clientManager.AddOrReplace("cluster", commonclient.NewClientFactoryWithOnlyClient(
+		context.Background(), "cluster", k8sfake.NewClientset(
+			genMockK8sNode(free.Name, "cluster", nodeFlavor.Name, ""))))
+
+	result, err := r.processWorkspace(context.Background(), workspace)
+	assert.NilError(t, err)
+
+	// A node was actually taken, and its label has not made the round trip yet.
+	assert.Equal(t, storedNode(t, cli, free.Name).GetSpecWorkspace(), workspace.Name)
+	assert.Equal(t, r.meetExpectations(workspace.Name), false,
+		"the bind left nothing outstanding, so this says nothing about arming one")
+	// And the pass that created it left something to bring the workspace back.
+	assert.Equal(t, result.RequeueAfter, r.option.nodeWait,
+		"the reconcile that armed the expectation scheduled no way back to the gate")
+}
+
+// armExpectations only fills a gap. A reconcile already coming back keeps the time it asked
+// for -- every requeue in this controller is shorter than expectationTimeout -- and a
+// workspace waiting on nothing is not given a wake-up it has no use for.
+func TestArmExpectationsOnlyFillsTheGap(t *testing.T) {
+	r := newMockWorkspaceReconciler(fake.NewClientBuilder().WithScheme(scheme.Scheme).Build())
+
+	// Whole-value, not just RequeueAfter: Requeue is the field a caller could be using to ask
+	// for an immediate rate-limited retry, and it is the one this must not trample.
+	assert.Equal(t, ctrlruntime.Result{}, r.armExpectations("ws-a", ctrlruntime.Result{}),
+		"nothing outstanding, so nothing to come back for")
+
+	r.setExpectations("ws-a", sets.NewSetByKeys("n1"))
+	assert.Equal(t, ctrlruntime.Result{RequeueAfter: time.Second},
+		r.armExpectations("ws-a", ctrlruntime.Result{RequeueAfter: time.Second}),
+		"a sooner requeue was already asked for")
+	assert.Equal(t, ctrlruntime.Result{Requeue: true},
+		r.armExpectations("ws-a", ctrlruntime.Result{Requeue: true}),
+		"an immediate retry is an answer too, and must not become a wait")
+	assert.Equal(t, ctrlruntime.Result{RequeueAfter: r.option.nodeWait},
+		r.armExpectations("ws-a", ctrlruntime.Result{}))
+}
+
+// A RequeueAfter of zero is not a short wait, it is no requeue at all -- the exact behaviour
+// the arming exists to remove. newWorkspaceReconcilerFull builds its option with a zero
+// nodeWait, and a guard that disarms itself under a zero option is not a guard.
+func TestExpectationRetryNeverCollapsesToZero(t *testing.T) {
+	r := newWorkspaceReconcilerFull(t, k8sfake.NewClientset())
+	assert.Equal(t, r.option.nodeWait, time.Duration(0), "this fixture is why the fallback exists")
+
+	r.setExpectations("ws-a", sets.NewSetByKeys("n1"))
+	assert.Equal(t, r.armExpectations("ws-a", ctrlruntime.Result{}).RequeueAfter, defaultExpectationRetry)
+}
+
+// Abandoning a wait is a data plane fault the workspace has just stopped reporting: the
+// annotation was cleared on the pass after the bind, so nothing on the object records that the
+// binding was given up on. The counter is the only thing left to alert on, and it is counted
+// per node because that is the granularity a deadline is kept and dropped at.
+func TestAbandonedExpectationIsCounted(t *testing.T) {
+	r := newMockWorkspaceReconciler(fake.NewClientBuilder().WithScheme(scheme.Scheme).Build())
+	before := testutil.ToFloat64(rmmetrics.WorkspaceExpectationExpiredTotal)
+
+	r.setExpectations("ws-a", sets.NewSetByKeys("n1", "n2", "n3"))
+	expire(&r, "ws-a", "n1")
+	expire(&r, "ws-a", "n2")
+	r.pruneExpectations("ws-a")
+
+	assert.Equal(t, testutil.ToFloat64(rmmetrics.WorkspaceExpectationExpiredTotal)-before, float64(2),
+		"abandonment is counted per node, as it is pruned per node")
+	assert.Equal(t, r.meetExpectations("ws-a"), false, "n3 was still worth waiting on")
 }


### PR DESCRIPTION
fix(resource-manager): arm the requeue that reads an expectation's deadline

A Workspace waits on an in-memory expectation while a node binding's label makes
the round trip through the data plane, and #724 gave each of those entries a
deadline so the wait cannot run forever. But a deadline is only read when
something calls pruneExpectations or meetExpectations, and both are reached only
from inside processWorkspace -- so it is worth nothing unless a later reconcile
is guaranteed to happen, and after the pass that *creates* the expectation, none
is.

scaleUp returns an empty Result once the bind succeeds; so does scaleDown when it
found every node it asked for; and processNodesAction returns before the gate on
exactly the passes where it applied something. The write updateSingleNodeBinding
just made does not bring the workspace back either: handleNodeEvent's UpdateFunc
does not enqueue on a claim being written -- the label is unchanged, which is the
thing being waited for -- and isRelevantFieldChanged does not look at
Spec.Workspace. Nothing else does: the Workspace predicates reject a
generation-equal resync, and the manager sets no SyncPeriod.

So the deadline repairs the second and later visits to the gate, and not the
first, which is the only visit a lost label round trip ever gets. A settle event
that never arrives still parks the workspace until the process restarts. It
arrives less often than it used to, but the paths left are real and unhealed: a
data plane label overwritten with a third value produces no settle event at all,
because syncK8sMetadata skips a label that disagrees with the claim; neither does
an admin Node that stops reconciling, or one deleted without the event reaching
this process.

So: arm the requeue on the way out. processWorkspace becomes a thin wrapper over
reconcileWorkspace that, on every non-error exit, gives a workspace with
expectations still outstanding a way back to the gate. Every exit rather than the
one that happened to be edited -- there are four, and the two early returns are
the ones a guard written inside the body would miss. An error is left alone: the
work queue requeues it with backoff and ignores RequeueAfter alongside one.

The retry reads option.nodeWait, the same value the gate already requeues on, but
through a helper with a fallback of its own, because a zero there is not a short
wait but no wait at all -- which is the exact behaviour this removes.

Abandonment was also silent. It is a data plane fault the workspace has just
stopped waiting on, and nothing on the object records it: the nodes-action
annotation was cleared on the pass right after the bind, so the request leaves no
trace of having been given up on. Raise the log to a warning naming the elapsed
wait rather than the configured timeout -- the deadline is only read when a
reconcile reaches the prune, so the wait can run past it by however long that
took -- and count it in safe_workspace_expectation_expired_total. A non-zero rate
means bindings are being written whose label never comes back. Counted per node,
because that is the granularity a deadline is kept and dropped at.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

