### PR TITLE
fix(ceph): give the RBD node plugin tolerations so it covers tainted nodes

### DIFF
--- a/Bootstrap/storage/ceph/README.md
+++ b/Bootstrap/storage/ceph/README.md
@@ -3,3 +3,30 @@
 Before applying `storageclass.yaml`, replace the `storage-rbd` Secret placeholders with a dedicated Ceph user and key.
 
 Do not deploy the manifest with `<ceph-user-id>` or `<ceph-user-key>` unchanged. The RBD CSI driver requires valid credentials for provisioning, expanding, and staging volumes.
+
+## Node plugin tolerations
+
+`ceph.sh` installs the RBD driver with `ceph-csi-rbd-values.yaml`, whose only
+job is to give the node plugin `tolerations: [{operator: Exists}]`. The upstream
+chart ships none, so on a cluster that taints nodes the DaemonSet silently
+covers only the untainted ones and any node that loses its plugin pod can never
+run an RBD-backed workload again. The values file explains the failure in full.
+
+An existing install predates this and will not pick the file up on its own:
+
+```sh
+helm upgrade --namespace ceph-csi-rbd ceph-csi-rbd ceph-csi/ceph-csi-rbd \
+  -f ceph-csi-rbd-values.yaml --reuse-values
+```
+
+Then check that the DaemonSet's `DESIRED` equals the node count — that number
+falling short is the symptom, and nothing else alerts on it:
+
+```sh
+kubectl get nodes --no-headers | wc -l
+kubectl -n ceph-csi-rbd get ds ceph-csi-rbd-nodeplugin
+```
+
+The rollout that follows is serial (`maxUnavailable: 1`) and stalls while any
+node is unreachable, which is harmless: pods already running keep the old spec
+and work fine, and pods created from then on carry the tolerations.

--- a/Bootstrap/storage/ceph/ceph-csi-rbd-values.yaml
+++ b/Bootstrap/storage/ceph/ceph-csi-rbd-values.yaml
@@ -1,0 +1,33 @@
+# Values for the ceph-csi-rbd chart (installed by ceph.sh).
+#
+# The node plugin is a DaemonSet, and the upstream chart ships it with no
+# tolerations at all. That is wrong for any cluster that taints nodes, and this
+# one taints most of them: `hyperloom.amd.com/spur-hold=absent:NoSchedule` sits
+# on the nodes spur has not pinned, which was 155 of 191 when this was written.
+#
+# NoSchedule does not evict, so the fleet looks healthy -- plugin pods placed
+# before a node was tainted keep running. The damage only shows when a node
+# loses its pod (reboot, eviction, a DaemonSet rollout): it can never get one
+# back. kubelet then has no registered CSI driver, and every pod that lands
+# there with an RBD volume hangs in ContainerCreating on
+#
+#   MountVolume.MountDevice failed ... driver name rbd.csi.ceph.com not found
+#   in the list of registered CSI drivers
+#
+# which reads like the node is missing the driver rather than the plugin being
+# unschedulable. It is also slow to notice: the node's CSINode object still
+# lists the driver from its previous registration, so the driver looks present
+# in the API while kubelet's in-memory registry has nothing. One NATS replica
+# sat unmountable this way for 15 days before anyone traced it back here.
+#
+# `operator: Exists` with no key tolerates everything, which is what a storage
+# driver wants: it has to be available wherever a workload can be scheduled, so
+# it should never be the reason a pod cannot start. The same argument applies
+# to the CNI and node-level monitoring.
+#
+# The signal to watch for is the DaemonSet's own DESIRED count. It was 36
+# against a 191-node cluster -- the driver was simply absent from 155 nodes,
+# and nothing alerted.
+nodeplugin:
+  tolerations:
+    - operator: Exists

