### PR TITLE
Allow specifying Kubernetes Service name for a workload

### DIFF
--- a/SaFE/apis/pkg/apis/amd/v1/well_known_constants.go
+++ b/SaFE/apis/pkg/apis/amd/v1/well_known_constants.go
@@ -142,8 +142,11 @@ const (
 	GroupIdLabel                      = WorkloadPrefix + "group.id"
 	RootWorkloadIdLabel               = WorkloadPrefix + "root.id"
 	K8sObjectIdLabel                  = PrimusSafePrefix + "k8s.object.id"
-	UseWorkspaceStorageAnnotation     = WorkloadPrefix + "use.workspace.storage"
-	ForceHostNetworkAnnotation        = WorkloadPrefix + "force.host.network"
+	// Data-plane Kubernetes Service object name. Dispatcher and the service
+	// API read this label instead of treating Workload.Name as the Service name.
+	ServiceNameLabel              = PrimusSafePrefix + "service.name"
+	UseWorkspaceStorageAnnotation = WorkloadPrefix + "use.workspace.storage"
+	ForceHostNetworkAnnotation    = WorkloadPrefix + "force.host.network"
 	// For full-GPU jobs with required affinity, the system reserves a node during retries to ensure reuse.
 	// Note: This feature is disabled when preemption is enabled
 	RetryOnOriginalNodesAnnotation = PrimusSafePrefix + "retry.on.original.nodes"

--- a/SaFE/apis/pkg/apis/amd/v1/workload_types.go
+++ b/SaFE/apis/pkg/apis/amd/v1/workload_types.go
@@ -95,6 +95,9 @@ type HealthCheck struct {
 }
 
 type Service struct {
+	// Kubernetes Service object name. When empty, the webhook defaults it to
+	// the workload name and stamps ServiceNameLabel on the Workload.
+	Name string `json:"name,omitempty"`
 	// Service protocol, e.g. TCP/UDP, default TCP
 	Protocol corev1.Protocol `json:"protocol"`
 	// Service port for external access, Defaults to targetPort.
@@ -269,7 +272,7 @@ type WorkloadPod struct {
 	Phase corev1.PodPhase `json:"phase,omitempty"`
 	// The node's IP address where the Pod is running
 	HostIp string `json:"hostIP,omitempty"`
-	// The Pod's own IP address inside the cluster Pod network. 
+	// The Pod's own IP address inside the cluster Pod network.
 	PodIp string `json:"podIP,omitempty"`
 	// The rank of pod, only for pytorch-job
 	Rank string `json:"rank,omitempty"`

--- a/SaFE/apis/pkg/client/applyconfiguration/amd/v1/service.go
+++ b/SaFE/apis/pkg/client/applyconfiguration/amd/v1/service.go
@@ -13,6 +13,9 @@ import (
 // ServiceApplyConfiguration represents a declarative configuration of the Service type for use
 // with apply.
 type ServiceApplyConfiguration struct {
+	// Kubernetes Service object name. When empty, the webhook defaults it to
+	// the workload name and stamps ServiceNameLabel on the Workload.
+	Name *string `json:"name,omitempty"`
 	// Service protocol, e.g. TCP/UDP, default TCP
 	Protocol *corev1.Protocol `json:"protocol,omitempty"`
 	// Service port for external access, Defaults to targetPort.
@@ -38,6 +41,14 @@ type ServiceApplyConfiguration struct {
 // apply.
 func Service() *ServiceApplyConfiguration {
 	return &ServiceApplyConfiguration{}
+}
+
+// WithName sets the Name field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Name field is set to the value of the last call.
+func (b *ServiceApplyConfiguration) WithName(value string) *ServiceApplyConfiguration {
+	b.Name = &value
+	return b
 }
 
 // WithProtocol sets the Protocol field in the declarative configuration to the given value

--- a/SaFE/apiserver/pkg/handlers/model-handlers/playground.go
+++ b/SaFE/apiserver/pkg/handlers/model-handlers/playground.go
@@ -33,6 +33,7 @@ import (
 	commonconfig "github.com/AMD-AIG-AIMA/SAFE/common/pkg/config"
 	dbclient "github.com/AMD-AIG-AIMA/SAFE/common/pkg/database/client"
 	commonerrors "github.com/AMD-AIG-AIMA/SAFE/common/pkg/errors"
+	commonworkload "github.com/AMD-AIG-AIMA/SAFE/common/pkg/workload"
 )
 
 // Chat handles direct chat with a model or workload.
@@ -143,7 +144,8 @@ func (h *Handler) Chat(c *gin.Context) {
 				baseUrl = "https://" + commonconfig.GetSystemHost() + "/" + clusterId + "/" + k8sWorkload.Spec.Workspace + "/" + k8sWorkload.Name + "/"
 			} else {
 				// Fallback to internal domain
-				baseUrl = fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", k8sWorkload.Name, k8sWorkload.Spec.Workspace, port)
+				baseUrl = fmt.Sprintf("http://%s.%s.svc.cluster.local:%d",
+					commonworkload.GetK8sServiceName(k8sWorkload), k8sWorkload.Spec.Workspace, port)
 			}
 		}
 
@@ -294,7 +296,8 @@ func (h *Handler) listPlaygroundServices(c *gin.Context) (interface{}, error) {
 			baseUrl = "https://" + commonconfig.GetSystemHost() + "/" + clusterId + "/" + w.Spec.Workspace + "/" + w.Name + "/"
 		} else {
 			// Fallback to internal domain: http://{name}.{workspace}.svc.cluster.local:{port}
-			baseUrl = fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", w.Name, w.Spec.Workspace, port)
+			baseUrl = fmt.Sprintf("http://%s.%s.svc.cluster.local:%d",
+				commonworkload.GetK8sServiceName(&w), w.Spec.Workspace, port)
 		}
 
 		items = append(items, PlaygroundServiceItem{

--- a/SaFE/apiserver/pkg/handlers/resources/ops_job.go
+++ b/SaFE/apiserver/pkg/handlers/resources/ops_job.go
@@ -38,6 +38,7 @@ import (
 	commonnodes "github.com/AMD-AIG-AIMA/SAFE/common/pkg/nodes"
 	commonjob "github.com/AMD-AIG-AIMA/SAFE/common/pkg/ops_job"
 	commonutils "github.com/AMD-AIG-AIMA/SAFE/common/pkg/utils"
+	commonworkload "github.com/AMD-AIG-AIMA/SAFE/common/pkg/workload"
 	commonworkspace "github.com/AMD-AIG-AIMA/SAFE/common/pkg/workspace"
 	jsonutils "github.com/AMD-AIG-AIMA/SAFE/utils/pkg/json"
 	"github.com/AMD-AIG-AIMA/SAFE/utils/pkg/sets"
@@ -1426,7 +1427,8 @@ func (h *Handler) generateEvaluationJob(c *gin.Context, body []byte) (*v1.OpsJob
 					}, k8sWorkload); err != nil {
 						klog.ErrorS(err, "failed to get K8s Workload for judge", "workloadId", judgeWorkload.WorkloadId)
 					} else {
-						judgeEndpoint = fmt.Sprintf("http://%s.%s.svc.cluster.local:8000/v1", judgeWorkload.WorkloadId, judgeWorkload.Workspace)
+						judgeEndpoint = fmt.Sprintf("http://%s.%s.svc.cluster.local:8000/v1",
+							commonworkload.GetK8sServiceName(k8sWorkload), judgeWorkload.Workspace)
 
 						// Extract served model name from workload
 						entryPoint := ""

--- a/SaFE/apiserver/pkg/handlers/resources/service.go
+++ b/SaFE/apiserver/pkg/handlers/resources/service.go
@@ -6,6 +6,7 @@
 package resources
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
@@ -60,6 +61,10 @@ func (h *Handler) getWorkloadService(c *gin.Context) (interface{}, error) {
 	service, err := k8sClients.ClientSet().CoreV1().Services(workspace).Get(ctx, svcName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
+	}
+	if owner := commonworkload.GetK8sServiceOwner(service); owner != adminWorkload.Name {
+		return nil, commonerrors.NewConflict(
+			fmt.Sprintf("service name %s is owned by workload %s", svcName, owner))
 	}
 	if len(service.Spec.Ports) == 0 {
 		return nil, commonerrors.NewNotFoundWithMessage("service does not have any ports")

--- a/SaFE/apiserver/pkg/handlers/resources/service.go
+++ b/SaFE/apiserver/pkg/handlers/resources/service.go
@@ -19,6 +19,7 @@ import (
 	commonconfig "github.com/AMD-AIG-AIMA/SAFE/common/pkg/config"
 	commonerrors "github.com/AMD-AIG-AIMA/SAFE/common/pkg/errors"
 	commonutils "github.com/AMD-AIG-AIMA/SAFE/common/pkg/utils"
+	commonworkload "github.com/AMD-AIG-AIMA/SAFE/common/pkg/workload"
 )
 
 // GetWorkloadService Obtain the service started by the data plane corresponding to this workload.
@@ -55,7 +56,8 @@ func (h *Handler) getWorkloadService(c *gin.Context) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	service, err := k8sClients.ClientSet().CoreV1().Services(workspace).Get(ctx, name, metav1.GetOptions{})
+	svcName := commonworkload.GetK8sServiceName(adminWorkload)
+	service, err := k8sClients.ClientSet().CoreV1().Services(workspace).Get(ctx, svcName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +69,7 @@ func (h *Handler) getWorkloadService(c *gin.Context) (interface{}, error) {
 		ClusterIp: service.Spec.ClusterIP,
 		Type:      service.Spec.Type,
 	}
-	internalDomain := adminWorkload.Name + "." + adminWorkload.Spec.Workspace +
+	internalDomain := svcName + "." + adminWorkload.Spec.Workspace +
 		".svc.cluster.local:" + strconv.Itoa(int(service.Spec.Ports[0].Port))
 	result.InternalDomain = internalDomain
 	if commonconfig.GetIngress() == common.HigressClassname && commonconfig.GetSystemHost() != "" {

--- a/SaFE/apiserver/pkg/handlers/resources/service_test.go
+++ b/SaFE/apiserver/pkg/handlers/resources/service_test.go
@@ -13,11 +13,15 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 
 	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
 	"github.com/AMD-AIG-AIMA/SAFE/apiserver/pkg/handlers/authority"
 	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/common"
+	k8sclient "github.com/AMD-AIG-AIMA/SAFE/common/pkg/k8sclient"
 	commonutils "github.com/AMD-AIG-AIMA/SAFE/common/pkg/utils"
 )
 
@@ -180,6 +184,41 @@ func TestGetWorkloadServiceValidation(t *testing.T) {
 		// Depending on implementation, this might be treated as invalid or as a workload name
 		// Current implementation checks for empty string only
 	})
+}
+
+func TestGetWorkloadServiceRejectsForeignService(t *testing.T) {
+	mockUser, adminClient := createMockUser()
+	workload := genMockWorkloadForService(mockUser.Name)
+	workload.Spec.Service = &v1.Service{Name: "shared-service"}
+	v1.SetLabel(workload, v1.ServiceNameLabel, "shared-service")
+	assert.NoError(t, adminClient.Create(context.Background(), workload))
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "shared-service",
+			Namespace: workload.Spec.Workspace,
+			Labels:    map[string]string{v1.WorkloadIdLabel: "another-workload"},
+		},
+		Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}},
+	}
+	clientManager := commonutils.NewObjectManager()
+	clientManager.Add("test-cluster", k8sclient.NewClientFactoryWithOnlyClient(
+		context.Background(), "test-cluster", k8sfake.NewSimpleClientset(service)))
+	handler := Handler{
+		Client:           adminClient,
+		accessController: authority.NewAccessController(adminClient),
+		clientManager:    clientManager,
+	}
+	response := httptest.NewRecorder()
+	ginContext, _ := gin.CreateTestContext(response)
+	ginContext.Request = httptest.NewRequest(http.MethodGet, "/api/v1/services/"+workload.Name, nil)
+	ginContext.Set(common.UserId, mockUser.Name)
+	ginContext.Set(common.Name, workload.Name)
+
+	_, err := handler.getWorkloadService(ginContext)
+
+	assert.Error(t, err)
+	assert.True(t, apierrors.IsConflict(err))
 }
 
 // genMockWorkloadForService creates a mock workload for service tests

--- a/SaFE/charts/primus-safe/crds/amd.com_workloads.yaml
+++ b/SaFE/charts/primus-safe/crds/amd.com_workloads.yaml
@@ -234,6 +234,11 @@ spec:
               service:
                 description: Service configuration
                 properties:
+                  name:
+                    description: |-
+                      Kubernetes Service object name. When empty, the webhook defaults it to
+                      the workload name and stamps ServiceNameLabel on the Workload.
+                    type: string
                   extends:
                     additionalProperties:
                       type: string

--- a/SaFE/charts/primus-safe/crds/amd.com_workloads.yaml
+++ b/SaFE/charts/primus-safe/crds/amd.com_workloads.yaml
@@ -234,11 +234,6 @@ spec:
               service:
                 description: Service configuration
                 properties:
-                  name:
-                    description: |-
-                      Kubernetes Service object name. When empty, the webhook defaults it to
-                      the workload name and stamps ServiceNameLabel on the Workload.
-                    type: string
                   extends:
                     additionalProperties:
                       type: string
@@ -255,6 +250,11 @@ spec:
                       endpoints to the head pod, otherwise traffic round-robins to workers
                       and hits connection refused.
                     type: object
+                  name:
+                    description: |-
+                      Kubernetes Service object name. When empty, the webhook defaults it to
+                      the workload name and stamps ServiceNameLabel on the Workload.
+                    type: string
                   nodePort:
                     description: Port of Host Node (for NodePort type)
                     type: integer

--- a/SaFE/common/pkg/workload/workload.go
+++ b/SaFE/common/pkg/workload/workload.go
@@ -46,6 +46,17 @@ func GetK8sServiceName(w *v1.Workload) string {
 	return w.Name
 }
 
+// GetK8sServiceOwner returns the workload identity recorded on a Service.
+func GetK8sServiceOwner(service *corev1.Service) string {
+	if service == nil {
+		return ""
+	}
+	if owner := service.Labels[v1.WorkloadIdLabel]; owner != "" {
+		return owner
+	}
+	return service.Name
+}
+
 // GetTotalReplica returns the total replica count across all resources in the workload
 func GetTotalReplica(w *v1.Workload) int {
 	n := 0

--- a/SaFE/common/pkg/workload/workload.go
+++ b/SaFE/common/pkg/workload/workload.go
@@ -30,6 +30,22 @@ import (
 	sliceutil "github.com/AMD-AIG-AIMA/SAFE/utils/pkg/slice"
 )
 
+// GetK8sServiceName returns the data-plane Kubernetes Service object name.
+// It reads ServiceNameLabel first, then Spec.Service.Name, and only then the
+// workload name so callers do not treat Workload.Name as the Service name.
+func GetK8sServiceName(w *v1.Workload) string {
+	if w == nil {
+		return ""
+	}
+	if name := v1.GetLabel(w, v1.ServiceNameLabel); name != "" {
+		return name
+	}
+	if w.Spec.Service != nil && w.Spec.Service.Name != "" {
+		return w.Spec.Service.Name
+	}
+	return w.Name
+}
+
 // GetTotalReplica returns the total replica count across all resources in the workload
 func GetTotalReplica(w *v1.Workload) int {
 	n := 0

--- a/SaFE/common/pkg/workload/workload_test.go
+++ b/SaFE/common/pkg/workload/workload_test.go
@@ -30,6 +30,32 @@ import (
 	commonutils "github.com/AMD-AIG-AIMA/SAFE/common/pkg/utils"
 )
 
+func TestGetK8sServiceName(t *testing.T) {
+	workload := &v1.Workload{
+		ObjectMeta: metav1.ObjectMeta{Name: "workload", Labels: map[string]string{}},
+		Spec:       v1.WorkloadSpec{Service: &v1.Service{Name: "spec-service"}},
+	}
+	assert.Equal(t, GetK8sServiceName(workload), "spec-service")
+
+	v1.SetLabel(workload, v1.ServiceNameLabel, "label-service")
+	assert.Equal(t, GetK8sServiceName(workload), "label-service")
+
+	workload.Spec.Service = nil
+	v1.RemoveLabel(workload, v1.ServiceNameLabel)
+	assert.Equal(t, GetK8sServiceName(workload), "workload")
+}
+
+func TestGetK8sServiceOwner(t *testing.T) {
+	service := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name:   "service",
+		Labels: map[string]string{v1.WorkloadIdLabel: "workload"},
+	}}
+	assert.Equal(t, GetK8sServiceOwner(service), "workload")
+
+	delete(service.Labels, v1.WorkloadIdLabel)
+	assert.Equal(t, GetK8sServiceOwner(service), "service")
+}
+
 func genMockWorkload(clusterName, workspace string) *v1.Workload {
 	workload := &v1.Workload{
 		ObjectMeta: metav1.ObjectMeta{

--- a/SaFE/job-manager/pkg/dispatcher/dispatcher.go
+++ b/SaFE/job-manager/pkg/dispatcher/dispatcher.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/rand"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
 	ctrlruntime "sigs.k8s.io/controller-runtime"
@@ -887,11 +888,23 @@ func (r *DispatcherReconciler) updateService(ctx context.Context, adminWorkload 
 
 	// Delete when no service desired
 	if adminWorkload.Spec.Service == nil {
-		err := k8sClientSet.CoreV1().Services(namespace).Delete(ctx, svcName, metav1.DeleteOptions{})
-		if adminWorkload.Name != "" && adminWorkload.Name != svcName {
-			_ = k8sClientSet.CoreV1().Services(namespace).Delete(ctx, adminWorkload.Name, metav1.DeleteOptions{})
+		services := k8sClientSet.CoreV1().Services(namespace)
+		if err := deleteServiceIfOwned(ctx, services, svcName, adminWorkload); err != nil {
+			return ctrlruntime.Result{}, err
 		}
-		return ctrlruntime.Result{}, client.IgnoreNotFound(err)
+		if adminWorkload.Name != "" && adminWorkload.Name != svcName {
+			if err := deleteServiceIfOwned(ctx, services, adminWorkload.Name, adminWorkload); err != nil {
+				return ctrlruntime.Result{}, err
+			}
+		}
+		if v1.GetLabel(adminWorkload, v1.ServiceNameLabel) != "" {
+			patch := client.MergeFrom(adminWorkload.DeepCopy())
+			v1.RemoveLabel(adminWorkload, v1.ServiceNameLabel)
+			if err := r.Patch(ctx, adminWorkload, patch); err != nil {
+				return ctrlruntime.Result{}, err
+			}
+		}
+		return ctrlruntime.Result{}, nil
 	}
 
 	// Get or create
@@ -957,44 +970,10 @@ func (r *DispatcherReconciler) createIngress(ctx context.Context, adminWorkload 
 	k8sClientSet := clientSets.ClientFactory().ClientSet()
 	namespace := adminWorkload.Spec.Workspace
 	name := adminWorkload.Name
-	svcName := commonworkload.GetK8sServiceName(adminWorkload)
 	if _, err := k8sClientSet.NetworkingV1().Ingresses(namespace).Get(ctx, name, metav1.GetOptions{}); err == nil {
 		return ctrlruntime.Result{}, nil
 	}
-	specService := adminWorkload.Spec.Service
-	pathType := networkingv1.PathTypePrefix
-	path := "/" + namespace + "/" + name + "/(.*)"
-	ing := &networkingv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-			Annotations: map[string]string{
-				v1.UserNameAnnotation:       v1.GetUserName(adminWorkload),
-				"higress.io/rewrite-target": "/$1",
-			},
-		},
-		Spec: networkingv1.IngressSpec{
-			IngressClassName: pointer.String(common.HigressClassname),
-			Rules: []networkingv1.IngressRule{{
-				Host: commonconfig.GetSystemHost(),
-				IngressRuleValue: networkingv1.IngressRuleValue{
-					HTTP: &networkingv1.HTTPIngressRuleValue{
-						Paths: []networkingv1.HTTPIngressPath{{
-							Path:     path,
-							PathType: &pathType,
-							Backend: networkingv1.IngressBackend{
-								Service: &networkingv1.IngressServiceBackend{
-									Name: svcName, Port: networkingv1.ServiceBackendPort{
-										Number: int32(specService.Port),
-									},
-								},
-							},
-						}},
-					},
-				},
-			}},
-		},
-	}
+	ing := buildIngress(adminWorkload)
 	// Only set owner reference when the owner object has a valid UID.
 	owner := obj
 	if len(owner.GetUID()) == 0 {
@@ -1017,6 +996,44 @@ func (r *DispatcherReconciler) createIngress(ctx context.Context, adminWorkload 
 	}
 	klog.Infof("ingress %s/%s created", namespace, name)
 	return ctrlruntime.Result{}, nil
+}
+
+// buildIngress creates the desired Ingress definition for a workload.
+func buildIngress(workload *v1.Workload) *networkingv1.Ingress {
+	pathType := networkingv1.PathTypePrefix
+	path := "/" + workload.Spec.Workspace + "/" + workload.Name + "/(.*)"
+	return &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      workload.Name,
+			Namespace: workload.Spec.Workspace,
+			Annotations: map[string]string{
+				v1.UserNameAnnotation:       v1.GetUserName(workload),
+				"higress.io/rewrite-target": "/$1",
+			},
+		},
+		Spec: networkingv1.IngressSpec{
+			IngressClassName: pointer.String(common.HigressClassname),
+			Rules: []networkingv1.IngressRule{{
+				Host: commonconfig.GetSystemHost(),
+				IngressRuleValue: networkingv1.IngressRuleValue{
+					HTTP: &networkingv1.HTTPIngressRuleValue{
+						Paths: []networkingv1.HTTPIngressPath{{
+							Path:     path,
+							PathType: &pathType,
+							Backend: networkingv1.IngressBackend{
+								Service: &networkingv1.IngressServiceBackend{
+									Name: commonworkload.GetK8sServiceName(workload),
+									Port: networkingv1.ServiceBackendPort{
+										Number: int32(workload.Spec.Service.Port),
+									},
+								},
+							},
+						}},
+					},
+				},
+			}},
+		},
+	}
 }
 
 // updateIngress makes sure the Ingress exists (or is removed) and points to the same-named Service and port.
@@ -1107,11 +1124,13 @@ func (r *DispatcherReconciler) generateLighthouse(ctx context.Context, rootWorkl
 	workload.Spec.Kind = common.DeploymentKind
 	workload.Spec.Resources = []v1.WorkloadResource{rootWorkload.Spec.Resources[0]}
 	workload.Spec.Service = &v1.Service{
+		Name:        workload.Name,
 		Protocol:    corev1.ProtocolTCP,
 		Port:        LightHousePort,
 		TargetPort:  LightHousePort,
 		ServiceType: corev1.ServiceTypeClusterIP,
 	}
+	v1.SetLabel(workload, v1.ServiceNameLabel, workload.Name)
 	workload.Spec.Service.Extends = make(map[string]string)
 	workload.Spec.Service.Extends["maxUnavailable"] = common.DefaultMaxUnavailable
 	workload.Spec.Service.Extends["maxSurge"] = common.DefaultMaxMaxSurge
@@ -1129,6 +1148,7 @@ func (r *DispatcherReconciler) generateTorchFTWorker(ctx context.Context,
 	nodePerGroup := rootWorkload.Spec.Resources[1].Replica / totalGroup
 	displayName := v1.GetDisplayName(rootWorkload) + "-" + groupIdStr
 	workload.Name = rootWorkload.Name + "-" + groupIdStr
+	rebindGeneratedServiceName(workload)
 	workload.Spec.Resources = []v1.WorkloadResource{rootWorkload.Spec.Resources[1]}
 	workload.Spec.Resources[0].Replica = 1 // pytorch master
 	if nodePerGroup > 1 {
@@ -1195,6 +1215,7 @@ func (r *DispatcherReconciler) generateMonarchMesh(ctx context.Context, rootWork
 	displayName := generateMeshNamePrefix(rootWorkload.Name) + groupIdStr
 	nodePerGroup := rootWorkload.Spec.Resources[1].Replica / totalGroup
 	workload.Name = displayName
+	rebindGeneratedServiceName(workload)
 	v1.SetLabel(workload, v1.DisplayNameLabel, displayName)
 	v1.SetLabel(workload, v1.RootWorkloadIdLabel, rootWorkload.Name)
 	v1.SetLabel(workload, v1.GroupIdLabel, groupIdStr)
@@ -1229,22 +1250,43 @@ func generateServicePorts(specService *v1.Service) []corev1.ServicePort {
 	}}
 }
 
-// checkK8sServiceOwner returns a bad request when the data-plane Service
-// belongs to another workload. Missing WorkloadIdLabel is treated as the
-// pre-custom-name convention where the Service was named after the workload.
+// checkK8sServiceOwner verifies that the workload owns the data-plane Service.
+// Missing WorkloadIdLabel uses the legacy Service-name ownership convention.
 func checkK8sServiceOwner(svc *corev1.Service, workload *v1.Workload) error {
-	owner := ""
-	if svc.Labels != nil {
-		owner = svc.Labels[v1.WorkloadIdLabel]
-	}
-	if owner == "" {
-		owner = svc.Name
-	}
+	owner := commonworkload.GetK8sServiceOwner(svc)
 	if owner != workload.Name {
-		return commonerrors.NewBadRequest(
-			fmt.Sprintf("service name %s is already used by workload %s", svc.Name, owner))
+		return fmt.Errorf("service name %s is already used by workload %s", svc.Name, owner)
 	}
 	return nil
+}
+
+// deleteServiceIfOwned deletes a Service only when the workload owns it.
+func deleteServiceIfOwned(ctx context.Context, services corev1client.ServiceInterface,
+	name string, workload *v1.Workload) error {
+	if name == "" {
+		return nil
+	}
+	service, err := services.Get(ctx, name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if err = checkK8sServiceOwner(service, workload); err != nil {
+		return err
+	}
+	return client.IgnoreNotFound(services.Delete(ctx, name, metav1.DeleteOptions{}))
+}
+
+// rebindGeneratedServiceName scopes an inherited Service to a generated workload.
+func rebindGeneratedServiceName(workload *v1.Workload) {
+	if workload.Spec.Service == nil {
+		v1.RemoveLabel(workload, v1.ServiceNameLabel)
+		return
+	}
+	workload.Spec.Service.Name = workload.Name
+	v1.SetLabel(workload, v1.ServiceNameLabel, workload.Name)
 }
 
 // buildServiceSelector composes the K8s Service selector for a workload.

--- a/SaFE/job-manager/pkg/dispatcher/dispatcher.go
+++ b/SaFE/job-manager/pkg/dispatcher/dispatcher.go
@@ -806,9 +806,12 @@ func (r *DispatcherReconciler) createService(ctx context.Context, adminWorkload 
 	k8sClientSet := clientSets.ClientFactory().ClientSet()
 	namespace := adminWorkload.Spec.Workspace
 	svcName := commonworkload.GetK8sServiceName(adminWorkload)
-	var err error
-	if _, err = k8sClientSet.CoreV1().Services(namespace).Get(ctx, svcName, metav1.GetOptions{}); err == nil {
-		return ctrlruntime.Result{}, nil
+	existing, err := k8sClientSet.CoreV1().Services(namespace).Get(ctx, svcName, metav1.GetOptions{})
+	if err == nil {
+		return ctrlruntime.Result{}, checkK8sServiceOwner(existing, adminWorkload)
+	}
+	if !apierrors.IsNotFound(err) {
+		return ctrlruntime.Result{}, err
 	}
 	specService := adminWorkload.Spec.Service
 	service := &corev1.Service{
@@ -853,8 +856,14 @@ func (r *DispatcherReconciler) createService(ctx context.Context, adminWorkload 
 		service.Spec.Ports[0].NodePort = int32(specService.NodePort)
 	}
 
-	if service, err = k8sClientSet.CoreV1().Services(namespace).Create(ctx,
-		service, metav1.CreateOptions{}); client.IgnoreAlreadyExists(err) != nil {
+	if _, err = k8sClientSet.CoreV1().Services(namespace).Create(ctx, service, metav1.CreateOptions{}); apierrors.IsAlreadyExists(err) {
+		existing, getErr := k8sClientSet.CoreV1().Services(namespace).Get(ctx, svcName, metav1.GetOptions{})
+		if getErr != nil {
+			return ctrlruntime.Result{}, getErr
+		}
+		return ctrlruntime.Result{}, checkK8sServiceOwner(existing, adminWorkload)
+	}
+	if err != nil {
 		klog.ErrorS(err, "failed to create service", "name", svcName)
 		if specService.NodePort > 0 {
 			// NodePort error occurred; cannot retry.
@@ -891,6 +900,9 @@ func (r *DispatcherReconciler) updateService(ctx context.Context, adminWorkload 
 		return r.createService(ctx, adminWorkload, clientSets, obj)
 	}
 	if err != nil {
+		return ctrlruntime.Result{}, err
+	}
+	if err = checkK8sServiceOwner(existing, adminWorkload); err != nil {
 		return ctrlruntime.Result{}, err
 	}
 
@@ -1215,6 +1227,24 @@ func generateServicePorts(specService *v1.Service) []corev1.ServicePort {
 		Port:       int32(specService.Port),
 		TargetPort: intstr.IntOrString{IntVal: int32(specService.TargetPort)},
 	}}
+}
+
+// checkK8sServiceOwner returns a bad request when the data-plane Service
+// belongs to another workload. Missing WorkloadIdLabel is treated as the
+// pre-custom-name convention where the Service was named after the workload.
+func checkK8sServiceOwner(svc *corev1.Service, workload *v1.Workload) error {
+	owner := ""
+	if svc.Labels != nil {
+		owner = svc.Labels[v1.WorkloadIdLabel]
+	}
+	if owner == "" {
+		owner = svc.Name
+	}
+	if owner != workload.Name {
+		return commonerrors.NewBadRequest(
+			fmt.Sprintf("service name %s is already used by workload %s", svc.Name, owner))
+	}
+	return nil
 }
 
 // buildServiceSelector composes the K8s Service selector for a workload.

--- a/SaFE/job-manager/pkg/dispatcher/dispatcher.go
+++ b/SaFE/job-manager/pkg/dispatcher/dispatcher.go
@@ -200,7 +200,7 @@ func (r *DispatcherReconciler) processTorchFTWorkload(ctx context.Context, rootW
 	if result, err := r.processWorkload(ctx, lightHouseWorkload); err != nil || result.RequeueAfter > 0 {
 		return result, err
 	}
-	lightHouseAddr := "http://" + lightHouseWorkload.Name + "." + rootWorkload.Spec.Workspace +
+	lightHouseAddr := "http://" + commonworkload.GetK8sServiceName(lightHouseWorkload) + "." + rootWorkload.Spec.Workspace +
 		".svc.cluster.local:" + strconv.Itoa(LightHousePort)
 
 	for i := 0; i < group; i++ {
@@ -805,18 +805,23 @@ func (r *DispatcherReconciler) createService(ctx context.Context, adminWorkload 
 	}
 	k8sClientSet := clientSets.ClientFactory().ClientSet()
 	namespace := adminWorkload.Spec.Workspace
+	svcName := commonworkload.GetK8sServiceName(adminWorkload)
 	var err error
-	if _, err = k8sClientSet.CoreV1().Services(namespace).Get(ctx, adminWorkload.Name, metav1.GetOptions{}); err == nil {
+	if _, err = k8sClientSet.CoreV1().Services(namespace).Get(ctx, svcName, metav1.GetOptions{}); err == nil {
 		return ctrlruntime.Result{}, nil
 	}
 	specService := adminWorkload.Spec.Service
 	service := &corev1.Service{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      adminWorkload.Name,
+			Name:      svcName,
 			Namespace: namespace,
 			Annotations: map[string]string{
 				v1.UserNameAnnotation: v1.GetUserName(adminWorkload),
+			},
+			Labels: map[string]string{
+				v1.WorkloadIdLabel:  adminWorkload.Name,
+				v1.ServiceNameLabel: svcName,
 			},
 		},
 		Spec: corev1.ServiceSpec{
@@ -850,14 +855,14 @@ func (r *DispatcherReconciler) createService(ctx context.Context, adminWorkload 
 
 	if service, err = k8sClientSet.CoreV1().Services(namespace).Create(ctx,
 		service, metav1.CreateOptions{}); client.IgnoreAlreadyExists(err) != nil {
-		klog.ErrorS(err, "failed to create service", "name", adminWorkload.Name)
+		klog.ErrorS(err, "failed to create service", "name", svcName)
 		if specService.NodePort > 0 {
 			// NodePort error occurred; cannot retry.
 			return ctrlruntime.Result{}, commonerrors.NewInternalError(err.Error())
 		}
 		return ctrlruntime.Result{}, err
 	}
-	klog.Infof("service %s/%s created", namespace, adminWorkload.Name)
+	klog.Infof("service %s/%s created", namespace, svcName)
 	return ctrlruntime.Result{}, nil
 }
 
@@ -869,15 +874,19 @@ func (r *DispatcherReconciler) updateService(ctx context.Context, adminWorkload 
 	clientSets *syncer.ClusterClientSets, obj *unstructured.Unstructured) (ctrlruntime.Result, error) {
 	k8sClientSet := clientSets.ClientFactory().ClientSet()
 	namespace := adminWorkload.Spec.Workspace
+	svcName := commonworkload.GetK8sServiceName(adminWorkload)
 
 	// Delete when no service desired
 	if adminWorkload.Spec.Service == nil {
-		err := k8sClientSet.CoreV1().Services(namespace).Delete(ctx, adminWorkload.Name, metav1.DeleteOptions{})
+		err := k8sClientSet.CoreV1().Services(namespace).Delete(ctx, svcName, metav1.DeleteOptions{})
+		if adminWorkload.Name != "" && adminWorkload.Name != svcName {
+			_ = k8sClientSet.CoreV1().Services(namespace).Delete(ctx, adminWorkload.Name, metav1.DeleteOptions{})
+		}
 		return ctrlruntime.Result{}, client.IgnoreNotFound(err)
 	}
 
 	// Get or create
-	existing, err := k8sClientSet.CoreV1().Services(namespace).Get(ctx, adminWorkload.Name, metav1.GetOptions{})
+	existing, err := k8sClientSet.CoreV1().Services(namespace).Get(ctx, svcName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		return r.createService(ctx, adminWorkload, clientSets, obj)
 	}
@@ -917,7 +926,7 @@ func (r *DispatcherReconciler) updateService(ctx context.Context, adminWorkload 
 		return ctrlruntime.Result{}, nil
 	}
 	if _, err = k8sClientSet.CoreV1().Services(namespace).Update(ctx, existing, metav1.UpdateOptions{}); err != nil {
-		klog.ErrorS(err, "failed to update service", "name", adminWorkload.Name)
+		klog.ErrorS(err, "failed to update service", "name", svcName)
 		if specService.NodePort > 0 {
 			// NodePort related update errors are not retryable via generic update
 			err = commonerrors.NewInternalError(err.Error())
@@ -936,6 +945,7 @@ func (r *DispatcherReconciler) createIngress(ctx context.Context, adminWorkload 
 	k8sClientSet := clientSets.ClientFactory().ClientSet()
 	namespace := adminWorkload.Spec.Workspace
 	name := adminWorkload.Name
+	svcName := commonworkload.GetK8sServiceName(adminWorkload)
 	if _, err := k8sClientSet.NetworkingV1().Ingresses(namespace).Get(ctx, name, metav1.GetOptions{}); err == nil {
 		return ctrlruntime.Result{}, nil
 	}
@@ -962,7 +972,7 @@ func (r *DispatcherReconciler) createIngress(ctx context.Context, adminWorkload 
 							PathType: &pathType,
 							Backend: networkingv1.IngressBackend{
 								Service: &networkingv1.IngressServiceBackend{
-									Name: name, Port: networkingv1.ServiceBackendPort{
+									Name: svcName, Port: networkingv1.ServiceBackendPort{
 										Number: int32(specService.Port),
 									},
 								},
@@ -1021,11 +1031,14 @@ func (r *DispatcherReconciler) updateIngress(ctx context.Context, adminWorkload 
 		return ctrlruntime.Result{}, err
 	}
 	specService := adminWorkload.Spec.Service
+	svcName := commonworkload.GetK8sServiceName(adminWorkload)
 	if len(existing.Spec.Rules) > 0 && existing.Spec.Rules[0].HTTP != nil && len(existing.Spec.Rules[0].HTTP.Paths) > 0 {
-		if existing.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Port.Number == int32(specService.Port) {
+		backend := existing.Spec.Rules[0].HTTP.Paths[0].Backend.Service
+		if backend.Name == svcName && backend.Port.Number == int32(specService.Port) {
 			return ctrlruntime.Result{}, nil
 		}
-		existing.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Port.Number = int32(specService.Port)
+		backend.Name = svcName
+		backend.Port.Number = int32(specService.Port)
 	} else {
 		return ctrlruntime.Result{}, commonerrors.NewInternalError("no rules found in ingress")
 	}

--- a/SaFE/job-manager/pkg/dispatcher/dispatcher_test.go
+++ b/SaFE/job-manager/pkg/dispatcher/dispatcher_test.go
@@ -15,6 +15,7 @@ import (
 	"gotest.tools/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -69,6 +70,10 @@ func genMockScheme() (*runtime.Scheme, error) {
 		return nil, err
 	}
 	err = appsv1.AddToScheme(result)
+	if err != nil {
+		return nil, err
+	}
+	err = networkingv1.AddToScheme(result)
 	if err != nil {
 		return nil, err
 	}
@@ -1287,21 +1292,27 @@ func newGenReconciler(t *testing.T) *DispatcherReconciler {
 func TestGenerateLighthouse(t *testing.T) {
 	r := newGenReconciler(t)
 	w := multiResourceWorkload()
+	w.Spec.Service = &v1.Service{Name: "root-service"}
+	v1.SetLabel(w, v1.ServiceNameLabel, "root-service")
 	lh := r.generateLighthouse(context.Background(), w)
 	assert.Assert(t, lh != nil)
 	assert.Equal(t, lh.Name, "rw-0")
 	assert.Equal(t, string(lh.Spec.Kind), common.DeploymentKind)
 	assert.Assert(t, lh.Spec.Service != nil)
+	assert.Equal(t, commonworkload.GetK8sServiceName(lh), "rw-0")
 }
 
 func TestGenerateTorchFTWorker(t *testing.T) {
 	r := newGenReconciler(t)
 	w := multiResourceWorkload()
+	w.Spec.Service = &v1.Service{Name: "root-service"}
+	v1.SetLabel(w, v1.ServiceNameLabel, "root-service")
 	worker := r.generateTorchFTWorker(context.Background(), w, 0, 2, "lighthouse:29400")
 	assert.Assert(t, worker != nil)
 	assert.Equal(t, worker.Name, "rw-1")
 	assert.Equal(t, string(worker.Spec.Kind), common.PytorchJobKind)
 	assert.Equal(t, worker.Spec.Env[common.TorchFTLightHouse], "lighthouse:29400")
+	assert.Equal(t, commonworkload.GetK8sServiceName(worker), "rw-1")
 }
 
 func TestGenerateMonarchClient(t *testing.T) {
@@ -1316,9 +1327,12 @@ func TestGenerateMonarchClient(t *testing.T) {
 func TestGenerateMonarchMesh(t *testing.T) {
 	r := newGenReconciler(t)
 	w := multiResourceWorkload()
+	w.Spec.Service = &v1.Service{Name: "root-service"}
+	v1.SetLabel(w, v1.ServiceNameLabel, "root-service")
 	mesh := r.generateMonarchMesh(context.Background(), w, 2, 0)
 	assert.Assert(t, mesh != nil)
 	assert.Equal(t, string(mesh.Spec.Kind), common.MonarchMesh)
+	assert.Equal(t, commonworkload.GetK8sServiceName(mesh), mesh.Name)
 }
 
 // --- merged from dispatcher_monkey_test.go ---
@@ -1561,9 +1575,9 @@ func TestCreateService(t *testing.T) {
 		ServiceType: corev1.ServiceTypeClusterIP,
 	}
 
+	clientset := k8sfake.NewSimpleClientset()
 	cs := &syncer.ClusterClientSets{}
-	cs.SetClientFactory(commonclient.NewClientFactoryWithOnlyClient(
-		context.Background(), "c", k8sfake.NewSimpleClientset()))
+	cs.SetClientFactory(commonclient.NewClientFactoryWithOnlyClient(context.Background(), "c", clientset))
 
 	// Give the owner object a UID + GVK so SetControllerReference works and the
 	// dynamic GetObject fallback is skipped.
@@ -1576,6 +1590,10 @@ func TestCreateService(t *testing.T) {
 	res, err := r.createService(context.Background(), w, cs, obj)
 	assert.NilError(t, err)
 	assert.Equal(t, res.RequeueAfter.Nanoseconds(), int64(0))
+	service, err := clientset.CoreV1().Services("ns").Get(context.Background(), "w", metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, service.Labels[v1.WorkloadIdLabel], "w")
+	assert.Equal(t, service.Labels[v1.ServiceNameLabel], "w")
 }
 
 func TestCreateServiceDuplicateNameOwnedByOther(t *testing.T) {
@@ -1606,7 +1624,8 @@ func TestCreateServiceDuplicateNameOwnedByOther(t *testing.T) {
 
 	res, err := r.createService(context.Background(), w, serviceClientSets(existing), obj)
 	assert.Assert(t, err != nil)
-	assert.Assert(t, commonerrors.IsBadRequest(err))
+	assert.ErrorContains(t, err, "already used by workload wl-a")
+	assert.Assert(t, !commonerrors.IsBadRequest(err))
 	assert.Equal(t, res.RequeueAfter.Nanoseconds(), int64(0))
 }
 
@@ -1617,6 +1636,19 @@ func TestCreateIngressNoService(t *testing.T) {
 	res, err := r.createIngress(context.Background(), w, nil, nil)
 	assert.NilError(t, err)
 	assert.Equal(t, res.RequeueAfter.Nanoseconds(), int64(0))
+}
+
+func TestCreateIngressUsesCustomServiceName(t *testing.T) {
+	workload := &v1.Workload{ObjectMeta: metav1.ObjectMeta{
+		Name:   "workload",
+		Labels: map[string]string{v1.ServiceNameLabel: "custom-service"},
+	}}
+	workload.Spec.Workspace = "ns"
+	workload.Spec.Service = &v1.Service{Port: 80}
+
+	ingress := buildIngress(workload)
+
+	assert.Equal(t, ingress.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Name, "custom-service")
 }
 
 func serviceClientSets(objs ...runtime.Object) *syncer.ClusterClientSets {
@@ -1634,6 +1666,75 @@ func TestUpdateServiceDeleteWhenNoSpec(t *testing.T) {
 	res, err := r.updateService(context.Background(), w, serviceClientSets(), nil)
 	assert.NilError(t, err)
 	assert.Equal(t, res.RequeueAfter.Nanoseconds(), int64(0))
+}
+
+func TestUpdateServiceDoesNotDeleteServiceOwnedByAnotherWorkload(t *testing.T) {
+	existing := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name:      "wl-a",
+		Namespace: "ns",
+		Labels:    map[string]string{v1.WorkloadIdLabel: "wl-b"},
+	}}
+	clientset := k8sfake.NewSimpleClientset(existing)
+	cs := &syncer.ClusterClientSets{}
+	cs.SetClientFactory(commonclient.NewClientFactoryWithOnlyClient(context.Background(), "c", clientset))
+	w := &v1.Workload{ObjectMeta: metav1.ObjectMeta{Name: "wl-a"}}
+	w.Spec.Workspace = "ns"
+
+	_, err := (&DispatcherReconciler{}).updateService(context.Background(), w, cs, nil)
+	assert.Assert(t, err != nil)
+	_, getErr := clientset.CoreV1().Services("ns").Get(context.Background(), "wl-a", metav1.GetOptions{})
+	assert.NilError(t, getErr)
+}
+
+func TestUpdateServiceChecksOwnerBeforeDeletingLegacyFallback(t *testing.T) {
+	custom := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name:      "custom",
+		Namespace: "ns",
+		Labels:    map[string]string{v1.WorkloadIdLabel: "wl-a"},
+	}}
+	legacy := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name:      "wl-a",
+		Namespace: "ns",
+		Labels:    map[string]string{v1.WorkloadIdLabel: "wl-b"},
+	}}
+	clientset := k8sfake.NewSimpleClientset(custom, legacy)
+	cs := &syncer.ClusterClientSets{}
+	cs.SetClientFactory(commonclient.NewClientFactoryWithOnlyClient(context.Background(), "c", clientset))
+	w := &v1.Workload{ObjectMeta: metav1.ObjectMeta{
+		Name:   "wl-a",
+		Labels: map[string]string{v1.ServiceNameLabel: "custom"},
+	}}
+	w.Spec.Workspace = "ns"
+
+	_, err := (&DispatcherReconciler{}).updateService(context.Background(), w, cs, nil)
+	assert.Assert(t, err != nil)
+	_, customErr := clientset.CoreV1().Services("ns").Get(context.Background(), "custom", metav1.GetOptions{})
+	assert.Assert(t, apierrors.IsNotFound(customErr))
+	_, legacyErr := clientset.CoreV1().Services("ns").Get(context.Background(), "wl-a", metav1.GetOptions{})
+	assert.NilError(t, legacyErr)
+}
+
+func TestUpdateServiceClearsServiceNameLabelAfterDelete(t *testing.T) {
+	scheme, err := genMockScheme()
+	assert.NilError(t, err)
+	workload := &v1.Workload{ObjectMeta: metav1.ObjectMeta{
+		Name:   "wl-a",
+		Labels: map[string]string{v1.ServiceNameLabel: "custom"},
+	}}
+	workload.Spec.Workspace = "ns"
+	adminClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(workload).Build()
+	service := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name:      "custom",
+		Namespace: "ns",
+		Labels:    map[string]string{v1.WorkloadIdLabel: "wl-a"},
+	}}
+
+	_, err = (&DispatcherReconciler{Client: adminClient}).updateService(
+		context.Background(), workload, serviceClientSets(service), nil)
+	assert.NilError(t, err)
+	stored := &v1.Workload{}
+	assert.NilError(t, adminClient.Get(context.Background(), ctrlclient.ObjectKey{Name: "wl-a"}, stored))
+	assert.Equal(t, v1.GetLabel(stored, v1.ServiceNameLabel), "")
 }
 
 func TestUpdateServiceUpdatesExisting(t *testing.T) {

--- a/SaFE/job-manager/pkg/dispatcher/dispatcher_test.go
+++ b/SaFE/job-manager/pkg/dispatcher/dispatcher_test.go
@@ -15,13 +15,13 @@ import (
 	"gotest.tools/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	k8sfake "k8s.io/client-go/kubernetes/fake"
 	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 	ctrlruntime "sigs.k8s.io/controller-runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -29,8 +29,9 @@ import (
 
 	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
 	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/common"
-	commonclient "github.com/AMD-AIG-AIMA/SAFE/common/pkg/k8sclient"
 	commonconfig "github.com/AMD-AIG-AIMA/SAFE/common/pkg/config"
+	commonerrors "github.com/AMD-AIG-AIMA/SAFE/common/pkg/errors"
+	commonclient "github.com/AMD-AIG-AIMA/SAFE/common/pkg/k8sclient"
 	commonutils "github.com/AMD-AIG-AIMA/SAFE/common/pkg/utils"
 	commonworkload "github.com/AMD-AIG-AIMA/SAFE/common/pkg/workload"
 	"github.com/AMD-AIG-AIMA/SAFE/job-manager/pkg/syncer"
@@ -1574,6 +1575,38 @@ func TestCreateService(t *testing.T) {
 
 	res, err := r.createService(context.Background(), w, cs, obj)
 	assert.NilError(t, err)
+	assert.Equal(t, res.RequeueAfter.Nanoseconds(), int64(0))
+}
+
+func TestCreateServiceDuplicateNameOwnedByOther(t *testing.T) {
+	r := &DispatcherReconciler{}
+
+	existing := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "shared-svc",
+			Namespace: "ns",
+			Labels:    map[string]string{v1.WorkloadIdLabel: "wl-a"},
+		},
+	}
+	w := &v1.Workload{ObjectMeta: metav1.ObjectMeta{Name: "wl-b"}}
+	w.Spec.Workspace = "ns"
+	w.Spec.Service = &v1.Service{
+		Name:        "shared-svc",
+		Protocol:    corev1.ProtocolTCP,
+		Port:        80,
+		TargetPort:  8080,
+		ServiceType: corev1.ServiceTypeClusterIP,
+	}
+
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	obj.SetName("wl-b")
+	obj.SetNamespace("ns")
+	obj.SetUID("owner-uid")
+	obj.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Pod"))
+
+	res, err := r.createService(context.Background(), w, serviceClientSets(existing), obj)
+	assert.Assert(t, err != nil)
+	assert.Assert(t, commonerrors.IsBadRequest(err))
 	assert.Equal(t, res.RequeueAfter.Nanoseconds(), int64(0))
 }
 

--- a/SaFE/webhooks/pkg/utils_test.go
+++ b/SaFE/webhooks/pkg/utils_test.go
@@ -18,8 +18,8 @@ import (
 	commonerrors "github.com/AMD-AIG-AIMA/SAFE/common/pkg/errors"
 	commonutils "github.com/AMD-AIG-AIMA/SAFE/common/pkg/utils"
 	"gotest.tools/assert"
-	corev1 "k8s.io/api/core/v1"
 	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -466,7 +466,7 @@ func TestWorkloadMutateOwnerReferenceEarlyReturns(t *testing.T) {
 func TestWorkloadMutateServiceProtocolSet(t *testing.T) {
 	m := &WorkloadMutator{}
 	w := &v1.Workload{Spec: v1.WorkloadSpec{Service: &v1.Service{Protocol: "tcp", TargetPort: 80, Port: 90}}}
-	m.mutateService(w)
+	m.mutateService(nil, w)
 	assert.Equal(t, w.Spec.Service.Protocol, corev1.ProtocolTCP)
 }
 

--- a/SaFE/webhooks/pkg/workload_webhook.go
+++ b/SaFE/webhooks/pkg/workload_webhook.go
@@ -1380,7 +1380,8 @@ func (v *WorkloadValidator) validateServiceNameUnique(ctx context.Context, workl
 			continue
 		}
 		if commonworkload.GetK8sServiceName(other) == svcName {
-			return fmt.Errorf("the service name %s is already used by workload %s", svcName, other.Name)
+			return commonerrors.NewAlreadyExist(
+				fmt.Sprintf("the service name %s is already used by workload %s", svcName, other.Name))
 		}
 	}
 	return nil

--- a/SaFE/webhooks/pkg/workload_webhook.go
+++ b/SaFE/webhooks/pkg/workload_webhook.go
@@ -170,7 +170,7 @@ func (m *WorkloadMutator) mutateCommon(ctx context.Context, oldWorkload, newWork
 	m.mutateCustomerLabels(newWorkload)
 	m.mutateCronJobs(newWorkload)
 	m.mutateHealthCheck(newWorkload)
-	m.mutateService(newWorkload)
+	m.mutateService(oldWorkload, newWorkload)
 	m.mutateSecrets(ctx, newWorkload, workspace)
 	m.mutateStickNodes(ctx, newWorkload, workspace)
 	return nil
@@ -352,9 +352,12 @@ func mutateHealthCheck(field *v1.HealthCheck) {
 	}
 }
 
-// mutateService uppercases protocol and defaults to TCP.
-func (m *WorkloadMutator) mutateService(workload *v1.Workload) {
+// mutateService normalizes Service settings and maintains its resolved name.
+func (m *WorkloadMutator) mutateService(oldWorkload, workload *v1.Workload) {
 	if workload.Spec.Service == nil {
+		if oldWorkload == nil || oldWorkload.Spec.Service == nil || !v1.IsWorkloadDispatched(oldWorkload) {
+			v1.RemoveLabel(workload, v1.ServiceNameLabel)
+		}
 		return
 	}
 	if workload.Spec.Service.Protocol != "" {
@@ -1594,9 +1597,12 @@ func (v *WorkloadValidator) validateSpecChanged(newWorkload, oldWorkload *v1.Wor
 			return true
 		} else if oldWorkload.Spec.Service == nil && newWorkload.Spec.Service != nil {
 			return true
-		} else if newWorkload.Spec.Service != nil && oldWorkload.Spec.Service != nil &&
-			!reflect.DeepEqual(*newWorkload.Spec.Service, *oldWorkload.Spec.Service) {
-			return true
+		} else if newWorkload.Spec.Service != nil && oldWorkload.Spec.Service != nil {
+			newService := *newWorkload.Spec.Service
+			oldService := *oldWorkload.Spec.Service
+			newService.Name = commonworkload.GetK8sServiceName(newWorkload)
+			oldService.Name = commonworkload.GetK8sServiceName(oldWorkload)
+			return !reflect.DeepEqual(newService, oldService)
 		}
 		return false
 	}

--- a/SaFE/webhooks/pkg/workload_webhook.go
+++ b/SaFE/webhooks/pkg/workload_webhook.go
@@ -1376,6 +1376,9 @@ func (v *WorkloadValidator) validateServiceNameUnique(ctx context.Context, workl
 		if other.Name == workload.Name {
 			continue
 		}
+		if other.Spec.Service == nil || !other.GetDeletionTimestamp().IsZero() {
+			continue
+		}
 		if commonworkload.GetK8sServiceName(other) == svcName {
 			return fmt.Errorf("the service name %s is already used by workload %s", svcName, other.Name)
 		}

--- a/SaFE/webhooks/pkg/workload_webhook.go
+++ b/SaFE/webhooks/pkg/workload_webhook.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
@@ -363,6 +364,16 @@ func (m *WorkloadMutator) mutateService(workload *v1.Workload) {
 	}
 	if workload.Spec.Service.Port == 0 {
 		workload.Spec.Service.Port = workload.Spec.Service.TargetPort
+	}
+	if workload.Spec.Service.Name != "" {
+		workload.Spec.Service.Name = stringutil.NormalizeName(workload.Spec.Service.Name)
+	} else if existing := v1.GetLabel(workload, v1.ServiceNameLabel); existing != "" {
+		workload.Spec.Service.Name = existing
+	} else {
+		workload.Spec.Service.Name = workload.Name
+	}
+	if workload.Spec.Service.Name != "" {
+		v1.SetLabel(workload, v1.ServiceNameLabel, workload.Spec.Service.Name)
 	}
 	if workload.Spec.Service.Extends == nil {
 		workload.Spec.Service.Extends = make(map[string]string)
@@ -944,6 +955,11 @@ func (v *WorkloadValidator) validateCommon(ctx context.Context, newWorkload, old
 	if err = v.validateService(ctx, newWorkload); err != nil {
 		return err
 	}
+	if oldWorkload != nil && v1.IsWorkloadDispatched(newWorkload) &&
+		oldWorkload.Spec.Service != nil && newWorkload.Spec.Service != nil &&
+		commonworkload.GetK8sServiceName(oldWorkload) != commonworkload.GetK8sServiceName(newWorkload) {
+		return fmt.Errorf("service name is immutable after the workload is dispatched")
+	}
 	if err = v.validateHealthCheck(newWorkload); err != nil {
 		return err
 	}
@@ -1330,6 +1346,38 @@ func (v *WorkloadValidator) validateService(ctx context.Context, workload *v1.Wo
 	if workload.Spec.Service.ServiceType == corev1.ServiceTypeNodePort {
 		if workload.Spec.Service.NodePort <= 0 {
 			return fmt.Errorf("the nodePort is empty")
+		}
+	}
+	svcName := commonworkload.GetK8sServiceName(workload)
+	if svcName != "" {
+		if errs := validation.IsDNS1035Label(svcName); len(errs) > 0 {
+			return fmt.Errorf("invalid service name %s: %s", svcName, strings.Join(errs, ", "))
+		}
+		if err := v.validateServiceNameUnique(ctx, workload, svcName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateServiceNameUnique rejects a Service name already used by another
+// workload in the same workspace.
+func (v *WorkloadValidator) validateServiceNameUnique(ctx context.Context, workload *v1.Workload, svcName string) error {
+	if v.Client == nil || workload.Spec.Workspace == "" {
+		return nil
+	}
+	list := &v1.WorkloadList{}
+	selector := labels.SelectorFromSet(map[string]string{v1.WorkspaceIdLabel: workload.Spec.Workspace})
+	if err := v.Client.List(ctx, list, &client.ListOptions{LabelSelector: selector}); err != nil {
+		return err
+	}
+	for i := range list.Items {
+		other := &list.Items[i]
+		if other.Name == workload.Name {
+			continue
+		}
+		if commonworkload.GetK8sServiceName(other) == svcName {
+			return fmt.Errorf("the service name %s is already used by workload %s", svcName, other.Name)
 		}
 	}
 	return nil

--- a/SaFE/webhooks/pkg/workload_webhook_test.go
+++ b/SaFE/webhooks/pkg/workload_webhook_test.go
@@ -367,6 +367,55 @@ func TestWorkloadValidateService(t *testing.T) {
 	assert.NilError(t, v.validateService(context.Background(), ok))
 }
 
+// TestWorkloadValidateServiceNameDuplicate rejects a Service name already used
+// by another service-bearing workload in the same workspace.
+func TestWorkloadValidateServiceNameDuplicate(t *testing.T) {
+	scheme := newScheme(t)
+	existing := &v1.Workload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "wl-a",
+			Labels: map[string]string{
+				v1.WorkspaceIdLabel: "ws1",
+				v1.ServiceNameLabel: "shared-svc",
+			},
+		},
+		Spec: v1.WorkloadSpec{
+			Workspace: "ws1",
+			Service: &v1.Service{
+				Name: "shared-svc", Port: 80, TargetPort: 8080,
+				Protocol: corev1.ProtocolTCP, ServiceType: corev1.ServiceTypeClusterIP,
+			},
+		},
+	}
+	v := &WorkloadValidator{Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()}
+
+	dup := &v1.Workload{
+		ObjectMeta: metav1.ObjectMeta{Name: "wl-b", Labels: map[string]string{v1.WorkspaceIdLabel: "ws1"}},
+		Spec: v1.WorkloadSpec{
+			Workspace: "ws1",
+			Service: &v1.Service{
+				Name: "shared-svc", Port: 80, TargetPort: 8080,
+				Protocol: corev1.ProtocolTCP, ServiceType: corev1.ServiceTypeClusterIP,
+			},
+		},
+	}
+	err := v.validateService(context.Background(), dup)
+	assert.Assert(t, err != nil)
+	assert.ErrorContains(t, err, "already used")
+
+	otherWs := &v1.Workload{
+		ObjectMeta: metav1.ObjectMeta{Name: "wl-c", Labels: map[string]string{v1.WorkspaceIdLabel: "ws2"}},
+		Spec: v1.WorkloadSpec{
+			Workspace: "ws2",
+			Service: &v1.Service{
+				Name: "shared-svc", Port: 80, TargetPort: 8080,
+				Protocol: corev1.ProtocolTCP, ServiceType: corev1.ServiceTypeClusterIP,
+			},
+		},
+	}
+	assert.NilError(t, v.validateService(context.Background(), otherWs))
+}
+
 // TestWorkloadValidateHealthCheck verifies health check validation.
 func TestWorkloadValidateHealthCheck(t *testing.T) {
 	v := &WorkloadValidator{}

--- a/SaFE/webhooks/pkg/workload_webhook_test.go
+++ b/SaFE/webhooks/pkg/workload_webhook_test.go
@@ -7,6 +7,7 @@ package webhooks
 
 import (
 	"context"
+	"net/http"
 	"testing"
 	"time"
 
@@ -25,6 +26,7 @@ import (
 	v1 "github.com/AMD-AIG-AIMA/SAFE/apis/pkg/apis/amd/v1"
 	"github.com/AMD-AIG-AIMA/SAFE/common/pkg/common"
 	commonconfig "github.com/AMD-AIG-AIMA/SAFE/common/pkg/config"
+	commonerrors "github.com/AMD-AIG-AIMA/SAFE/common/pkg/errors"
 	"github.com/AMD-AIG-AIMA/SAFE/utils/pkg/stringutil"
 	"github.com/AMD-AIG-AIMA/SAFE/utils/pkg/timeutil"
 )
@@ -678,6 +680,46 @@ func TestWorkloadValidateFullChain(t *testing.T) {
 	v := &WorkloadValidator{Client: c}
 	assert.NilError(t, v.validateOnCreation(context.Background(), fullValidWorkload()))
 	assert.NilError(t, v.validateOnUpdate(context.Background(), fullValidWorkload(), fullValidWorkload()))
+}
+
+// TestWorkloadValidateCreationDuplicateServiceName verifies creation is denied
+// when another workload in the workspace already owns the service name.
+func TestWorkloadValidateCreationDuplicateServiceName(t *testing.T) {
+	owner := &v1.Workload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "wl-owner",
+			Labels: map[string]string{
+				v1.WorkspaceIdLabel: "ws1",
+				v1.ServiceNameLabel: "shared-svc",
+			},
+		},
+		Spec: v1.WorkloadSpec{
+			Workspace: "ws1",
+			Service:   &v1.Service{Name: "shared-svc"},
+		},
+	}
+	c := fullWorkloadEnvClient(t)
+	assert.NilError(t, c.Create(context.Background(), owner))
+
+	w := fullValidWorkload()
+	w.Name = "wl-new"
+	w.Spec.Service = &v1.Service{
+		Name: "shared-svc", Port: 80, TargetPort: 8080,
+		Protocol: corev1.ProtocolTCP, ServiceType: corev1.ServiceTypeClusterIP,
+	}
+
+	v := &WorkloadValidator{Client: c, decoder: newDecoder(t)}
+	err := v.validateOnCreation(context.Background(), w)
+	assert.Assert(t, err != nil)
+	assert.Assert(t, commonerrors.IsAlreadyExist(err))
+
+	resp := v.Handle(context.Background(), newRequest(t, admissionv1.Create, w, nil))
+	assert.Assert(t, !resp.Allowed)
+	assert.Equal(t, resp.Result.Code, int32(http.StatusConflict))
+
+	// A free name in the same workspace still passes.
+	w.Spec.Service.Name = "other-svc"
+	assert.NilError(t, v.validateOnCreation(context.Background(), w))
 }
 
 // TestWorkloadValidatorHandleFull verifies the validator handler with a complete environment.

--- a/SaFE/webhooks/pkg/workload_webhook_test.go
+++ b/SaFE/webhooks/pkg/workload_webhook_test.go
@@ -106,11 +106,61 @@ func TestWorkloadMutateHealthCheck(t *testing.T) {
 // TestWorkloadMutateService verifies service protocol and defaults.
 func TestWorkloadMutateService(t *testing.T) {
 	m := &WorkloadMutator{}
-	w := &v1.Workload{Spec: v1.WorkloadSpec{Service: &v1.Service{TargetPort: 8080}}}
-	m.mutateService(w)
+	w := &v1.Workload{
+		ObjectMeta: metav1.ObjectMeta{Name: "workload-a"},
+		Spec:       v1.WorkloadSpec{Service: &v1.Service{TargetPort: 8080}},
+	}
+	m.mutateService(nil, w)
 	assert.Equal(t, w.Spec.Service.Protocol, corev1.ProtocolTCP)
 	assert.Equal(t, w.Spec.Service.Port, 8080)
+	assert.Equal(t, w.Spec.Service.Name, "workload-a")
+	assert.Equal(t, v1.GetLabel(w, v1.ServiceNameLabel), "workload-a")
 	assert.Assert(t, w.Spec.Service.Extends != nil)
+}
+
+func TestLegacyDispatchedWorkloadAcceptsDefaultServiceNameBackfill(t *testing.T) {
+	oldWorkload := &v1.Workload{
+		ObjectMeta: metav1.ObjectMeta{Name: "legacy"},
+		Spec: v1.WorkloadSpec{
+			Service: &v1.Service{
+				Protocol: corev1.ProtocolTCP,
+				Port:     8080,
+				Extends: map[string]string{
+					"maxUnavailable": common.DefaultMaxUnavailable,
+					"maxSurge":       common.DefaultMaxMaxSurge,
+				},
+			},
+		},
+	}
+	v1.SetAnnotation(oldWorkload, v1.WorkloadDispatchedAnnotation, "now")
+	newWorkload := oldWorkload.DeepCopy()
+
+	(&WorkloadMutator{}).mutateService(oldWorkload, newWorkload)
+
+	assert.Equal(t, newWorkload.Spec.Service.Name, "legacy")
+	assert.NilError(t, (&WorkloadValidator{}).validateSpecChanged(newWorkload, oldWorkload))
+}
+
+func TestWorkloadMutateServiceNameLabelRemoval(t *testing.T) {
+	mutator := &WorkloadMutator{}
+	oldWorkload := &v1.Workload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "workload",
+			Labels: map[string]string{v1.ServiceNameLabel: "custom-service"},
+		},
+		Spec: v1.WorkloadSpec{Service: &v1.Service{Name: "custom-service"}},
+	}
+	newWorkload := oldWorkload.DeepCopy()
+	newWorkload.Spec.Service = nil
+
+	mutator.mutateService(oldWorkload, newWorkload)
+	assert.Equal(t, v1.GetLabel(newWorkload, v1.ServiceNameLabel), "")
+
+	v1.SetAnnotation(oldWorkload, v1.WorkloadDispatchedAnnotation, "now")
+	newWorkload = oldWorkload.DeepCopy()
+	newWorkload.Spec.Service = nil
+	mutator.mutateService(oldWorkload, newWorkload)
+	assert.Equal(t, v1.GetLabel(newWorkload, v1.ServiceNameLabel), "custom-service")
 }
 
 // TestWorkloadMutateDeployment verifies deployment-specific resets.


### PR DESCRIPTION
## Summary
- Add optional `spec.service.name` and stamp it on the workload as `primus-safe.service.name`.
- Dispatcher creates and updates the data-plane Service (and Ingress backend) using that name.
- The workload service API looks up the Service and builds the internal domain from the same name.

## Test plan
- [ ] Create a workload with `service.name` set and confirm the K8s Service uses that name.
- [ ] Create a workload without `service.name` and confirm it still defaults to the workload id.
- [ ] GET the workload service endpoint and check `internalDomain` matches the Service name.


Made with [Cursor](https://cursor.com)