### PR TITLE
feat(web): add Resume to Infera and Dynamo workloads

### DIFF
--- a/Web/apps/safe/src/assets/main.css
+++ b/Web/apps/safe/src/assets/main.css
@@ -202,6 +202,15 @@ $btn-colors: (
 }
 
 /* **********操作栏-三个折叠+展开pop按钮样式****************** */
+/* Row action buttons. Each inline action is wrapped in a span because a native
+   disabled button never fires the hover el-tooltip listens for, which left a
+   greyed-out action unable to say why it is unavailable. Those wrappers break
+   the .el-button+.el-button sibling margin, so spacing comes from gap instead. */
+.action-cell {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
 .actions-menu {
   padding: 6px 0;
 }

--- a/Web/apps/safe/src/components/Workload/WorkloadHeader.vue
+++ b/Web/apps/safe/src/components/Workload/WorkloadHeader.vue
@@ -107,13 +107,13 @@
 
           <el-tooltip
             v-if="showResumeButton"
-            :content="detailData?.phase !== 'Stopped' ? 'Already running' : 'Resume'"
+            :content="canResumePhase ? 'Resume' : 'Resume is unavailable for this workload state'"
             placement="top"
           >
             <el-button
               circle
               class="glass-btn glass-btn--success"
-              :disabled="!['Stopped','Failed','Succeeded'].includes(detailData?.phase)"
+              :disabled="!canResumePhase"
               @click="emit('resume')"
             >
               <el-icon><VideoPlay /></el-icon>
@@ -191,6 +191,7 @@ import {
   Edit,
 } from '@element-plus/icons-vue'
 import { WorkloadPhaseButtonType } from '@/services'
+import { RESUMABLE_PHASES } from '@/composables/useWorkloadResumePermission'
 import { copyText, formatTimeStr } from '@/utils'
 import { useDark } from '@vueuse/core'
 import { useRouter } from 'vue-router'
@@ -249,6 +250,10 @@ const showResumeButton = computed(() => {
   const noResumeKinds = ['PyTorchJob', 'TorchFT', 'RayJob']
   return !noResumeKinds.includes(kind ?? '')
 })
+
+// Shares the phase whitelist with the list-page action so the button state and
+// its tooltip cannot disagree.
+const canResumePhase = computed(() => RESUMABLE_PHASES.includes(props.detailData?.phase ?? ''))
 
 const handleBack = () => {
   emit('back')

--- a/Web/apps/safe/src/composables/useWorkloadResumePermission.ts
+++ b/Web/apps/safe/src/composables/useWorkloadResumePermission.ts
@@ -8,7 +8,7 @@ type ResumePermissionRow = {
   userId?: string
 }
 
-const RESUMABLE_PHASES = ['Stopped', 'Failed', 'Succeeded']
+export const RESUMABLE_PHASES = ['Stopped', 'Failed', 'Succeeded']
 
 export function useWorkloadResumePermission(canWrite?: MaybeRefOrGetter<boolean>) {
   const userStore = useUserStore()

--- a/Web/apps/safe/src/pages/Authoring/index.vue
+++ b/Web/apps/safe/src/pages/Authoring/index.vue
@@ -222,53 +222,57 @@
 
         <el-table-column label="Actions" width="180" fixed="right">
           <template #default="{ row }">
-            <!-- First 2 inline actions -->
-            <template v-for="act in getActions(row).slice(0, 2)" :key="act.key">
-              <el-tooltip :content="act.tooltip?.(row) ?? act.label" placement="top">
-                <el-button
-                  circle
-                  size="default"
-                  :class="act.btnClass"
-                  :icon="act.icon"
-                  :disabled="act.disabled?.(row) ?? false"
-                  @click="act.onClick(row)"
-                />
-              </el-tooltip>
-            </template>
-
-            <el-popover
-              v-if="getActions(row).length > 2"
-              placement="bottom-start"
-              trigger="click"
-              :width="240"
-              :teleported="true"
-              :enterable="true"
-              popper-class="actions-menu"
-              :visible="moreOpenId === row.workloadId"
-              @hide="moreOpenId === row.workloadId && (moreOpenId = null)"
-            >
-              <template #reference>
-                <el-button
-                  circle
-                  class="btn-primary-plain"
-                  :icon="MoreFilled"
-                  size="default"
-                  @click.stop="toggleMore(row.workloadId)"
-                />
+            <div class="action-cell">
+              <!-- First 2 inline actions -->
+              <template v-for="act in getActions(row).slice(0, 2)" :key="act.key">
+                <el-tooltip :content="act.tooltip?.(row) ?? act.label" placement="top">
+                  <span>
+                    <el-button
+                      circle
+                      size="default"
+                      :class="act.btnClass"
+                      :icon="act.icon"
+                      :disabled="act.disabled?.(row) ?? false"
+                      @click="act.onClick(row)"
+                    />
+                  </span>
+                </el-tooltip>
               </template>
 
-              <ul class="menu-col">
-                <li
-                  v-for="act in getActions(row).slice(2)"
-                  :key="act.key"
-                  :class="['menu-item', { disabled: act.disabled?.(row) }]"
-                  @click.stop="handleMenuClick(act, row)"
-                >
-                  <component :is="act.icon" class="menu-ico" />
-                  <span class="menu-label">{{ act.label }}</span>
-                </li>
-              </ul>
-            </el-popover>
+              <el-popover
+                v-if="getActions(row).length > 2"
+                placement="bottom-start"
+                trigger="click"
+                :width="240"
+                :teleported="true"
+                :enterable="true"
+                popper-class="actions-menu"
+                :visible="moreOpenId === row.workloadId"
+                @hide="moreOpenId === row.workloadId && (moreOpenId = null)"
+              >
+                <template #reference>
+                  <el-button
+                    circle
+                    class="btn-primary-plain"
+                    :icon="MoreFilled"
+                    size="default"
+                    @click.stop="toggleMore(row.workloadId)"
+                  />
+                </template>
+
+                <ul class="menu-col">
+                  <li
+                    v-for="act in getActions(row).slice(2)"
+                    :key="act.key"
+                    :class="['menu-item', { disabled: act.disabled?.(row) }]"
+                    @click.stop="handleMenuClick(act, row)"
+                  >
+                    <component :is="act.icon" class="menu-ico" />
+                    <span class="menu-label">{{ act.label }}</span>
+                  </li>
+                </ul>
+              </el-popover>
+            </div>
           </template>
         </el-table-column>
       </el-table>

--- a/Web/apps/safe/src/pages/Dynamo/Components/AddDialog.test.ts
+++ b/Web/apps/safe/src/pages/Dynamo/Components/AddDialog.test.ts
@@ -50,4 +50,9 @@ describe('Dynamo/Infera AddDialog', () => {
   it('does not keep unreachable Infera entrypoint preview code in the Dynamo-only section', () => {
     expect(dialogSource).not.toContain('inferaBackendEntrySections')
   })
+
+  it('resumes the original workload id instead of submitting a new workload', () => {
+    expect(dialogSource).toContain('resumeWorkload(props.wlid, payload)')
+    expect(dialogSource).toContain(':disabled="isEdit || isResume"')
+  })
 })

--- a/Web/apps/safe/src/pages/Dynamo/Components/AddDialog.vue
+++ b/Web/apps/safe/src/pages/Dynamo/Components/AddDialog.vue
@@ -31,7 +31,7 @@
           <el-row :gutter="16">
             <el-col :span="16">
               <el-form-item label="name" prop="displayName">
-                <el-input v-model="form.displayName" :disabled="isEdit" />
+                <el-input v-model="form.displayName" :disabled="isEdit || isResume" />
               </el-form-item>
             </el-col>
             <el-col :span="8">
@@ -424,7 +424,7 @@ import { computed, reactive, ref, watch } from 'vue'
 import { type FormInstance, type FormRules, ElMessage } from 'element-plus'
 import ImageInput from '@/components/Base/ImageInput.vue'
 import KeyValueList from '@/components/Base/KeyValueList.vue'
-import { addWorkload, editWorkload, getWorkloadDetail } from '@/services/workload'
+import { addWorkload, editWorkload, getWorkloadDetail, resumeWorkload } from '@/services/workload'
 import { useWorkspaceStore } from '@/stores/workspace'
 import { useUserStore } from '@/stores/user'
 import { ArrowRight, InfoFilled } from '@element-plus/icons-vue'
@@ -486,6 +486,7 @@ const store = useWorkspaceStore()
 const userStore = useUserStore()
 const isManager = computed(() => userStore.isManager)
 const isEdit = computed(() => props.action === 'Edit')
+const isResume = computed(() => props.action === 'Resume')
 const isInfera = computed(() => props.workloadType === 'infera')
 const workloadLabel = computed(() => (isInfera.value ? 'Infera' : 'Dynamo'))
 const workloadDefaultName = computed(() => (isInfera.value ? 'infera' : 'dynamo'))
@@ -757,6 +758,11 @@ const onSubmit = async (formEl: FormInstance | undefined) => {
       const { workspaceId: _workspaceId, displayName: _displayName, groupVersionKind: _gvk, ...editPayload } = payload
       await editWorkload(props.wlid, editPayload)
       ElMessage.success('Edit successful')
+    } else if (isResume.value) {
+      // Resume restarts the original workload id rather than creating a new one.
+      if (!props.wlid) return
+      await resumeWorkload(props.wlid, payload)
+      ElMessage.success('Resume successful')
     } else {
       await addWorkload(payload)
       ElMessage.success(`${props.action} successful`)

--- a/Web/apps/safe/src/pages/Dynamo/DynamoDetail.vue
+++ b/Web/apps/safe/src/pages/Dynamo/DynamoDetail.vue
@@ -4,6 +4,7 @@
     :detail-data="detailData"
     hide-edit
     @clone="onClone"
+    @resume="onResume"
     @delete="onDelete"
     @stop="onStop"
   />
@@ -136,7 +137,7 @@
     :wlid="workloadId"
     :action="addAction"
     :workload-type="props.workloadType"
-    @success="router.push(workloadConfig.listPath)"
+    @success="onDialogSuccess"
   />
   <SshConfigDialog
     v-model:visible="sshVisible"
@@ -193,7 +194,7 @@ const { canWrite } = useWorkloadWriteGuard()
 
 const activeTab = ref('overview')
 const addVisible = ref(false)
-const addAction = ref<'Clone'>('Clone')
+const addAction = ref<'Clone' | 'Resume'>('Clone')
 
 interface ServiceData {
   type?: string
@@ -287,6 +288,21 @@ const roleRows = computed(() => {
 const onClone = () => {
   addAction.value = 'Clone'
   addVisible.value = true
+}
+
+const onResume = () => {
+  addAction.value = 'Resume'
+  addVisible.value = true
+}
+
+const onDialogSuccess = () => {
+  // Resume restarts this same workload id, so stay here and refetch instead of
+  // bouncing to the list like Clone does.
+  if (addAction.value === 'Resume') {
+    getDetail()
+    return
+  }
+  router.push(workloadConfig.value.listPath)
 }
 
 const refreshPods = async () => {

--- a/Web/apps/safe/src/pages/Dynamo/index.vue
+++ b/Web/apps/safe/src/pages/Dynamo/index.vue
@@ -236,9 +236,11 @@ import {
   Refresh,
   Search,
   Timer,
+  VideoPlay,
 } from '@element-plus/icons-vue'
 import ResetIcon from '@/components/icons/ResetIcon.vue'
 import { useWorkloadWriteGuard } from '@/composables/useWorkloadWriteGuard'
+import { useWorkloadResumePermission } from '@/composables/useWorkloadResumePermission'
 import { useWorkloadListQuery } from '@/composables/useWorkloadListQuery'
 import { useWorkspaceStore } from '@/stores/workspace'
 import { useUserStore } from '@/stores/user'
@@ -263,6 +265,8 @@ dayjs.extend(utc)
 
 defineOptions({ name: 'dynamoPage' })
 
+const RESUME_COOLDOWN_SECONDS = 15
+
 const props = withDefaults(defineProps<{
   workloadType?: 'dynamo' | 'infera'
 }>(), {
@@ -286,6 +290,7 @@ const workloadConfig = computed(() =>
 const store = useWorkspaceStore()
 const userStore = useUserStore()
 const { canWrite } = useWorkloadWriteGuard()
+const { getResumeDisabled, getResumeTooltip } = useWorkloadResumePermission(canWrite)
 const tableRef = ref()
 const isDark = useDark()
 
@@ -307,7 +312,11 @@ interface DynamoRow {
   phase?: string
   priority?: number
   creationTime?: string
+  endTime?: string
   secondsUntilTimeout?: number
+  workspaceId?: string
+  workspace?: string
+  userId?: string
   resources?: Array<{ replica?: number | string }>
   dynamoOptions?: {
     serviceRoles?: string[]
@@ -353,7 +362,7 @@ const { readQuery, writeQuery, syncUserId } = useWorkloadListQuery({
 
 const addVisible = ref(false)
 const curWlId = ref('')
-const curAction = ref<'Create' | 'Clone'>('Create')
+const curAction = ref<'Create' | 'Clone' | 'Resume'>('Create')
 const tableHeight = computed(() => 'calc(100vh / var(--zoom) - 245px)')
 const moreOpenId = ref<string | null>(null)
 
@@ -365,6 +374,19 @@ const openCreate = () => {
 
 const openClone = (row: DynamoRow) => {
   curAction.value = 'Clone'
+  curWlId.value = row.workloadId
+  addVisible.value = true
+}
+
+const openResume = (row: DynamoRow) => {
+  // The backend rejects a resume that lands too soon after the stop it follows.
+  if (row.endTime && dayjs().diff(dayjs.utc(row.endTime), 'second') < RESUME_COOLDOWN_SECONDS) {
+    ElMessage.warning(
+      `Please wait ${RESUME_COOLDOWN_SECONDS} seconds after stopping before resuming the workload.`,
+    )
+    return
+  }
+  curAction.value = 'Resume'
   curWlId.value = row.workloadId
   addVisible.value = true
 }
@@ -471,6 +493,17 @@ type Action = {
 }
 
 const getActions = (_row: DynamoRow): Action[] => [
+  // Resume leads the action row so the phase-gated restart keeps one of the two
+  // inline slots instead of being pushed under the "..." menu by Clone/Stop.
+  {
+    key: 'resume',
+    label: 'Resume',
+    icon: VideoPlay,
+    btnClass: 'btn-primary-plain',
+    disabled: getResumeDisabled,
+    tooltip: getResumeTooltip,
+    onClick: (row) => openResume(row),
+  },
   {
     key: 'clone',
     label: 'Clone',

--- a/Web/apps/safe/src/pages/Dynamo/index.vue
+++ b/Web/apps/safe/src/pages/Dynamo/index.vue
@@ -148,52 +148,56 @@
         </el-table-column>
         <el-table-column label="Actions" width="180" fixed="right">
           <template #default="{ row }">
-            <template v-for="act in getActions(row).slice(0, 2)" :key="act.key">
-              <el-tooltip :content="act.tooltip?.(row) ?? act.label" placement="top">
-                <el-button
-                  circle
-                  size="default"
-                  :class="act.btnClass"
-                  :icon="act.icon"
-                  :disabled="act.disabled?.(row) ?? false"
-                  @click="act.onClick(row)"
-                />
-              </el-tooltip>
-            </template>
-
-            <el-popover
-              v-if="getActions(row).length > 2"
-              placement="bottom-start"
-              trigger="click"
-              :width="240"
-              :teleported="true"
-              :enterable="true"
-              popper-class="actions-menu"
-              :visible="moreOpenId === row.workloadId"
-              @hide="moreOpenId === row.workloadId && (moreOpenId = null)"
-            >
-              <template #reference>
-                <el-button
-                  circle
-                  class="btn-primary-plain"
-                  :icon="MoreFilled"
-                  size="default"
-                  @click.stop="toggleMore(row.workloadId)"
-                />
+            <div class="action-cell">
+              <template v-for="act in getActions(row).slice(0, 2)" :key="act.key">
+                <el-tooltip :content="act.tooltip?.(row) ?? act.label" placement="top">
+                  <span>
+                    <el-button
+                      circle
+                      size="default"
+                      :class="act.btnClass"
+                      :icon="act.icon"
+                      :disabled="act.disabled?.(row) ?? false"
+                      @click="act.onClick(row)"
+                    />
+                  </span>
+                </el-tooltip>
               </template>
 
-              <ul class="menu-col">
-                <li
-                  v-for="act in getActions(row).slice(2)"
-                  :key="act.key"
-                  :class="['menu-item', { disabled: act.disabled?.(row) }]"
-                  @click.stop="handleMenuClick(act, row)"
-                >
-                  <component :is="act.icon" class="menu-ico" />
-                  <span class="menu-label">{{ act.label }}</span>
-                </li>
-              </ul>
-            </el-popover>
+              <el-popover
+                v-if="getActions(row).length > 2"
+                placement="bottom-start"
+                trigger="click"
+                :width="240"
+                :teleported="true"
+                :enterable="true"
+                popper-class="actions-menu"
+                :visible="moreOpenId === row.workloadId"
+                @hide="moreOpenId === row.workloadId && (moreOpenId = null)"
+              >
+                <template #reference>
+                  <el-button
+                    circle
+                    class="btn-primary-plain"
+                    :icon="MoreFilled"
+                    size="default"
+                    @click.stop="toggleMore(row.workloadId)"
+                  />
+                </template>
+
+                <ul class="menu-col">
+                  <li
+                    v-for="act in getActions(row).slice(2)"
+                    :key="act.key"
+                    :class="['menu-item', { disabled: act.disabled?.(row) }]"
+                    @click.stop="handleMenuClick(act, row)"
+                  >
+                    <component :is="act.icon" class="menu-ico" />
+                    <span class="menu-label">{{ act.label }}</span>
+                  </li>
+                </ul>
+              </el-popover>
+            </div>
           </template>
         </el-table-column>
       </el-table>

--- a/Web/apps/safe/src/pages/Infer/index.vue
+++ b/Web/apps/safe/src/pages/Infer/index.vue
@@ -235,53 +235,57 @@
 
         <el-table-column label="Actions" width="180" fixed="right">
           <template #default="{ row }">
-            <!-- First 2 inline actions -->
-            <template v-for="act in getActions(row).slice(0, 2)" :key="act.key">
-              <el-tooltip :content="act.tooltip?.(row) ?? act.label" placement="top">
-                <el-button
-                  circle
-                  size="default"
-                  :class="act.btnClass"
-                  :icon="act.icon"
-                  :disabled="act.disabled?.(row) ?? false"
-                  @click="act.onClick(row)"
-                />
-              </el-tooltip>
-            </template>
-
-            <el-popover
-              v-if="getActions(row).length > 2"
-              placement="bottom-start"
-              trigger="click"
-              :width="240"
-              :teleported="true"
-              :enterable="true"
-              popper-class="actions-menu"
-              :visible="moreOpenId === row.workloadId"
-              @hide="moreOpenId === row.workloadId && (moreOpenId = null)"
-            >
-              <template #reference>
-                <el-button
-                  circle
-                  class="btn-primary-plain"
-                  :icon="MoreFilled"
-                  size="default"
-                  @click.stop="toggleMore(row.workloadId)"
-                />
+            <div class="action-cell">
+              <!-- First 2 inline actions -->
+              <template v-for="act in getActions(row).slice(0, 2)" :key="act.key">
+                <el-tooltip :content="act.tooltip?.(row) ?? act.label" placement="top">
+                  <span>
+                    <el-button
+                      circle
+                      size="default"
+                      :class="act.btnClass"
+                      :icon="act.icon"
+                      :disabled="act.disabled?.(row) ?? false"
+                      @click="act.onClick(row)"
+                    />
+                  </span>
+                </el-tooltip>
               </template>
 
-              <ul class="menu-col">
-                <li
-                  v-for="act in getActions(row).slice(2)"
-                  :key="act.key"
-                  :class="['menu-item', { disabled: act.disabled?.(row) }]"
-                  @click.stop="handleMenuClick(act, row)"
-                >
-                  <component :is="act.icon" class="menu-ico" />
-                  <span class="menu-label">{{ act.label }}</span>
-                </li>
-              </ul>
-            </el-popover>
+              <el-popover
+                v-if="getActions(row).length > 2"
+                placement="bottom-start"
+                trigger="click"
+                :width="240"
+                :teleported="true"
+                :enterable="true"
+                popper-class="actions-menu"
+                :visible="moreOpenId === row.workloadId"
+                @hide="moreOpenId === row.workloadId && (moreOpenId = null)"
+              >
+                <template #reference>
+                  <el-button
+                    circle
+                    class="btn-primary-plain"
+                    :icon="MoreFilled"
+                    size="default"
+                    @click.stop="toggleMore(row.workloadId)"
+                  />
+                </template>
+
+                <ul class="menu-col">
+                  <li
+                    v-for="act in getActions(row).slice(2)"
+                    :key="act.key"
+                    :class="['menu-item', { disabled: act.disabled?.(row) }]"
+                    @click.stop="handleMenuClick(act, row)"
+                  >
+                    <component :is="act.icon" class="menu-ico" />
+                    <span class="menu-label">{{ act.label }}</span>
+                  </li>
+                </ul>
+              </el-popover>
+            </div>
           </template>
         </el-table-column>
       </el-table>


### PR DESCRIPTION
﻿## What

Adds the Resume action to **Infera** and **Dynamo** workloads, matching what Authoring and Infer already have: click Resume, adjust the config in the create drawer, and submit — the original workload id is restarted via `POST /workloads/{id}/resume` rather than a new workload being created.

`Infera/index.vue` and `InferaDetail.vue` are thin wrappers around the Dynamo components, so all changes live under `pages/Dynamo` and cover both products.

## Why

Infera and Dynamo were the only resumable workload kinds with no Resume action. Worse, `WorkloadHeader.showResumeButton` only excludes PyTorchJob / TorchFT / RayJob, so the Dynamo/Infera **detail page already rendered a Resume button that emitted into nothing** — `DynamoDetail.vue` never bound `@resume`.

## Changes

**`pages/Dynamo/index.vue`** (list, shared by Dynamo + Infera)
- New `resume` action, placed first because the template only renders the first two actions inline and pushes the rest under the "..." menu. Same ordering as Infer.
- Reuses `useWorkloadResumePermission` for the disabled state and tooltip (phase must be Stopped/Failed/Succeeded, and the user must be a manager, workspace admin, or the workload owner).
- Reuses the post-stop cooldown guard from Authoring/Infer, since the backend rejects a resume that lands too soon after the stop it follows.
- `DynamoRow` gains `endTime` / `workspaceId` / `workspace` / `userId`, which the permission check and cooldown guard read.

**`pages/Dynamo/Components/AddDialog.vue`**
- `isResume` computed; name field is disabled for Resume because the original workload id is reused.
- Submit routes to `resumeWorkload(props.wlid, payload)`. The payload still comes from `buildInferaCreatePayload` / `buildDynamoCreatePayload`, so there is no second submission-building code path.

**`pages/Dynamo/DynamoDetail.vue`**
- Binds `@resume` to the same drawer, fixing the dead button.
- `@success` now branches: Clone navigates to the list as before, Resume stays on the page and refetches, since it targets this same workload id.

**`WorkloadHeader.vue` + `useWorkloadResumePermission.ts`** (second commit)
- The Resume tooltip only special-cased `Stopped`, so a Failed or Succeeded workload showed "Already running" over a button that was actually enabled. `RESUMABLE_PHASES` is now exported from the composable and drives both the disabled state and the tooltip. Affects the Authoring / Infer / CICD detail pages too.

## Verification

- `npm run type-check` (`vue-tsc --build`) — clean
- `npx oxlint <changed files> -D correctness` — 0 warnings, 0 errors
- `npm run test` — 127 passed. Added one case to the existing `Dynamo/Components/AddDialog.test.ts` (following its source-assertion style) pinning the resume wiring, since that is exactly what silently rotted on the detail page.

Not yet exercised against a live cluster — worth a manual pass on a stopped Infera workload before merge.