--- a/Bootstrap/storage/ceph/ceph.sh
+++ b/Bootstrap/storage/ceph/ceph.sh
@@ -30,7 +30,10 @@ CLUSTERID=$(kubectl get cephcluster -n rook-ceph rook-ceph  -o jsonpath='{.statu
 # Add the Ceph CSI Helm repository
 helm repo add ceph-csi https://ceph.github.io/csi-charts
 # Install the Ceph CSI RBD driver in its own namespace
-helm install --namespace "ceph-csi-rbd" "ceph-csi-rbd" ceph-csi/ceph-csi-rbd --create-namespace
+# -f is not optional: the chart's default node plugin has no tolerations and so
+# skips every tainted node. See the comment in the values file.
+helm install --namespace "ceph-csi-rbd" "ceph-csi-rbd" ceph-csi/ceph-csi-rbd --create-namespace \
+  -f ceph-csi-rbd-values.yaml
 # Export the Ceph CSI configmap to a local file
 kubectl get cm -n ceph-csi-rbd ceph-csi-config -o yaml > ceph-csi-config.yaml
 # Check if the cluster ID is already present in the config


### PR DESCRIPTION
## Problem

The `ceph-csi-rbd` chart ships its node plugin DaemonSet with no tolerations, and `ceph.sh` installed it with no values file at all. This cluster taints most of its nodes — `hyperloom.amd.com/spur-hold=absent:NoSchedule` was on **155 of 191** — so the DaemonSet's `DESIRED` was **36** and the driver was simply absent from the rest.

`NoSchedule` does not evict, so the fleet looks healthy: plugin pods placed before a node was tainted keep running. The damage only shows when a node *loses* its pod (reboot, eviction, a rollout) — it can then never get one back. Every pod scheduled there with an RBD volume hangs in `ContainerCreating` on

```
MountVolume.MountDevice failed ... driver name rbd.csi.ceph.com not found
in the list of registered CSI drivers
```

which reads as a missing driver rather than an unschedulable plugin. It is also slow to notice: the node's `CSINode` object still advertises the driver from its last registration, so it looks present in the API while kubelet's in-memory registry has nothing.

`primus-claw-nats-1` sat unmountable this way for **15 days**, which is what surfaced the bug — it was misdiagnosed as the node needing the Ceph RBD driver installed.

## Change

- New `Bootstrap/storage/ceph/ceph-csi-rbd-values.yaml` setting `nodeplugin.tolerations: [{operator: Exists}]`, with the full failure chain in comments.
- `ceph.sh` passes it with `-f`.
- README covers applying it to an existing install and the `DESIRED`-vs-node-count check.

`operator: Exists` is the right setting for a storage driver: it has to be available wherever a workload can land, so it must never itself be the reason a pod cannot start. The same argument applies to the CNI and node-level monitoring.

## Verification

Applied to the live cluster ahead of this PR.

`kubectl patch` of the DaemonSet took `DESIRED` from **36 → 191**; the previously stranded node got a running node plugin within 60s, and the 15-day-stuck PVC mounted on its own — no pod deletion needed.

The Helm release was then brought in line with this values file at the pinned chart version:

```
Release   REVISION 2   chart ceph-csi-rbd-3.17.0   STATUS deployed
DaemonSet tolerations  [{"operator":"Exists"}]
nodeplugin             191/191 Running, no pod created or restarted by the upgrade
provisioner            3/3, no rollout
```

Zero disruption: the cluster uses **krbd**, not `rbd-nbd` (no `mounter` parameter on the StorageClass, `imageFeatures: layering`, `/dev/rbd0` mapped by the kernel, no `rbd-nbd` processes, zero nbd-backed mounts). The `csi-rbdplugin` userspace process is not in the I/O path, so already-mounted volumes are unaffected by a plugin restart; only in-flight stage/unstage calls would see a retry.

## Note for whoever runs the upgrade

Two things bit during the live rollout and are worth knowing:

1. **Pin `--version`.** The repo already serves 3.17.1; an unpinned `helm upgrade` swaps images too, which is a much bigger change than tolerations.
2. **`ceph-csi-config` will be clobbered without care.** The chart renders `config.json: "[]"`, but `ceph.sh` patches the real clusterID and monitors in *after* install. Helm 3's three-way merge computes its delta as `diff(current → modified)`, so any field the manifest sets and the live object disagrees on gets written back — the cluster config would be reset to `[]` and the driver would lose its addressing. The live `csiConfig` has to be passed in at upgrade time (it is now stored in the release, so `--reuse-values` is safe from here on). Fixing that post-install `kubectl` patch properly is left out of this PR.

A serial `maxUnavailable: 1` rollout also stalls while any node is unreachable. That is harmless — running pods keep the old spec and work, and pods created from then on carry the tolerations.