### PR TITLE
fix(authoring): install the socat that ssh -R needs

### DIFF
--- a/SaFE/charts/primus-safe/values.yaml
+++ b/SaFE/charts/primus-safe/values.yaml
@@ -163,7 +163,8 @@ ssh:
   server_ip: ""
   # Remote port forwarding (`ssh -R` / RemoteForward). The listen socket is opened
   # inside the user's target Pod, letting Pod processes reach a proxy running on
-  # the developer's machine. Requires `socat` in the workload image.
+  # the developer's machine. The pod-side listener is a `socat`, which an Authoring pod
+  # installs at startup; other workload kinds need it in the image.
   reverse_forward:
     # On by default. Set to false where pod traffic must not be able to leave through
     # a developer's network; what keeps it contained otherwise is the rest of this

--- a/SaFE/docker/preprocess/build_authoring.sh
+++ b/SaFE/docker/preprocess/build_authoring.sh
@@ -16,6 +16,20 @@ else
   echo "openssh-server installation failed"
 fi
 
+# socat backs the Pod-side listener for `ssh -R`: the apiserver execs a
+# `socat TCP-LISTEN:<port>,bind=127.0.0.1,fork` in this container and refuses the
+# forward outright when it is absent. The workload image belongs to the user - it is
+# usually an upstream vLLM/SGLang/PyTorch image - so the platform cannot assume socat
+# is in it, any more than it assumes sshd is. Report on what is actually on PATH
+# rather than on the install's exit status: install_if_not_exists sends apt's own
+# output to /dev/null, and PATH is what the apiserver's listener script tests.
+install_if_not_exists socat
+if command -v socat >/dev/null 2>&1; then
+  echo "socat is available, ssh -R remote forwarding will work"
+else
+  echo "WARN: socat is not available, ssh -R remote forwarding will be refused"
+fi
+
 # curl is required below to fetch the AMD certificate setup script.
 install_if_not_exists curl
 

--- a/docs-site/docs/tasks/interact-with-your-job.md
+++ b/docs-site/docs/tasks/interact-with-your-job.md
@@ -119,9 +119,11 @@ Requirements and limits for `-R`:
 
 - It is on by default. A platform administrator can turn it off for a cluster with
   `ssh.reverse_forward.enable: false`, in which case `-R` is refused.
-- The workload image must contain `socat`, along with `awk`, `cat`, `date`, `grep`,
-  `mkdir`, `readlink` and `sleep` — the pod-side listener is built from them. A
-  missing one is reported by name rather than as a mysterious failure to listen.
+- The pod-side listener is built from `socat`, `awk`, `cat`, `date`, `grep`, `mkdir`,
+  `readlink` and `sleep`. An Authoring pod installs `socat` for you at startup, the way
+  it installs the SSH server; the rest are in any base image. Other workload kinds run
+  your image untouched, so there `socat` has to be in the image. Whichever is missing is
+  reported by name rather than as a mysterious failure to listen.
 - The pod-side listener may only bind `127.0.0.1`, so no other workload can use your tunnel.
 - The listen port must fall inside the configured range (`1024`–`65535` by default, so that a
   forward cannot shadow a privileged service inside your pod), and a session may hold at most 8


### PR DESCRIPTION
## What

Add `socat` to the packages an Authoring pod installs at startup, alongside the SSH server it already installs.

## Why

`ssh -R` (#726) opens its listen socket inside the user's Pod by exec'ing a `socat TCP-LISTEN:<port>,bind=127.0.0.1,fork` there, and `acceptorScript` refuses the forward by name when socat is absent.

The workload container runs the user's own image — on this cluster typically an upstream `vllm-openai-rocm` / `sglang` / PyTorch image, which has no reason to carry socat. So the first `RemoteForward` anyone tries comes back rejected. Observed live today, nine times in two hours against one Authoring pod:

```
W0901 10:37:57 reverse_forward.go:539] tcpip-forward rejected for user
  ...yihan-dev-4ftxj-master-0.pytorch.bash.control-plan-hyperloom:
  pod listener failed: socat is not installed in the container
```

The requirement was documented (`values.yaml`, `interact-with-your-job.md`) but nothing satisfied it. An Authoring pod already bootstraps its interactive tooling at startup — that is where `openssh-server` comes from — and socat belongs on the same list.

## Notes

- The verification after the install asks `command -v` rather than the installer's exit status: `install_if_not_exists` sends apt's output to `/dev/null`, and PATH is exactly what the apiserver's listener script tests.
- Scope is `WORKLOAD_KIND=Authoring` only; other workload kinds still run the image untouched, and the docs now distinguish the two cases instead of asking for socat in every image.
- No behaviour change for images that already ship socat — `install_if_not_exists` skips them.

## Test

- `sh -n` on the script; the new block exercised against the real `utils.sh` in an Authoring pod, both with socat already present and absent.
- Installing socat by hand in the affected pod and reconnecting makes `RemoteForward 127.0.0.1:7890` work, which is what this change makes automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)