### PR TITLE
feat(workload): carry the container's termination reason

### DIFF
--- a/SaFE/apis/pkg/apis/amd/v1/workload_types.go
+++ b/SaFE/apis/pkg/apis/amd/v1/workload_types.go
@@ -293,6 +293,16 @@ type WorkloadPod struct {
 type Container struct {
 	// Container name
 	Name string `json:"name"`
+	// Why the container last terminated, as the kubelet named it: OOMKilled,
+	// Error, ContainerCannotRun, DeadlineExceeded, Completed.
+	//
+	// Distinct from Message, which is free text. This is the only place OOM is
+	// stated: the pod-level status.reason that WorkloadPod.FailedMessage carries
+	// covers the kill decisions made above the container (Evicted, Preempted,
+	// NodeLost), and a container the kernel killed for memory leaves that field
+	// empty. Consumers were left inferring it from exit code 137, which is any
+	// SIGKILL and therefore also every eviction and every deliberate stop.
+	Reason string `json:"reason,omitempty"`
 	// Message regarding the last termination of the container
 	Message string `json:"message,omitempty"`
 	// Exit status from the last termination of the container

--- a/SaFE/apis/pkg/client/applyconfiguration/amd/v1/container.go
+++ b/SaFE/apis/pkg/client/applyconfiguration/amd/v1/container.go
@@ -11,6 +11,16 @@ package v1
 type ContainerApplyConfiguration struct {
 	// Container name
 	Name *string `json:"name,omitempty"`
+	// Why the container last terminated, as the kubelet named it: OOMKilled,
+	// Error, ContainerCannotRun, DeadlineExceeded, Completed.
+	//
+	// Distinct from Message, which is free text. This is the only place OOM is
+	// stated: the pod-level status.reason that WorkloadPod.FailedMessage carries
+	// covers the kill decisions made above the container (Evicted, Preempted,
+	// NodeLost), and a container the kernel killed for memory leaves that field
+	// empty. Consumers were left inferring it from exit code 137, which is any
+	// SIGKILL and therefore also every eviction and every deliberate stop.
+	Reason *string `json:"reason,omitempty"`
 	// Message regarding the last termination of the container
 	Message *string `json:"message,omitempty"`
 	// Exit status from the last termination of the container
@@ -28,6 +38,14 @@ func Container() *ContainerApplyConfiguration {
 // If called multiple times, the Name field is set to the value of the last call.
 func (b *ContainerApplyConfiguration) WithName(value string) *ContainerApplyConfiguration {
 	b.Name = &value
+	return b
+}
+
+// WithReason sets the Reason field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Reason field is set to the value of the last call.
+func (b *ContainerApplyConfiguration) WithReason(value string) *ContainerApplyConfiguration {
+	b.Reason = &value
 	return b
 }
 

--- a/SaFE/charts/primus-safe/crds/amd.com_workloads.yaml
+++ b/SaFE/charts/primus-safe/crds/amd.com_workloads.yaml
@@ -459,6 +459,18 @@ scheduling). Terminated pods (Succeeded/Failed)
                           name:
                             description: Container name
                             type: string
+                          reason:
+                            description: |-
+                              Why the container last terminated, as the kubelet named it: OOMKilled,
+                              Error, ContainerCannotRun, DeadlineExceeded, Completed.
+
+                              Distinct from Message, which is free text. This is the only place OOM is
+                              stated: the pod-level status.reason that WorkloadPod.FailedMessage carries
+                              covers the kill decisions made above the container (Evicted, Preempted,
+                              NodeLost), and a container the kernel killed for memory leaves that field
+                              empty. Consumers were left inferring it from exit code 137, which is any
+                              SIGKILL and therefore also every eviction and every deliberate stop.
+                            type: string
                         required:
                         - exitCode
                         - name

--- a/SaFE/job-manager/pkg/syncer/pod_handler.go
+++ b/SaFE/job-manager/pkg/syncer/pod_handler.go
@@ -836,6 +836,7 @@ func buildPodTerminatedInfo(ctx context.Context, clientSet kubernetes.Interface,
 		}
 		c := v1.Container{
 			Name:     container.Name,
+			Reason:   terminated.Reason,
 			ExitCode: terminated.ExitCode,
 			Message:  terminated.Message,
 		}

--- a/SaFE/job-manager/pkg/syncer/pod_handler_test.go
+++ b/SaFE/job-manager/pkg/syncer/pod_handler_test.go
@@ -411,6 +411,54 @@ func TestBuildPodTerminatedInfoSucceeded(t *testing.T) {
 	assert.Assert(t, wp.EndTime != "")
 }
 
+// A container the kernel killed for memory is the case the pod-level reason
+// cannot describe: status.reason carries the kill decisions made *above* the
+// container (Evicted, Preempted, NodeLost) and is empty for an OOM, so consumers
+// were left inferring it from exit code 137 -- which is any SIGKILL, and therefore
+// also every eviction and every deliberate stop.
+func TestBuildPodTerminatedInfoCarriesContainerReason(t *testing.T) {
+	w := &v1.Workload{}
+	pod := &corev1.Pod{Status: corev1.PodStatus{
+		Phase: corev1.PodFailed,
+		ContainerStatuses: []corev1.ContainerStatus{{
+			Name: "main",
+			State: corev1.ContainerState{
+				Terminated: &corev1.ContainerStateTerminated{
+					Reason:   "OOMKilled",
+					ExitCode: 137,
+					Message:  "",
+				},
+			},
+		}},
+	}}
+	wp := &v1.WorkloadPod{}
+	buildPodTerminatedInfo(context.Background(), nil, w, pod, wp, "main")
+	assert.Equal(t, len(wp.Containers), 1)
+	assert.Equal(t, wp.Containers[0].Reason, "OOMKilled")
+	assert.Equal(t, wp.Containers[0].ExitCode, int32(137))
+	// The pod-level field says nothing here, which is exactly why the container
+	// one had to be carried.
+	assert.Equal(t, wp.FailedMessage, "")
+}
+
+// The ordinary case still reports its reason, so a consumer can tell "the process
+// exited badly" from "something killed it" without a second source.
+func TestBuildPodTerminatedInfoCarriesOrdinaryReason(t *testing.T) {
+	w := &v1.Workload{}
+	pod := &corev1.Pod{Status: corev1.PodStatus{
+		Phase: corev1.PodFailed,
+		ContainerStatuses: []corev1.ContainerStatus{{
+			Name: "main",
+			State: corev1.ContainerState{
+				Terminated: &corev1.ContainerStateTerminated{Reason: "Error", ExitCode: 1},
+			},
+		}},
+	}}
+	wp := &v1.WorkloadPod{}
+	buildPodTerminatedInfo(context.Background(), nil, w, pod, wp, "main")
+	assert.Equal(t, wp.Containers[0].Reason, "Error")
+}
+
 func TestGenerateStickyFault(t *testing.T) {
 	// Empty node id -> nil fault, no error.
 	f, err := generateStickyFault(&v1.Workload{}, "", syncerScheme(t))


### PR DESCRIPTION
## Summary

`WorkloadPod.Containers` reports a container's message and exit code and drops
the one field that says why it ended: `state.terminated.reason`. This adds it.

That field is the only place an OOM is stated. The pod-level `status.reason`
already carried in `WorkloadPod.FailedMessage` covers the kill decisions made
*above* the container — `Evicted`, `Preempted`, `NodeLost` — and is empty when
the kernel killed a container for memory. A consumer trying to tell an
out-of-memory run from a preempted one therefore had only exit code 137, which
is any SIGKILL and so is also every eviction and every deliberate stop.

The caller is the dispatch control plane above Claw, which classifies how a run
ended so that a node reclaim is not charged to the model that happened to be
running on it. Without this field an OOM is a guess; with it, it is a reading.

One field, one assignment, four lines of schema:

```go
// SaFE/apis/pkg/apis/amd/v1/workload_types.go
type Container struct {
	Name     string `json:"name"`
	Reason   string `json:"reason,omitempty"`   // new
	Message  string `json:"message,omitempty"`
	ExitCode int32  `json:"exitCode"`
}
```

`omitempty`, and not added to the CRD's `required` list, so nothing that reads a
`Container` today has to change.

## Generated files

`applyconfiguration/amd/v1/container.go` and
`charts/primus-safe/crds/amd.com_workloads.yaml` are generated. They were written
by hand first and then checked against the real generators:

```
SaFE/apis   $ bash hack/update-codegen.sh     # deepcopy, applyconfig, client, lister, informer
SaFE/charts $ make manifests                  # controller-gen v0.17.2
```

Both reproduce the committed files **byte for byte** and modify nothing else —
`git status` is clean afterwards. So the two generated files in this diff are
exactly what CI would produce, and re-running codegen on top of this branch is a
no-op.

## Testing

```
SaFE/job-manager $ go test -gcflags=all=-l ./pkg/syncer/...
ok  	github.com/AMD-AIG-AIMA/SAFE/job-manager/pkg/syncer
```

Two new cases in `pod_handler_test.go`: a container the kubelet reports as
`OOMKilled`, and an ordinary `Error`, each asserting the reason arrives on
`WorkloadPod.Containers[0].Reason`. Both were confirmed to actually bite by
deleting the `Reason: terminated.Reason` assignment and watching them fail.

Note for reviewers on the local build: `go build ./SaFE/job-manager/...` from the
repository root fails on a `structured-merge-diff` v4/v6 mismatch inside
`k8s.io/apimachinery@v0.32.5`. That reproduces identically on `origin/main` with
no changes applied, so it is pre-existing and unrelated to this PR; running from
inside `SaFE/job-manager` — the way the `unit-test` workflow does — resolves
correctly and passes.

## Risk

Additive only. No field renamed, removed, or made required; no behaviour changes
for any existing consumer. A cluster running an older CRD simply drops the
unknown field until the chart is upgraded, and readers that never look at
`Reason` see an empty string, which is what they would have seen anyway on a
platform that does not report one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
