### PR TITLE
Watch the current node instead of polling node status

### DIFF
--- a/SaFE/node-agent/pkg/node/node.go
+++ b/SaFE/node-agent/pkg/node/node.go
@@ -39,6 +39,9 @@ var (
 	// WATCH_TIMEOUT_SECONDS bounds a single watch so a stalled connection is
 	// torn down and the cache is refreshed from a new Get.
 	WATCH_TIMEOUT_SECONDS int64 = 300
+	// WATCH_CLOSE_WARN_COUNT raises the log level after this many watches
+	// close without delivering an event.
+	WATCH_CLOSE_WARN_COUNT = 3
 )
 
 // Node represents a Kubernetes node with additional functionality for monitoring and updating node status
@@ -89,14 +92,28 @@ func (n *Node) Start() error {
 
 // update watches the current node and reconnects after watch failures.
 func (n *Node) update() {
+	consecutiveImmediate := 0
 	for {
 		if n.ctx.Err() != nil {
 			n.logWatcherStop()
 			return
 		}
-		if err := n.watchK8sNode(); err != nil && n.ctx.Err() == nil {
-			klog.ErrorS(err, "failed to watch k8s node")
+		immediateClose, err := n.watchK8sNode()
+		if n.ctx.Err() != nil {
+			n.logWatcherStop()
+			return
 		}
+		if err == nil {
+			if immediateClose {
+				consecutiveImmediate++
+			} else {
+				consecutiveImmediate = 0
+			}
+			n.logWatchClosed(immediateClose, consecutiveImmediate)
+			continue
+		}
+		consecutiveImmediate = 0
+		klog.ErrorS(err, "failed to watch k8s node")
 		select {
 		case <-n.ctx.Done():
 			n.logWatcherStop()
@@ -104,6 +121,14 @@ func (n *Node) update() {
 		case <-time.After(WATCH_RETRY_INTERVAL):
 		}
 	}
+}
+
+func (n *Node) logWatchClosed(immediateClose bool, consecutive int) {
+	if immediateClose && consecutive >= WATCH_CLOSE_WARN_COUNT {
+		klog.InfoS("node watch closed immediately, reconnecting", "consecutive", consecutive)
+		return
+	}
+	klog.V(4).InfoS("node watch closed, reconnecting")
 }
 
 func (n *Node) logWatcherStop() {
@@ -115,9 +140,11 @@ func (n *Node) logWatcherStop() {
 }
 
 // watchK8sNode watches only the current node and updates the local cache.
-func (n *Node) watchK8sNode() error {
+// A clean close with no events returns immediateClose so the caller can reconnect
+// without waiting; a close after at least one event is the expected timeout.
+func (n *Node) watchK8sNode() (immediateClose bool, err error) {
 	if err := n.syncK8sNode(); err != nil {
-		return err
+		return false, err
 	}
 
 	n.mu.Lock()
@@ -132,22 +159,23 @@ func (n *Node) watchK8sNode() error {
 		TimeoutSeconds:  &timeout,
 	})
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer watcher.Stop()
 
+	sawEvent := false
 	for {
 		select {
 		case <-n.ctx.Done():
-			return n.ctx.Err()
+			return false, n.ctx.Err()
 		case event, ok := <-watcher.ResultChan():
 			if !ok {
-				klog.V(4).InfoS("node watch closed, reconnecting")
-				return nil
+				return !sawEvent, nil
 			}
 			if err := n.applyWatchEvent(event); err != nil {
-				return err
+				return false, err
 			}
+			sawEvent = true
 		}
 	}
 }

--- a/SaFE/node-agent/pkg/node/node.go
+++ b/SaFE/node-agent/pkg/node/node.go
@@ -241,7 +241,7 @@ func (n *Node) applyWatchEvent(event watch.Event) error {
 		if !ok || node == nil {
 			return fmt.Errorf("unexpected watch object: %T", event.Object)
 		}
-		n.setK8sNode(node)
+		n.setK8sNodeIfNewer(node)
 	case watch.Deleted:
 		klog.InfoS("watched node was deleted")
 	case watch.Error:
@@ -309,20 +309,18 @@ func (n *Node) UpdateConditions(conditions []corev1.NodeCondition) error {
 		if k8sNode == nil {
 			return fmt.Errorf("please initialize node first")
 		}
-		sentResourceVersion := k8sNode.ResourceVersion
 		k8sNode.Status.Conditions = conditions
 
 		node, updateErr := n.k8sClient.Nodes().UpdateStatus(n.ctx, k8sNode, metav1.UpdateOptions{})
 		if updateErr != nil {
 			if apierrors.IsConflict(updateErr) {
-				// refresh node
 				if err = n.syncK8sNode(); err != nil {
 					return err
 				}
 			}
 			return updateErr
 		}
-		n.setK8sNodeIfUnchanged(sentResourceVersion, node)
+		n.setK8sNodeIfNewer(node)
 		return nil
 	})
 
@@ -345,7 +343,7 @@ func (n *Node) updateNodeStartTime(startTime time.Time) error {
 	if err != nil {
 		return client.IgnoreNotFound(err)
 	}
-	n.setK8sNodeIfUnchanged(k8sNode.ResourceVersion, patched)
+	n.setK8sNodeIfNewer(patched)
 	return nil
 }
 
@@ -376,22 +374,43 @@ func (n *Node) setK8sNode(node *corev1.Node) {
 	n.k8sNode = node.DeepCopy()
 }
 
-// setK8sNodeIfUnchanged stores an API response only when the cache still holds
-// the resource version the request was built from. A watch event applied while
-// the request was in flight is newer and must not be rolled back.
-func (n *Node) setK8sNodeIfUnchanged(expectedResourceVersion string, node *corev1.Node) bool {
+// setK8sNodeIfNewer stores node unless its resource version is older than the
+// cache. Equality is not an ordering: a delayed watch event and a GET or
+// UpdateStatus response can both differ from the cached value, and only a
+// numeric compare tells which one should win.
+func (n *Node) setK8sNodeIfNewer(node *corev1.Node) bool {
 	if node == nil {
 		return false
 	}
 	n.mu.Lock()
 	defer n.mu.Unlock()
-	if n.k8sNode != nil && n.k8sNode.ResourceVersion != expectedResourceVersion {
-		klog.V(4).InfoS("skip stale node response",
-			"cached", n.k8sNode.ResourceVersion, "expected", expectedResourceVersion)
+	if n.k8sNode != nil && resourceVersionOlder(node.ResourceVersion, n.k8sNode.ResourceVersion) {
+		klog.V(4).InfoS("skip older node object",
+			"cached", n.k8sNode.ResourceVersion, "incoming", node.ResourceVersion)
 		return false
 	}
 	n.k8sNode = node.DeepCopy()
 	return true
+}
+
+// resourceVersionOlder reports whether incoming is behind cached. apiserver
+// resource versions are decimal etcd revisions, so "9" is older than "10".
+func resourceVersionOlder(incoming, cached string) bool {
+	if incoming == cached {
+		return false
+	}
+	if incoming == "" {
+		return cached != ""
+	}
+	if cached == "" {
+		return false
+	}
+	in, errIn := strconv.ParseUint(incoming, 10, 64)
+	ca, errCa := strconv.ParseUint(cached, 10, 64)
+	if errIn != nil || errCa != nil {
+		return false
+	}
+	return in < ca
 }
 
 // IsMatchGpuChip checks if the node's GPU chip matches the specified chip type.
@@ -471,7 +490,7 @@ func (n *Node) syncK8sNode() error {
 		klog.ErrorS(err, "failed to get k8s node")
 		return err
 	}
-	n.setK8sNode(k8sNode)
+	n.setK8sNodeIfNewer(k8sNode)
 	return nil
 }
 

--- a/SaFE/node-agent/pkg/node/node.go
+++ b/SaFE/node-agent/pkg/node/node.go
@@ -16,7 +16,9 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/util/retry"
@@ -33,7 +35,7 @@ import (
 var (
 	NSENTER = "nsenter --target 1 --mount --uts --ipc --net --pid --"
 
-	SYNC_INTERVAL = 3 * time.Second
+	WATCH_RETRY_INTERVAL = 3 * time.Second
 )
 
 // Node represents a Kubernetes node with additional functionality for monitoring and updating node status
@@ -82,22 +84,83 @@ func (n *Node) Start() error {
 	return nil
 }
 
-// update runs continuously to sync node status at regular intervals.
+// update watches the current node and reconnects after watch failures.
 func (n *Node) update() {
-	ticker := time.NewTicker(SYNC_INTERVAL)
-	defer ticker.Stop()
-	n.syncK8sNode()
+	for {
+		if n.ctx.Err() != nil {
+			n.logWatcherStop()
+			return
+		}
+		if err := n.watchK8sNode(); err != nil && n.ctx.Err() == nil {
+			klog.ErrorS(err, "failed to watch k8s node")
+		}
+		select {
+		case <-n.ctx.Done():
+			n.logWatcherStop()
+			return
+		case <-time.After(WATCH_RETRY_INTERVAL):
+		}
+	}
+}
+
+func (n *Node) logWatcherStop() {
+	if n.k8sNode != nil {
+		klog.Infof("stop node watcher: %s", n.k8sNode.Name)
+	}
+}
+
+// watchK8sNode watches only the current node and updates the local cache.
+func (n *Node) watchK8sNode() error {
+	if err := n.syncK8sNode(); err != nil {
+		return err
+	}
+
+	n.mu.Lock()
+	name := n.k8sNode.Name
+	rv := n.k8sNode.ResourceVersion
+	n.mu.Unlock()
+
+	watcher, err := n.k8sClient.Nodes().Watch(n.ctx, metav1.ListOptions{
+		FieldSelector:   fields.OneTermEqualSelector("metadata.name", name).String(),
+		ResourceVersion: rv,
+	})
+	if err != nil {
+		return err
+	}
+	defer watcher.Stop()
+
 	for {
 		select {
 		case <-n.ctx.Done():
-			if n.k8sNode != nil {
-				klog.Infof("stop node watcher: %s", n.k8sNode.Name)
+			return n.ctx.Err()
+		case event, ok := <-watcher.ResultChan():
+			if !ok {
+				return fmt.Errorf("watch closed")
 			}
-			return
-		case <-ticker.C:
-			n.syncK8sNode()
+			if err := n.applyWatchEvent(event); err != nil {
+				return err
+			}
 		}
 	}
+}
+
+// applyWatchEvent applies a watch event for the current node to the local cache.
+func (n *Node) applyWatchEvent(event watch.Event) error {
+	switch event.Type {
+	case watch.Added, watch.Modified:
+		node, ok := event.Object.(*corev1.Node)
+		if !ok || node == nil {
+			return fmt.Errorf("unexpected watch object: %T", event.Object)
+		}
+		n.mu.Lock()
+		n.k8sNode = node.DeepCopy()
+		n.mu.Unlock()
+	case watch.Deleted:
+		klog.InfoS("watched node was deleted")
+	case watch.Error:
+		return fmt.Errorf("watch error: %v", event.Object)
+	}
+	return nil
 }
 
 // updateStartTime updates the node's startup time by executing system commands(uptime -s).

--- a/SaFE/node-agent/pkg/node/node.go
+++ b/SaFE/node-agent/pkg/node/node.go
@@ -18,6 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -36,11 +37,15 @@ var (
 	NSENTER = "nsenter --target 1 --mount --uts --ipc --net --pid --"
 
 	WATCH_RETRY_INTERVAL = 3 * time.Second
+	WATCH_RETRY_MAX      = 30 * time.Second
+	// WATCH_SHORT_DURATION treats a watch that dies sooner than this as a
+	// short-lived failure. Healthy timeout reconnects are not short.
+	WATCH_SHORT_DURATION = 5 * time.Second
 	// WATCH_TIMEOUT_SECONDS bounds a single watch so a stalled connection is
 	// torn down and the cache is refreshed from a new Get.
 	WATCH_TIMEOUT_SECONDS int64 = 300
-	// WATCH_CLOSE_WARN_COUNT raises the log level after this many watches
-	// close without delivering an event.
+	// WATCH_CLOSE_WARN_COUNT raises the log level after this many consecutive
+	// short-lived watches.
 	WATCH_CLOSE_WARN_COUNT = 3
 )
 
@@ -48,7 +53,7 @@ var (
 type Node struct {
 	ctx       context.Context
 	k8sNode   *corev1.Node
-	mu        sync.Mutex
+	mu        sync.RWMutex
 	k8sClient typedcorev1.CoreV1Interface
 }
 
@@ -79,10 +84,10 @@ func NewNodeWithClientSet(ctx context.Context, opts *types.Options, k8sClientSet
 
 // Start initializes and starts the node watcher goroutine.
 func (n *Node) Start() error {
-	if n == nil || n.k8sNode == nil {
+	if n == nil || n.snapshotK8sNode() == nil {
 		return fmt.Errorf("please initialize node first")
 	}
-	klog.Infof("begin to start node watcher: %s", n.k8sNode.Name)
+	klog.Infof("begin to start node watcher: %s", n.snapshotK8sNode().Name)
 	if err := n.updateStartTime(); err != nil {
 		klog.ErrorS(err, "failed to update start time")
 	}
@@ -92,90 +97,124 @@ func (n *Node) Start() error {
 
 // update watches the current node and reconnects after watch failures.
 func (n *Node) update() {
-	consecutiveImmediate := 0
+	consecutiveShort := 0
 	for {
 		if n.ctx.Err() != nil {
 			n.logWatcherStop()
 			return
 		}
-		immediateClose, err := n.watchK8sNode()
+		started := time.Now()
+		err := n.watchK8sNode()
 		if n.ctx.Err() != nil {
 			n.logWatcherStop()
 			return
 		}
-		if err == nil {
-			if immediateClose {
-				consecutiveImmediate++
-			} else {
-				consecutiveImmediate = 0
-			}
-			n.logWatchClosed(immediateClose, consecutiveImmediate)
-			continue
+		lived := time.Since(started)
+		if err != nil {
+			klog.ErrorS(err, "failed to watch k8s node")
 		}
-		consecutiveImmediate = 0
-		klog.ErrorS(err, "failed to watch k8s node")
-		select {
-		case <-n.ctx.Done():
+		delay := time.Duration(0)
+		if lived < WATCH_SHORT_DURATION {
+			consecutiveShort++
+			delay = watchRetryDelay(consecutiveShort)
+			n.logWatchClosed(lived, consecutiveShort, err)
+		} else {
+			consecutiveShort = 0
+			if err != nil {
+				delay = watchRetryDelay(1)
+			}
+			klog.V(4).InfoS("node watch closed, reconnecting", "duration", lived)
+		}
+		if n.waitRetry(delay) {
 			n.logWatcherStop()
 			return
-		case <-time.After(WATCH_RETRY_INTERVAL):
 		}
 	}
 }
 
-func (n *Node) logWatchClosed(immediateClose bool, consecutive int) {
-	if immediateClose && consecutive >= WATCH_CLOSE_WARN_COUNT {
-		klog.InfoS("node watch closed immediately, reconnecting", "consecutive", consecutive)
+// watchRetryDelay returns a jittered exponential delay for consecutive short watches.
+func watchRetryDelay(consecutiveShort int) time.Duration {
+	if consecutiveShort <= 0 {
+		return 0
+	}
+	d := WATCH_RETRY_INTERVAL
+	for i := 1; i < consecutiveShort; i++ {
+		if d >= WATCH_RETRY_MAX/2 {
+			d = WATCH_RETRY_MAX
+			break
+		}
+		d *= 2
+	}
+	if d > WATCH_RETRY_MAX {
+		d = WATCH_RETRY_MAX
+	}
+	return wait.Jitter(d, 0.5)
+}
+
+func (n *Node) waitRetry(d time.Duration) bool {
+	if d <= 0 {
+		return n.ctx.Err() != nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-n.ctx.Done():
+		return true
+	case <-timer.C:
+		return false
+	}
+}
+
+func (n *Node) logWatchClosed(lived time.Duration, consecutive int, err error) {
+	if consecutive >= WATCH_CLOSE_WARN_COUNT {
+		klog.InfoS("node watch closed after a short connection, backing off",
+			"duration", lived, "consecutive", consecutive, "err", err)
 		return
 	}
-	klog.V(4).InfoS("node watch closed, reconnecting")
+	klog.V(4).InfoS("node watch closed after a short connection, backing off",
+		"duration", lived, "consecutive", consecutive)
 }
 
 func (n *Node) logWatcherStop() {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-	if n.k8sNode != nil {
-		klog.Infof("stop node watcher: %s", n.k8sNode.Name)
+	node := n.snapshotK8sNode()
+	if node != nil {
+		klog.Infof("stop node watcher: %s", node.Name)
 	}
 }
 
 // watchK8sNode watches only the current node and updates the local cache.
-// A clean close with no events returns immediateClose so the caller can reconnect
-// without waiting; a close after at least one event is the expected timeout.
-func (n *Node) watchK8sNode() (immediateClose bool, err error) {
+func (n *Node) watchK8sNode() error {
 	if err := n.syncK8sNode(); err != nil {
-		return false, err
+		return err
 	}
 
-	n.mu.Lock()
-	name := n.k8sNode.Name
-	rv := n.k8sNode.ResourceVersion
-	n.mu.Unlock()
+	node := n.snapshotK8sNode()
+	if node == nil {
+		return fmt.Errorf("please initialize node first")
+	}
 
 	timeout := WATCH_TIMEOUT_SECONDS
 	watcher, err := n.k8sClient.Nodes().Watch(n.ctx, metav1.ListOptions{
-		FieldSelector:   fields.OneTermEqualSelector("metadata.name", name).String(),
-		ResourceVersion: rv,
+		FieldSelector:   fields.OneTermEqualSelector("metadata.name", node.Name).String(),
+		ResourceVersion: node.ResourceVersion,
 		TimeoutSeconds:  &timeout,
 	})
 	if err != nil {
-		return false, err
+		return err
 	}
 	defer watcher.Stop()
 
-	sawEvent := false
 	for {
 		select {
 		case <-n.ctx.Done():
-			return false, n.ctx.Err()
+			return n.ctx.Err()
 		case event, ok := <-watcher.ResultChan():
 			if !ok {
-				return !sawEvent, nil
+				return nil
 			}
 			if err := n.applyWatchEvent(event); err != nil {
-				return false, err
+				return err
 			}
-			sawEvent = true
 		}
 	}
 }
@@ -221,12 +260,13 @@ func (n *Node) updateStartTime() error {
 
 // FindConditionByType finds a node condition by its type string.
 func (n *Node) FindConditionByType(conditionType string) *corev1.NodeCondition {
-	if n.k8sNode == nil {
+	node := n.snapshotK8sNode()
+	if node == nil {
 		return nil
 	}
-	for i, currentCond := range n.k8sNode.Status.Conditions {
+	for i, currentCond := range node.Status.Conditions {
 		if conditionType == string(currentCond.Type) {
-			return &n.k8sNode.Status.Conditions[i]
+			return &node.Status.Conditions[i]
 		}
 	}
 	return nil
@@ -234,12 +274,13 @@ func (n *Node) FindConditionByType(conditionType string) *corev1.NodeCondition {
 
 // FindCondition finds a node condition using a custom comparison function.
 func (n *Node) FindCondition(cond *corev1.NodeCondition, isCondEqual func(cond1, cond2 *corev1.NodeCondition) bool) *corev1.NodeCondition {
-	if n.k8sNode == nil {
+	node := n.snapshotK8sNode()
+	if node == nil {
 		return nil
 	}
-	for i, currentCond := range n.k8sNode.Status.Conditions {
+	for i, currentCond := range node.Status.Conditions {
 		if isCondEqual(&currentCond, cond) {
-			return &n.k8sNode.Status.Conditions[i]
+			return &node.Status.Conditions[i]
 		}
 	}
 	return nil
@@ -247,15 +288,16 @@ func (n *Node) FindCondition(cond *corev1.NodeCondition, isCondEqual func(cond1,
 
 // UpdateConditions updates the node's status conditions with retry logic for conflict handling.
 func (n *Node) UpdateConditions(conditions []corev1.NodeCondition) error {
-	if n.k8sNode == nil {
+	if n.snapshotK8sNode() == nil {
 		return fmt.Errorf("please initialize node first")
 	}
 	var err error
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		n.mu.Lock()
-		k8sNode := n.k8sNode.DeepCopy()
+		k8sNode := n.snapshotK8sNode()
+		if k8sNode == nil {
+			return fmt.Errorf("please initialize node first")
+		}
 		k8sNode.Status.Conditions = conditions
-		n.mu.Unlock()
 
 		node, updateErr := n.k8sClient.Nodes().UpdateStatus(n.ctx, k8sNode, metav1.UpdateOptions{})
 		if updateErr != nil {
@@ -267,9 +309,7 @@ func (n *Node) UpdateConditions(conditions []corev1.NodeCondition) error {
 			}
 			return updateErr
 		}
-		n.mu.Lock()
-		n.k8sNode = node.DeepCopy()
-		n.mu.Unlock()
+		n.setK8sNode(node)
 		return nil
 	})
 
@@ -278,23 +318,49 @@ func (n *Node) UpdateConditions(conditions []corev1.NodeCondition) error {
 
 // updateNodeStartTime updates the node's startup time label.
 func (n *Node) updateNodeStartTime(startTime time.Time) error {
+	k8sNode := n.snapshotK8sNode()
+	if k8sNode == nil {
+		return fmt.Errorf("please initialize node first")
+	}
 	startTimeStr := strconv.FormatInt(startTime.Unix(), 10)
-	if v1.GetNodeStartupTime(n.k8sNode) == startTimeStr {
+	if v1.GetNodeStartupTime(k8sNode) == startTimeStr {
 		return nil
 	}
 	data := fmt.Sprintf(`{"metadata":{"labels":{"%s": "%s"}}}`, v1.NodeStartupTimeLabel, startTimeStr)
-	k8sNode, err := n.k8sClient.Nodes().Patch(n.ctx,
-		n.k8sNode.Name, apitypes.MergePatchType, []byte(data), metav1.PatchOptions{})
+	patched, err := n.k8sClient.Nodes().Patch(n.ctx,
+		k8sNode.Name, apitypes.MergePatchType, []byte(data), metav1.PatchOptions{})
 	if err != nil {
 		return client.IgnoreNotFound(err)
 	}
-	n.k8sNode = k8sNode
+	n.setK8sNode(patched)
 	return nil
 }
 
-// GetK8sNode returns the current Kubernetes node object.
+// GetK8sNode returns a snapshot of the current Kubernetes node object.
 func (n *Node) GetK8sNode() *corev1.Node {
-	return n.k8sNode
+	return n.snapshotK8sNode()
+}
+
+func (n *Node) snapshotK8sNode() *corev1.Node {
+	if n == nil {
+		return nil
+	}
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	if n.k8sNode == nil {
+		return nil
+	}
+	return n.k8sNode.DeepCopy()
+}
+
+func (n *Node) setK8sNode(node *corev1.Node) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if node == nil {
+		n.k8sNode = nil
+		return
+	}
+	n.k8sNode = node.DeepCopy()
 }
 
 // IsMatchGpuChip checks if the node's GPU chip matches the specified chip type.
@@ -313,57 +379,68 @@ func (n *Node) IsMatchGpuChip(chip string) bool {
 
 // GetGpuQuantity returns the allocatable GPU quantity for the node.
 func (n *Node) GetGpuQuantity() resource.Quantity {
-	if n.k8sNode == nil {
+	node := n.snapshotK8sNode()
+	if node == nil {
 		return resource.Quantity{}
 	}
 	var result resource.Quantity
 	switch {
-	case n.isAmdGpu():
-		result, _ = n.k8sNode.Status.Allocatable[common.AmdGpu]
-	case n.isNvGpu():
-		result, _ = n.k8sNode.Status.Allocatable[common.NvidiaGpu]
+	case isAmdGpu(node):
+		result, _ = node.Status.Allocatable[common.AmdGpu]
+	case isNvGpu(node):
+		result, _ = node.Status.Allocatable[common.NvidiaGpu]
 	}
 	return result
 }
 
 // GetEphemeralStorage returns the allocatable EphemeralStorage for the node.
 func (n *Node) GetEphemeralStorage() resource.Quantity {
-	if n.k8sNode == nil {
+	node := n.snapshotK8sNode()
+	if node == nil {
 		return resource.Quantity{}
 	}
-	result, _ := n.k8sNode.Status.Allocatable[corev1.ResourceEphemeralStorage]
+	result, _ := node.Status.Allocatable[corev1.ResourceEphemeralStorage]
 	return result
 }
 
 // isNvGpu checks if the node has NVIDIA GPU hardware.
 func (n *Node) isNvGpu() bool {
-	if n.k8sNode == nil {
-		return false
-	}
-	_, ok := n.k8sNode.Labels[common.NvidiaIdentification]
-	return ok
+	return isNvGpu(n.snapshotK8sNode())
 }
 
 // isAmdGpu checks if the node has AMD GPU hardware.
 func (n *Node) isAmdGpu() bool {
-	if n.k8sNode == nil {
+	return isAmdGpu(n.snapshotK8sNode())
+}
+
+func isNvGpu(node *corev1.Node) bool {
+	if node == nil {
 		return false
 	}
-	val, ok := n.k8sNode.Labels[common.AMDGpuIdentification]
+	_, ok := node.Labels[common.NvidiaIdentification]
+	return ok
+}
+
+func isAmdGpu(node *corev1.Node) bool {
+	if node == nil {
+		return false
+	}
+	val, ok := node.Labels[common.AMDGpuIdentification]
 	return ok && val == v1.TrueStr
 }
 
 // syncK8sNode synchronizes the local node cache with the latest version from Kubernetes API.
 func (n *Node) syncK8sNode() error {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	k8sNode, err := n.k8sClient.Nodes().Get(n.ctx, n.GetK8sNode().Name, metav1.GetOptions{})
+	current := n.snapshotK8sNode()
+	if current == nil {
+		return fmt.Errorf("please initialize node first")
+	}
+	k8sNode, err := n.k8sClient.Nodes().Get(n.ctx, current.Name, metav1.GetOptions{})
 	if err != nil {
 		klog.ErrorS(err, "failed to get k8s node")
 		return err
 	}
-	n.k8sNode = k8sNode.DeepCopy()
+	n.setK8sNode(k8sNode)
 	return nil
 }
 

--- a/SaFE/node-agent/pkg/node/node.go
+++ b/SaFE/node-agent/pkg/node/node.go
@@ -8,6 +8,7 @@ package node
 import (
 	"context"
 	"fmt"
+	"math/rand/v2"
 	"strconv"
 	"sync"
 	"time"
@@ -38,12 +39,15 @@ var (
 
 	WATCH_RETRY_INTERVAL = 3 * time.Second
 	WATCH_RETRY_MAX      = 30 * time.Second
-	// WATCH_SHORT_DURATION treats a watch that dies sooner than this as a
-	// short-lived failure. Healthy timeout reconnects are not short.
-	WATCH_SHORT_DURATION = 5 * time.Second
-	// WATCH_TIMEOUT_SECONDS bounds a single watch so a stalled connection is
-	// torn down and the cache is refreshed from a new Get.
-	WATCH_TIMEOUT_SECONDS int64 = 300
+	// WATCH_HEALTHY_DURATION is the connection lifetime that clears the
+	// backoff. Anything shorter counts as a failed connection, so proxies
+	// dropping idle connections keep backing the agent off instead of
+	// looping over Get and Watch.
+	WATCH_HEALTHY_DURATION = 2 * time.Minute
+	// WATCH_MIN_TIMEOUT_SECONDS is the lower bound of a single watch. The
+	// real timeout is randomized within [min, 2*min) so agents do not
+	// reconnect in lockstep.
+	WATCH_MIN_TIMEOUT_SECONDS int64 = 300
 	// WATCH_CLOSE_WARN_COUNT raises the log level after this many consecutive
 	// short-lived watches.
 	WATCH_CLOSE_WARN_COUNT = 3
@@ -114,7 +118,7 @@ func (n *Node) update() {
 			klog.ErrorS(err, "failed to watch k8s node")
 		}
 		delay := time.Duration(0)
-		if lived < WATCH_SHORT_DURATION {
+		if lived < WATCH_HEALTHY_DURATION {
 			consecutiveShort++
 			delay = watchRetryDelay(consecutiveShort)
 			n.logWatchClosed(lived, consecutiveShort, err)
@@ -193,7 +197,7 @@ func (n *Node) watchK8sNode() error {
 		return fmt.Errorf("please initialize node first")
 	}
 
-	timeout := WATCH_TIMEOUT_SECONDS
+	timeout := watchTimeoutSeconds()
 	watcher, err := n.k8sClient.Nodes().Watch(n.ctx, metav1.ListOptions{
 		FieldSelector:   fields.OneTermEqualSelector("metadata.name", node.Name).String(),
 		ResourceVersion: node.ResourceVersion,
@@ -219,6 +223,16 @@ func (n *Node) watchK8sNode() error {
 	}
 }
 
+// watchTimeoutSeconds randomizes the watch timeout so agents reconnect at
+// different times instead of in lockstep.
+func watchTimeoutSeconds() int64 {
+	base := WATCH_MIN_TIMEOUT_SECONDS
+	if base <= 0 {
+		return base
+	}
+	return base + rand.Int64N(base)
+}
+
 // applyWatchEvent applies a watch event for the current node to the local cache.
 func (n *Node) applyWatchEvent(event watch.Event) error {
 	switch event.Type {
@@ -227,13 +241,11 @@ func (n *Node) applyWatchEvent(event watch.Event) error {
 		if !ok || node == nil {
 			return fmt.Errorf("unexpected watch object: %T", event.Object)
 		}
-		n.mu.Lock()
-		n.k8sNode = node.DeepCopy()
-		n.mu.Unlock()
+		n.setK8sNode(node)
 	case watch.Deleted:
 		klog.InfoS("watched node was deleted")
 	case watch.Error:
-		return fmt.Errorf("watch error: %v", event.Object)
+		return apierrors.FromObject(event.Object)
 	}
 	return nil
 }
@@ -297,6 +309,7 @@ func (n *Node) UpdateConditions(conditions []corev1.NodeCondition) error {
 		if k8sNode == nil {
 			return fmt.Errorf("please initialize node first")
 		}
+		sentResourceVersion := k8sNode.ResourceVersion
 		k8sNode.Status.Conditions = conditions
 
 		node, updateErr := n.k8sClient.Nodes().UpdateStatus(n.ctx, k8sNode, metav1.UpdateOptions{})
@@ -309,7 +322,7 @@ func (n *Node) UpdateConditions(conditions []corev1.NodeCondition) error {
 			}
 			return updateErr
 		}
-		n.setK8sNode(node)
+		n.setK8sNodeIfUnchanged(sentResourceVersion, node)
 		return nil
 	})
 
@@ -332,7 +345,7 @@ func (n *Node) updateNodeStartTime(startTime time.Time) error {
 	if err != nil {
 		return client.IgnoreNotFound(err)
 	}
-	n.setK8sNode(patched)
+	n.setK8sNodeIfUnchanged(k8sNode.ResourceVersion, patched)
 	return nil
 }
 
@@ -361,6 +374,24 @@ func (n *Node) setK8sNode(node *corev1.Node) {
 		return
 	}
 	n.k8sNode = node.DeepCopy()
+}
+
+// setK8sNodeIfUnchanged stores an API response only when the cache still holds
+// the resource version the request was built from. A watch event applied while
+// the request was in flight is newer and must not be rolled back.
+func (n *Node) setK8sNodeIfUnchanged(expectedResourceVersion string, node *corev1.Node) bool {
+	if node == nil {
+		return false
+	}
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.k8sNode != nil && n.k8sNode.ResourceVersion != expectedResourceVersion {
+		klog.V(4).InfoS("skip stale node response",
+			"cached", n.k8sNode.ResourceVersion, "expected", expectedResourceVersion)
+		return false
+	}
+	n.k8sNode = node.DeepCopy()
+	return true
 }
 
 // IsMatchGpuChip checks if the node's GPU chip matches the specified chip type.

--- a/SaFE/node-agent/pkg/node/node.go
+++ b/SaFE/node-agent/pkg/node/node.go
@@ -36,6 +36,9 @@ var (
 	NSENTER = "nsenter --target 1 --mount --uts --ipc --net --pid --"
 
 	WATCH_RETRY_INTERVAL = 3 * time.Second
+	// WATCH_TIMEOUT_SECONDS bounds a single watch so a stalled connection is
+	// torn down and the cache is refreshed from a new Get.
+	WATCH_TIMEOUT_SECONDS int64 = 300
 )
 
 // Node represents a Kubernetes node with additional functionality for monitoring and updating node status
@@ -104,6 +107,8 @@ func (n *Node) update() {
 }
 
 func (n *Node) logWatcherStop() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
 	if n.k8sNode != nil {
 		klog.Infof("stop node watcher: %s", n.k8sNode.Name)
 	}
@@ -120,9 +125,11 @@ func (n *Node) watchK8sNode() error {
 	rv := n.k8sNode.ResourceVersion
 	n.mu.Unlock()
 
+	timeout := WATCH_TIMEOUT_SECONDS
 	watcher, err := n.k8sClient.Nodes().Watch(n.ctx, metav1.ListOptions{
 		FieldSelector:   fields.OneTermEqualSelector("metadata.name", name).String(),
 		ResourceVersion: rv,
+		TimeoutSeconds:  &timeout,
 	})
 	if err != nil {
 		return err
@@ -135,7 +142,8 @@ func (n *Node) watchK8sNode() error {
 			return n.ctx.Err()
 		case event, ok := <-watcher.ResultChan():
 			if !ok {
-				return fmt.Errorf("watch closed")
+				klog.V(4).InfoS("node watch closed, reconnecting")
+				return nil
 			}
 			if err := n.applyWatchEvent(event); err != nil {
 				return err

--- a/SaFE/node-agent/pkg/node/node.go
+++ b/SaFE/node-agent/pkg/node/node.go
@@ -19,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
@@ -375,42 +376,46 @@ func (n *Node) setK8sNode(node *corev1.Node) {
 }
 
 // setK8sNodeIfNewer stores node unless its resource version is older than the
-// cache. Equality is not an ordering: a delayed watch event and a GET or
-// UpdateStatus response can both differ from the cached value, and only a
-// numeric compare tells which one should win.
+// cache. Ordering uses CompareResourceVersion. If that compare fails and the
+// cache already holds a well-formed resource version, the cache is kept.
 func (n *Node) setK8sNodeIfNewer(node *corev1.Node) bool {
 	if node == nil {
 		return false
 	}
 	n.mu.Lock()
 	defer n.mu.Unlock()
-	if n.k8sNode != nil && resourceVersionOlder(node.ResourceVersion, n.k8sNode.ResourceVersion) {
-		klog.V(4).InfoS("skip older node object",
-			"cached", n.k8sNode.ResourceVersion, "incoming", node.ResourceVersion)
-		return false
+	if n.k8sNode != nil {
+		older, err := resourceVersionOlder(node.ResourceVersion, n.k8sNode.ResourceVersion)
+		if err != nil {
+			if wellFormedResourceVersion(n.k8sNode.ResourceVersion) {
+				klog.V(4).InfoS("skip node object with incomparable resource version",
+					"cached", n.k8sNode.ResourceVersion, "incoming", node.ResourceVersion, "err", err)
+				return false
+			}
+		} else if older {
+			klog.V(4).InfoS("skip older node object",
+				"cached", n.k8sNode.ResourceVersion, "incoming", node.ResourceVersion)
+			return false
+		}
 	}
 	n.k8sNode = node.DeepCopy()
 	return true
 }
 
-// resourceVersionOlder reports whether incoming is behind cached. apiserver
-// resource versions are decimal etcd revisions, so "9" is older than "10".
-func resourceVersionOlder(incoming, cached string) bool {
-	if incoming == cached {
-		return false
+// resourceVersionOlder reports whether incoming is behind cached using the
+// Kubernetes ResourceVersion ordering. A compare error means the values are
+// not well-formed and the caller must not replace the cache.
+func resourceVersionOlder(incoming, cached string) (bool, error) {
+	cmp, err := resourceversion.CompareResourceVersion(incoming, cached)
+	if err != nil {
+		return false, err
 	}
-	if incoming == "" {
-		return cached != ""
-	}
-	if cached == "" {
-		return false
-	}
-	in, errIn := strconv.ParseUint(incoming, 10, 64)
-	ca, errCa := strconv.ParseUint(cached, 10, 64)
-	if errIn != nil || errCa != nil {
-		return false
-	}
-	return in < ca
+	return cmp < 0, nil
+}
+
+func wellFormedResourceVersion(rv string) bool {
+	_, err := resourceversion.CompareResourceVersion(rv, rv)
+	return err == nil
 }
 
 // IsMatchGpuChip checks if the node's GPU chip matches the specified chip type.

--- a/SaFE/node-agent/pkg/node/node_test.go
+++ b/SaFE/node-agent/pkg/node/node_test.go
@@ -7,7 +7,6 @@ package node
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"runtime"
 	"strconv"
@@ -23,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/fake"
 	ktesting "k8s.io/client-go/testing"
 
@@ -55,36 +54,114 @@ func newNode(t *testing.T) (*Node, *fake.Clientset) {
 	opts := &types.Options{
 		NodeName: testNode.Name,
 	}
-	SYNC_INTERVAL = time.Millisecond * 100
+	savedRetry := WATCH_RETRY_INTERVAL
+	WATCH_RETRY_INTERVAL = time.Millisecond * 100
+	t.Cleanup(func() { WATCH_RETRY_INTERVAL = savedRetry })
 	n, err := NewNodeWithClientSet(context.Background(), opts, fakeClientSet)
 	assert.NilError(t, err)
 	return n, fakeClientSet
 }
 
+func waitForNodeLabel(t *testing.T, n *Node, key, want string) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if n.GetK8sNode().Labels[key] == want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("node label %s=%q, want %q", key, n.GetK8sNode().Labels[key], want)
+}
+
 func TestWatchNode(t *testing.T) {
-	// Mock NSENTER to avoid permission issues
-	savedNSENTER := NSENTER
-	NSENTER = ""
-	defer func() { NSENTER = savedNSENTER }()
-
 	n, fakeClientSet := newNode(t)
-	err := n.Start()
-	assert.NilError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	n.ctx = ctx
 
-	data, _ := json.Marshal(map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"labels": map[string]interface{}{
-				"test.key": "test.val",
-			},
-		},
+	watcher := watch.NewFake()
+	var fieldSelector string
+	fakeClientSet.PrependWatchReactor("nodes", func(action ktesting.Action) (bool, watch.Interface, error) {
+		wa := action.(ktesting.WatchAction)
+		if fields := wa.GetWatchRestrictions().Fields; fields != nil {
+			fieldSelector = fields.String()
+		}
+		return true, watcher, nil
 	})
-	_, err = fakeClientSet.CoreV1().Nodes().Patch(context.Background(), n.GetK8sNode().Name,
-		apitypes.MergePatchType, data, metav1.PatchOptions{})
-	assert.NilError(t, err)
 
-	time.Sleep(time.Millisecond * 200)
-	val, _ := n.GetK8sNode().Labels["test.key"]
-	assert.Equal(t, val, "test.val")
+	done := make(chan error, 1)
+	go func() {
+		done <- n.watchK8sNode()
+	}()
+
+	updated := n.GetK8sNode().DeepCopy()
+	updated.Labels["test.key"] = "test.val"
+	watcher.Modify(updated)
+	waitForNodeLabel(t, n, "test.key", "test.val")
+	assert.Equal(t, fieldSelector, "metadata.name=test-node")
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("watchK8sNode did not return after cancel")
+	}
+}
+
+func TestApplyWatchEventModified(t *testing.T) {
+	n, _ := newNode(t)
+	updated := n.GetK8sNode().DeepCopy()
+	updated.Labels["test.key"] = "test.val"
+	assert.NilError(t, n.applyWatchEvent(watch.Event{Type: watch.Modified, Object: updated}))
+	assert.Equal(t, n.GetK8sNode().Labels["test.key"], "test.val")
+}
+
+func TestApplyWatchEventUnexpectedObject(t *testing.T) {
+	n, _ := newNode(t)
+	err := n.applyWatchEvent(watch.Event{Type: watch.Added, Object: &corev1.Pod{}})
+	assert.Assert(t, err != nil)
+}
+
+func TestApplyWatchEventDeletedKeepsCache(t *testing.T) {
+	n, _ := newNode(t)
+	name := n.GetK8sNode().Name
+	assert.NilError(t, n.applyWatchEvent(watch.Event{Type: watch.Deleted, Object: n.GetK8sNode()}))
+	assert.Equal(t, n.GetK8sNode().Name, name)
+}
+
+func TestApplyWatchEventError(t *testing.T) {
+	n, _ := newNode(t)
+	err := n.applyWatchEvent(watch.Event{Type: watch.Error, Object: &metav1.Status{Message: "watch failed"}})
+	assert.Assert(t, err != nil)
+}
+
+func TestWatchK8sNodeWatchError(t *testing.T) {
+	n, fakeClientSet := newNode(t)
+	fakeClientSet.PrependWatchReactor("nodes", func(action ktesting.Action) (bool, watch.Interface, error) {
+		return true, nil, fmt.Errorf("watch failed")
+	})
+	err := n.watchK8sNode()
+	assert.Assert(t, err != nil)
+}
+
+func TestWatchK8sNodeClosed(t *testing.T) {
+	n, fakeClientSet := newNode(t)
+	watcher := watch.NewFake()
+	fakeClientSet.PrependWatchReactor("nodes", func(action ktesting.Action) (bool, watch.Interface, error) {
+		return true, watcher, nil
+	})
+	done := make(chan error, 1)
+	go func() {
+		done <- n.watchK8sNode()
+	}()
+	watcher.Stop()
+	select {
+	case err := <-done:
+		assert.Assert(t, err != nil)
+	case <-time.After(time.Second):
+		t.Fatal("watchK8sNode did not return after watch closed")
+	}
 }
 
 func TestGetGpuQuantity(t *testing.T) {
@@ -337,15 +414,22 @@ func TestIsMatchGpuChipInvalidAmdLabel(t *testing.T) {
 	assert.Equal(t, n.IsMatchGpuChip(string(v1.AmdGpuChip)), false)
 }
 
-// TestNodeUpdateStopsOnCancel exits the sync loop when the context is cancelled.
+// TestNodeUpdateStopsOnCancel exits the watch loop when the context is cancelled.
 func TestNodeUpdateStopsOnCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	n, _ := newNode(t)
 	n.ctx = ctx
-	go n.update()
+	done := make(chan struct{})
+	go func() {
+		n.update()
+		close(done)
+	}()
 	cancel()
-	time.Sleep(150 * time.Millisecond)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("update did not stop after cancel")
+	}
 }
 
 // --- merged from node_new_test.go ---

--- a/SaFE/node-agent/pkg/node/node_test.go
+++ b/SaFE/node-agent/pkg/node/node_test.go
@@ -134,8 +134,71 @@ func TestApplyWatchEventDeletedKeepsCache(t *testing.T) {
 
 func TestApplyWatchEventError(t *testing.T) {
 	n, _ := newNode(t)
-	err := n.applyWatchEvent(watch.Event{Type: watch.Error, Object: &metav1.Status{Message: "watch failed"}})
+	err := n.applyWatchEvent(watch.Event{Type: watch.Error, Object: &metav1.Status{
+		Status:  metav1.StatusFailure,
+		Code:    410,
+		Reason:  metav1.StatusReasonExpired,
+		Message: "too old resource version",
+	}})
 	assert.Assert(t, err != nil)
+	assert.Equal(t, apierrors.ReasonForError(err), metav1.StatusReasonExpired)
+	assert.Equal(t, apierrors.IsResourceExpired(err), true)
+}
+
+func TestWatchTimeoutSecondsIsRandomizedAboveMinimum(t *testing.T) {
+	saved := WATCH_MIN_TIMEOUT_SECONDS
+	WATCH_MIN_TIMEOUT_SECONDS = 300
+	t.Cleanup(func() { WATCH_MIN_TIMEOUT_SECONDS = saved })
+
+	seen := map[int64]struct{}{}
+	for i := 0; i < 100; i++ {
+		got := watchTimeoutSeconds()
+		assert.Assert(t, got >= WATCH_MIN_TIMEOUT_SECONDS, "got=%d", got)
+		assert.Assert(t, got < 2*WATCH_MIN_TIMEOUT_SECONDS, "got=%d", got)
+		seen[got] = struct{}{}
+	}
+	assert.Assert(t, len(seen) > 1, "timeout was not randomized")
+}
+
+func TestSetK8sNodeIfUnchangedSkipsStaleResponse(t *testing.T) {
+	n, _ := newNode(t)
+	watched := n.GetK8sNode().DeepCopy()
+	watched.ResourceVersion = "12"
+	watched.Labels["source"] = "watch"
+	n.setK8sNode(watched)
+
+	stale := n.GetK8sNode().DeepCopy()
+	stale.ResourceVersion = "11"
+	stale.Labels["source"] = "update"
+	assert.Equal(t, n.setK8sNodeIfUnchanged("11", stale), false)
+	assert.Equal(t, n.GetK8sNode().ResourceVersion, "12")
+	assert.Equal(t, n.GetK8sNode().Labels["source"], "watch")
+
+	fresh := n.GetK8sNode().DeepCopy()
+	fresh.ResourceVersion = "13"
+	fresh.Labels["source"] = "update"
+	assert.Equal(t, n.setK8sNodeIfUnchanged("12", fresh), true)
+	assert.Equal(t, n.GetK8sNode().ResourceVersion, "13")
+}
+
+func TestUpdateConditionsKeepsNewerWatchState(t *testing.T) {
+	n, fakeClientSet := newNode(t)
+	fakeClientSet.PrependReactor("update", "nodes", func(action ktesting.Action) (bool, kruntime.Object, error) {
+		watched := n.GetK8sNode().DeepCopy()
+		watched.ResourceVersion = "12"
+		watched.Labels["source"] = "watch"
+		n.setK8sNode(watched)
+
+		returned := action.(ktesting.UpdateAction).GetObject().(*corev1.Node).DeepCopy()
+		returned.ResourceVersion = "11"
+		return true, returned, nil
+	})
+
+	assert.NilError(t, n.UpdateConditions([]corev1.NodeCondition{
+		{Type: "safe.stale", Status: corev1.ConditionTrue},
+	}))
+	assert.Equal(t, n.GetK8sNode().ResourceVersion, "12")
+	assert.Equal(t, n.GetK8sNode().Labels["source"], "watch")
 }
 
 func TestWatchK8sNodeWatchError(t *testing.T) {
@@ -211,12 +274,12 @@ func TestWatchRetryDelayGrowsWithConsecutiveShortWatches(t *testing.T) {
 func TestUpdateBacksOffOnShortWatchClose(t *testing.T) {
 	n, fakeClientSet := newNode(t)
 	savedRetry := WATCH_RETRY_INTERVAL
-	savedShort := WATCH_SHORT_DURATION
+	savedHealthy := WATCH_HEALTHY_DURATION
 	WATCH_RETRY_INTERVAL = 300 * time.Millisecond
-	WATCH_SHORT_DURATION = time.Second
+	WATCH_HEALTHY_DURATION = time.Second
 	t.Cleanup(func() {
 		WATCH_RETRY_INTERVAL = savedRetry
-		WATCH_SHORT_DURATION = savedShort
+		WATCH_HEALTHY_DURATION = savedHealthy
 	})
 
 	var watches atomic.Int32
@@ -260,12 +323,12 @@ func TestUpdateBacksOffOnShortWatchClose(t *testing.T) {
 func TestUpdateReconnectsImmediatelyAfterLongWatch(t *testing.T) {
 	n, fakeClientSet := newNode(t)
 	savedRetry := WATCH_RETRY_INTERVAL
-	savedShort := WATCH_SHORT_DURATION
+	savedHealthy := WATCH_HEALTHY_DURATION
 	WATCH_RETRY_INTERVAL = time.Second
-	WATCH_SHORT_DURATION = 30 * time.Millisecond
+	WATCH_HEALTHY_DURATION = 30 * time.Millisecond
 	t.Cleanup(func() {
 		WATCH_RETRY_INTERVAL = savedRetry
-		WATCH_SHORT_DURATION = savedShort
+		WATCH_HEALTHY_DURATION = savedHealthy
 	})
 
 	var watches atomic.Int32
@@ -293,7 +356,7 @@ func TestUpdateReconnectsImmediatelyAfterLongWatch(t *testing.T) {
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
-	time.Sleep(WATCH_SHORT_DURATION + 20*time.Millisecond)
+	time.Sleep(WATCH_HEALTHY_DURATION + 20*time.Millisecond)
 	watcher.Stop()
 
 	deadline = time.Now().Add(400 * time.Millisecond)

--- a/SaFE/node-agent/pkg/node/node_test.go
+++ b/SaFE/node-agent/pkg/node/node_test.go
@@ -160,12 +160,43 @@ func TestWatchTimeoutSecondsIsRandomizedAboveMinimum(t *testing.T) {
 	assert.Assert(t, len(seen) > 1, "timeout was not randomized")
 }
 
-func TestResourceVersionOlderUsesDecimalOrder(t *testing.T) {
-	assert.Equal(t, resourceVersionOlder("9", "10"), true)
-	assert.Equal(t, resourceVersionOlder("10", "9"), false)
-	assert.Equal(t, resourceVersionOlder("12", "12"), false)
-	assert.Equal(t, resourceVersionOlder("", "12"), true)
-	assert.Equal(t, resourceVersionOlder("12", ""), false)
+func TestResourceVersionOlderUsesAPICompare(t *testing.T) {
+	older, err := resourceVersionOlder("9", "10")
+	assert.NilError(t, err)
+	assert.Equal(t, older, true)
+
+	older, err = resourceVersionOlder("10", "9")
+	assert.NilError(t, err)
+	assert.Equal(t, older, false)
+
+	older, err = resourceVersionOlder("12", "12")
+	assert.NilError(t, err)
+	assert.Equal(t, older, false)
+
+	_, err = resourceVersionOlder("", "12")
+	assert.Assert(t, err != nil)
+	_, err = resourceVersionOlder("12", "")
+	assert.Assert(t, err != nil)
+	_, err = resourceVersionOlder("01", "12")
+	assert.Assert(t, err != nil)
+}
+
+func TestSetK8sNodeIfNewerKeepsCacheWhenResourceVersionIsIncomparable(t *testing.T) {
+	n, _ := newNode(t)
+	n.setK8sNode(nodeWithRV(n.GetK8sNode(), "12", "watch"))
+
+	assert.Equal(t, n.setK8sNodeIfNewer(nodeWithRV(n.GetK8sNode(), "", "empty")), false)
+	assert.Equal(t, n.setK8sNodeIfNewer(nodeWithRV(n.GetK8sNode(), "01", "leading-zero")), false)
+	assert.Equal(t, n.setK8sNodeIfNewer(nodeWithRV(n.GetK8sNode(), "not-an-rv", "opaque")), false)
+	assert.Equal(t, n.GetK8sNode().ResourceVersion, "12")
+	assert.Equal(t, n.GetK8sNode().Labels["source"], "watch")
+}
+
+func TestSetK8sNodeIfNewerAllowsWellFormedRVOverEmptyCache(t *testing.T) {
+	n, _ := newNode(t)
+	assert.Equal(t, n.GetK8sNode().ResourceVersion, "")
+	assert.Equal(t, n.setK8sNodeIfNewer(nodeWithRV(n.GetK8sNode(), "12", "watch")), true)
+	assert.Equal(t, n.GetK8sNode().ResourceVersion, "12")
 }
 
 func TestSetK8sNodeIfNewerSkipsOlderResourceVersion(t *testing.T) {

--- a/SaFE/node-agent/pkg/node/node_test.go
+++ b/SaFE/node-agent/pkg/node/node_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"runtime"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -93,8 +94,7 @@ func TestWatchNode(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		_, err := n.watchK8sNode()
-		done <- err
+		done <- n.watchK8sNode()
 	}()
 
 	updated := n.GetK8sNode().DeepCopy()
@@ -143,7 +143,7 @@ func TestWatchK8sNodeWatchError(t *testing.T) {
 	fakeClientSet.PrependWatchReactor("nodes", func(action ktesting.Action) (bool, watch.Interface, error) {
 		return true, nil, fmt.Errorf("watch failed")
 	})
-	_, err := n.watchK8sNode()
+	err := n.watchK8sNode()
 	assert.Assert(t, err != nil)
 }
 
@@ -153,22 +153,14 @@ func TestWatchK8sNodeClosed(t *testing.T) {
 	fakeClientSet.PrependWatchReactor("nodes", func(action ktesting.Action) (bool, watch.Interface, error) {
 		return true, watcher, nil
 	})
-	done := make(chan struct {
-		immediate bool
-		err       error
-	}, 1)
+	done := make(chan error, 1)
 	go func() {
-		immediate, err := n.watchK8sNode()
-		done <- struct {
-			immediate bool
-			err       error
-		}{immediate, err}
+		done <- n.watchK8sNode()
 	}()
 	watcher.Stop()
 	select {
-	case got := <-done:
-		assert.NilError(t, got.err)
-		assert.Equal(t, got.immediate, true)
+	case err := <-done:
+		assert.NilError(t, err)
 	case <-time.After(time.Second):
 		t.Fatal("watchK8sNode did not return after watch closed")
 	}
@@ -180,16 +172,9 @@ func TestWatchK8sNodeClosedAfterEvent(t *testing.T) {
 	fakeClientSet.PrependWatchReactor("nodes", func(action ktesting.Action) (bool, watch.Interface, error) {
 		return true, watcher, nil
 	})
-	done := make(chan struct {
-		immediate bool
-		err       error
-	}, 1)
+	done := make(chan error, 1)
 	go func() {
-		immediate, err := n.watchK8sNode()
-		done <- struct {
-			immediate bool
-			err       error
-		}{immediate, err}
+		done <- n.watchK8sNode()
 	}()
 	updated := n.GetK8sNode().DeepCopy()
 	updated.Labels["test.key"] = "test.val"
@@ -197,19 +182,42 @@ func TestWatchK8sNodeClosedAfterEvent(t *testing.T) {
 	waitForNodeLabel(t, n, "test.key", "test.val")
 	watcher.Stop()
 	select {
-	case got := <-done:
-		assert.NilError(t, got.err)
-		assert.Equal(t, got.immediate, false)
+	case err := <-done:
+		assert.NilError(t, err)
 	case <-time.After(time.Second):
 		t.Fatal("watchK8sNode did not return after watch closed")
 	}
 }
 
-func TestUpdateReconnectsImmediatelyOnCleanClose(t *testing.T) {
+func TestWatchRetryDelayGrowsWithConsecutiveShortWatches(t *testing.T) {
+	savedInterval := WATCH_RETRY_INTERVAL
+	savedMax := WATCH_RETRY_MAX
+	WATCH_RETRY_INTERVAL = 100 * time.Millisecond
+	WATCH_RETRY_MAX = 400 * time.Millisecond
+	t.Cleanup(func() {
+		WATCH_RETRY_INTERVAL = savedInterval
+		WATCH_RETRY_MAX = savedMax
+	})
+
+	first := watchRetryDelay(1)
+	assert.Assert(t, first >= WATCH_RETRY_INTERVAL, "first=%s", first)
+	assert.Assert(t, first <= WATCH_RETRY_INTERVAL+WATCH_RETRY_INTERVAL/2, "first=%s", first)
+
+	capped := watchRetryDelay(8)
+	assert.Assert(t, capped >= WATCH_RETRY_MAX, "capped=%s", capped)
+	assert.Assert(t, capped <= WATCH_RETRY_MAX+WATCH_RETRY_MAX/2, "capped=%s", capped)
+}
+
+func TestUpdateBacksOffOnShortWatchClose(t *testing.T) {
 	n, fakeClientSet := newNode(t)
 	savedRetry := WATCH_RETRY_INTERVAL
-	WATCH_RETRY_INTERVAL = time.Second
-	t.Cleanup(func() { WATCH_RETRY_INTERVAL = savedRetry })
+	savedShort := WATCH_SHORT_DURATION
+	WATCH_RETRY_INTERVAL = 300 * time.Millisecond
+	WATCH_SHORT_DURATION = time.Second
+	t.Cleanup(func() {
+		WATCH_RETRY_INTERVAL = savedRetry
+		WATCH_SHORT_DURATION = savedShort
+	})
 
 	var watches atomic.Int32
 	fakeClientSet.PrependWatchReactor("nodes", func(action ktesting.Action) (bool, watch.Interface, error) {
@@ -227,12 +235,73 @@ func TestUpdateReconnectsImmediatelyOnCleanClose(t *testing.T) {
 		close(done)
 	}()
 
-	deadline := time.Now().Add(400 * time.Millisecond)
+	deadline := time.Now().Add(150 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	assert.Equal(t, int32(1), watches.Load())
+
+	deadline = time.Now().Add(time.Second)
 	for time.Now().Before(deadline) {
 		if watches.Load() >= 2 {
 			break
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("update did not stop after cancel")
+	}
+	assert.Assert(t, watches.Load() >= 2, "watches=%d", watches.Load())
+}
+
+func TestUpdateReconnectsImmediatelyAfterLongWatch(t *testing.T) {
+	n, fakeClientSet := newNode(t)
+	savedRetry := WATCH_RETRY_INTERVAL
+	savedShort := WATCH_SHORT_DURATION
+	WATCH_RETRY_INTERVAL = time.Second
+	WATCH_SHORT_DURATION = 30 * time.Millisecond
+	t.Cleanup(func() {
+		WATCH_RETRY_INTERVAL = savedRetry
+		WATCH_SHORT_DURATION = savedShort
+	})
+
+	var watches atomic.Int32
+	watcher := watch.NewFake()
+	fakeClientSet.PrependWatchReactor("nodes", func(action ktesting.Action) (bool, watch.Interface, error) {
+		if watches.Add(1) == 1 {
+			return true, watcher, nil
+		}
+		w := watch.NewFake()
+		return true, w, nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	n.ctx = ctx
+	done := make(chan struct{})
+	go func() {
+		n.update()
+		close(done)
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if watches.Load() >= 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	time.Sleep(WATCH_SHORT_DURATION + 20*time.Millisecond)
+	watcher.Stop()
+
+	deadline = time.Now().Add(400 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if watches.Load() >= 2 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
 	}
 	cancel()
 	select {
@@ -252,7 +321,20 @@ func TestStartWatchesNode(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	n.ctx = ctx
+
+	watchStarted := make(chan struct{})
+	var once sync.Once
+	fakeClientSet.PrependWatchReactor("nodes", func(action ktesting.Action) (bool, watch.Interface, error) {
+		once.Do(func() { close(watchStarted) })
+		return false, nil, nil
+	})
+
 	assert.NilError(t, n.Start())
+	select {
+	case <-watchStarted:
+	case <-time.After(time.Second):
+		t.Fatal("watch reactor did not start")
+	}
 
 	updated := n.GetK8sNode().DeepCopy()
 	updated.Labels["test.key"] = "test.val"
@@ -260,6 +342,13 @@ func TestStartWatchesNode(t *testing.T) {
 	assert.NilError(t, err)
 	waitForNodeLabel(t, n, "test.key", "test.val")
 	cancel()
+}
+
+func TestGetK8sNodeReturnsSnapshot(t *testing.T) {
+	n, _ := newNode(t)
+	got := n.GetK8sNode()
+	got.Labels["mutated"] = "1"
+	assert.Equal(t, n.GetK8sNode().Labels["mutated"], "")
 }
 
 func TestGetGpuQuantity(t *testing.T) {

--- a/SaFE/node-agent/pkg/node/node_test.go
+++ b/SaFE/node-agent/pkg/node/node_test.go
@@ -158,10 +158,29 @@ func TestWatchK8sNodeClosed(t *testing.T) {
 	watcher.Stop()
 	select {
 	case err := <-done:
-		assert.Assert(t, err != nil)
+		assert.NilError(t, err)
 	case <-time.After(time.Second):
 		t.Fatal("watchK8sNode did not return after watch closed")
 	}
+}
+
+func TestStartWatchesNode(t *testing.T) {
+	savedNSENTER := NSENTER
+	NSENTER = ""
+	defer func() { NSENTER = savedNSENTER }()
+
+	n, fakeClientSet := newNode(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	n.ctx = ctx
+	assert.NilError(t, n.Start())
+
+	updated := n.GetK8sNode().DeepCopy()
+	updated.Labels["test.key"] = "test.val"
+	_, err := fakeClientSet.CoreV1().Nodes().Update(context.Background(), updated, metav1.UpdateOptions{})
+	assert.NilError(t, err)
+	waitForNodeLabel(t, n, "test.key", "test.val")
+	cancel()
 }
 
 func TestGetGpuQuantity(t *testing.T) {

--- a/SaFE/node-agent/pkg/node/node_test.go
+++ b/SaFE/node-agent/pkg/node/node_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"runtime"
 	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -92,7 +93,8 @@ func TestWatchNode(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- n.watchK8sNode()
+		_, err := n.watchK8sNode()
+		done <- err
 	}()
 
 	updated := n.GetK8sNode().DeepCopy()
@@ -141,7 +143,7 @@ func TestWatchK8sNodeWatchError(t *testing.T) {
 	fakeClientSet.PrependWatchReactor("nodes", func(action ktesting.Action) (bool, watch.Interface, error) {
 		return true, nil, fmt.Errorf("watch failed")
 	})
-	err := n.watchK8sNode()
+	_, err := n.watchK8sNode()
 	assert.Assert(t, err != nil)
 }
 
@@ -151,17 +153,94 @@ func TestWatchK8sNodeClosed(t *testing.T) {
 	fakeClientSet.PrependWatchReactor("nodes", func(action ktesting.Action) (bool, watch.Interface, error) {
 		return true, watcher, nil
 	})
-	done := make(chan error, 1)
+	done := make(chan struct {
+		immediate bool
+		err       error
+	}, 1)
 	go func() {
-		done <- n.watchK8sNode()
+		immediate, err := n.watchK8sNode()
+		done <- struct {
+			immediate bool
+			err       error
+		}{immediate, err}
 	}()
 	watcher.Stop()
 	select {
-	case err := <-done:
-		assert.NilError(t, err)
+	case got := <-done:
+		assert.NilError(t, got.err)
+		assert.Equal(t, got.immediate, true)
 	case <-time.After(time.Second):
 		t.Fatal("watchK8sNode did not return after watch closed")
 	}
+}
+
+func TestWatchK8sNodeClosedAfterEvent(t *testing.T) {
+	n, fakeClientSet := newNode(t)
+	watcher := watch.NewFake()
+	fakeClientSet.PrependWatchReactor("nodes", func(action ktesting.Action) (bool, watch.Interface, error) {
+		return true, watcher, nil
+	})
+	done := make(chan struct {
+		immediate bool
+		err       error
+	}, 1)
+	go func() {
+		immediate, err := n.watchK8sNode()
+		done <- struct {
+			immediate bool
+			err       error
+		}{immediate, err}
+	}()
+	updated := n.GetK8sNode().DeepCopy()
+	updated.Labels["test.key"] = "test.val"
+	watcher.Modify(updated)
+	waitForNodeLabel(t, n, "test.key", "test.val")
+	watcher.Stop()
+	select {
+	case got := <-done:
+		assert.NilError(t, got.err)
+		assert.Equal(t, got.immediate, false)
+	case <-time.After(time.Second):
+		t.Fatal("watchK8sNode did not return after watch closed")
+	}
+}
+
+func TestUpdateReconnectsImmediatelyOnCleanClose(t *testing.T) {
+	n, fakeClientSet := newNode(t)
+	savedRetry := WATCH_RETRY_INTERVAL
+	WATCH_RETRY_INTERVAL = time.Second
+	t.Cleanup(func() { WATCH_RETRY_INTERVAL = savedRetry })
+
+	var watches atomic.Int32
+	fakeClientSet.PrependWatchReactor("nodes", func(action ktesting.Action) (bool, watch.Interface, error) {
+		watches.Add(1)
+		w := watch.NewFake()
+		w.Stop()
+		return true, w, nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	n.ctx = ctx
+	done := make(chan struct{})
+	go func() {
+		n.update()
+		close(done)
+	}()
+
+	deadline := time.Now().Add(400 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if watches.Load() >= 2 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("update did not stop after cancel")
+	}
+	assert.Assert(t, watches.Load() >= 2, "watches=%d", watches.Load())
 }
 
 func TestStartWatchesNode(t *testing.T) {

--- a/SaFE/node-agent/pkg/node/node_test.go
+++ b/SaFE/node-agent/pkg/node/node_test.go
@@ -160,7 +160,15 @@ func TestWatchTimeoutSecondsIsRandomizedAboveMinimum(t *testing.T) {
 	assert.Assert(t, len(seen) > 1, "timeout was not randomized")
 }
 
-func TestSetK8sNodeIfUnchangedSkipsStaleResponse(t *testing.T) {
+func TestResourceVersionOlderUsesDecimalOrder(t *testing.T) {
+	assert.Equal(t, resourceVersionOlder("9", "10"), true)
+	assert.Equal(t, resourceVersionOlder("10", "9"), false)
+	assert.Equal(t, resourceVersionOlder("12", "12"), false)
+	assert.Equal(t, resourceVersionOlder("", "12"), true)
+	assert.Equal(t, resourceVersionOlder("12", ""), false)
+}
+
+func TestSetK8sNodeIfNewerSkipsOlderResourceVersion(t *testing.T) {
 	n, _ := newNode(t)
 	watched := n.GetK8sNode().DeepCopy()
 	watched.ResourceVersion = "12"
@@ -170,15 +178,62 @@ func TestSetK8sNodeIfUnchangedSkipsStaleResponse(t *testing.T) {
 	stale := n.GetK8sNode().DeepCopy()
 	stale.ResourceVersion = "11"
 	stale.Labels["source"] = "update"
-	assert.Equal(t, n.setK8sNodeIfUnchanged("11", stale), false)
+	assert.Equal(t, n.setK8sNodeIfNewer(stale), false)
 	assert.Equal(t, n.GetK8sNode().ResourceVersion, "12")
 	assert.Equal(t, n.GetK8sNode().Labels["source"], "watch")
 
 	fresh := n.GetK8sNode().DeepCopy()
 	fresh.ResourceVersion = "13"
 	fresh.Labels["source"] = "update"
-	assert.Equal(t, n.setK8sNodeIfUnchanged("12", fresh), true)
+	assert.Equal(t, n.setK8sNodeIfNewer(fresh), true)
 	assert.Equal(t, n.GetK8sNode().ResourceVersion, "13")
+}
+
+func TestCacheKeepsAheadGetWhenDelayedWatchArrives(t *testing.T) {
+	n, _ := newNode(t)
+	n.setK8sNode(nodeWithRV(n.GetK8sNode(), "10", "watch-10"))
+	assert.Equal(t, n.setK8sNodeIfNewer(nodeWithRV(n.GetK8sNode(), "11", "get-11")), true)
+	assert.Equal(t, n.setK8sNodeIfNewer(nodeWithRV(n.GetK8sNode(), "12", "update-12")), true)
+
+	assert.NilError(t, n.applyWatchEvent(watch.Event{
+		Type:   watch.Modified,
+		Object: nodeWithRV(n.GetK8sNode(), "10", "watch-10"),
+	}))
+	assert.NilError(t, n.applyWatchEvent(watch.Event{
+		Type:   watch.Modified,
+		Object: nodeWithRV(n.GetK8sNode(), "11", "get-11"),
+	}))
+	assert.Equal(t, n.GetK8sNode().ResourceVersion, "12")
+	assert.Equal(t, n.GetK8sNode().Labels["source"], "update-12")
+}
+
+func TestUpdateStatusAppliesAfterStaleWatchEvent(t *testing.T) {
+	n, _ := newNode(t)
+	n.setK8sNode(nodeWithRV(n.GetK8sNode(), "12", "update-12"))
+
+	staleWatch := nodeWithRV(n.GetK8sNode(), "10", "watch-10")
+	assert.NilError(t, n.applyWatchEvent(watch.Event{Type: watch.Modified, Object: staleWatch}))
+	assert.Equal(t, n.GetK8sNode().ResourceVersion, "12")
+	assert.Equal(t, n.GetK8sNode().Labels["source"], "update-12")
+
+	response := nodeWithRV(n.GetK8sNode(), "12", "update-12")
+	assert.Equal(t, n.setK8sNodeIfNewer(response), true)
+	assert.Equal(t, n.GetK8sNode().ResourceVersion, "12")
+
+	n.setK8sNode(nodeWithRV(n.GetK8sNode(), "10", "watch-10"))
+	assert.Equal(t, n.setK8sNodeIfNewer(response), true)
+	assert.Equal(t, n.GetK8sNode().ResourceVersion, "12")
+	assert.Equal(t, n.GetK8sNode().Labels["source"], "update-12")
+}
+
+func nodeWithRV(node *corev1.Node, rv, source string) *corev1.Node {
+	out := node.DeepCopy()
+	out.ResourceVersion = rv
+	if out.Labels == nil {
+		out.Labels = map[string]string{}
+	}
+	out.Labels["source"] = source
+	return out
 }
 
 func TestUpdateConditionsKeepsNewerWatchState(t *testing.T) {


### PR DESCRIPTION
## Summary
- Switch node-agent from interval Get to a Watch on the current node (`metadata.name`).
- Reconnect after watch failures and keep Get for UpdateStatus conflict retries.

## Test plan
- [ ] `go test -count=1 -parallel 8 ./pkg/node/` in `SaFE/node-agent`


Made with [Cursor](https://cursor.com)