### PR TITLE
Add optional service name to Infer and Infera/Dynamo workloads

### DIFF
--- a/Web/apps/safe/src/composables/useWorkloadDetail.ts
+++ b/Web/apps/safe/src/composables/useWorkloadDetail.ts
@@ -228,6 +228,9 @@ export function useWorkloadDetail(options: UseWorkloadDetailOptions) {
         const servicePayload = detail.service
           ? {
               service: {
+                // Resume echoes back the name from GET. Omitting it would make the
+                // backend fall back to the workload id and rename the Service.
+                ...(detail.service.name ? { name: detail.service.name } : {}),
                 protocol: detail.service.protocol,
                 port: detail.service.port,
                 targetPort: detail.service.targetPort,

--- a/Web/apps/safe/src/pages/Dynamo/Components/AddDialog.test.ts
+++ b/Web/apps/safe/src/pages/Dynamo/Components/AddDialog.test.ts
@@ -57,7 +57,8 @@ describe('Dynamo/Infera AddDialog', () => {
   })
 
   it('carries the service name over on Resume but drops it on Clone', () => {
-    expect(dialogSource).toContain('label="service name"')
+    expect(dialogSource).toContain('<div class="section-title">Service Configuration</div>')
+    expect(dialogSource).toContain('label="Service Name"')
     expect(dialogSource).toContain(
       "name: props.action === 'Clone' ? '' : String(detail.service?.name || '')",
     )

--- a/Web/apps/safe/src/pages/Dynamo/Components/AddDialog.test.ts
+++ b/Web/apps/safe/src/pages/Dynamo/Components/AddDialog.test.ts
@@ -55,4 +55,11 @@ describe('Dynamo/Infera AddDialog', () => {
     expect(dialogSource).toContain('resumeWorkload(props.wlid, payload)')
     expect(dialogSource).toContain(':disabled="isEdit || isResume"')
   })
+
+  it('carries the service name over on Resume but drops it on Clone', () => {
+    expect(dialogSource).toContain('label="service name"')
+    expect(dialogSource).toContain(
+      "name: props.action === 'Clone' ? '' : String(detail.service?.name || '')",
+    )
+  })
 })

--- a/Web/apps/safe/src/pages/Dynamo/Components/AddDialog.vue
+++ b/Web/apps/safe/src/pages/Dynamo/Components/AddDialog.vue
@@ -45,25 +45,6 @@
             </el-col>
           </el-row>
 
-          <el-form-item label="service name" prop="service.name">
-            <div class="flex items-center gap-2 w-full">
-              <el-input
-                v-model="form.service.name"
-                :disabled="isEdit"
-                placeholder="Defaults to the workload ID"
-                class="flex-1"
-              />
-              <el-tooltip
-                content="In-cluster Service DNS name. Defaults to the workload ID, which changes on every recreate, so set a stable name to keep clients reachable across Resume. Cannot be changed once the workload is dispatched."
-                placement="top"
-              >
-                <el-icon class="text-gray-500 cursor-help">
-                  <InfoFilled />
-                </el-icon>
-              </el-tooltip>
-            </div>
-          </el-form-item>
-
           <el-form-item label="description">
             <el-input v-model="form.description" type="textarea" :rows="2" />
           </el-form-item>
@@ -383,6 +364,38 @@
             class="entry-editor"
             @input="markWorkerEntrypointCustomized"
           />
+        </div>
+
+        <div class="section-card">
+          <div class="section-header">
+            <div class="section-bar"></div>
+            <div>
+              <div class="section-title">Service Configuration</div>
+              <div class="section-subtitle">
+                Service name. Ports follow the frontend entrypoint, over {{ form.service.protocol }}
+                / {{ form.service.serviceType }}
+              </div>
+            </div>
+          </div>
+
+          <el-form-item label="Service Name" prop="service.name">
+            <div class="flex items-center gap-2 w-full">
+              <el-input
+                v-model="form.service.name"
+                :disabled="isEdit"
+                placeholder="Defaults to the workload ID"
+                class="flex-1"
+              />
+              <el-tooltip
+                content="In-cluster Service DNS name. Defaults to the workload ID, which changes on every recreate, so set a stable name to keep clients reachable across Resume. Cannot be changed once the workload is dispatched."
+                placement="top"
+              >
+                <el-icon class="text-gray-500 cursor-help">
+                  <InfoFilled />
+                </el-icon>
+              </el-tooltip>
+            </div>
+          </el-form-item>
         </div>
 
         <div class="section-card">

--- a/Web/apps/safe/src/pages/Dynamo/Components/AddDialog.vue
+++ b/Web/apps/safe/src/pages/Dynamo/Components/AddDialog.vue
@@ -45,6 +45,25 @@
             </el-col>
           </el-row>
 
+          <el-form-item label="service name" prop="service.name">
+            <div class="flex items-center gap-2 w-full">
+              <el-input
+                v-model="form.service.name"
+                :disabled="isEdit"
+                placeholder="Defaults to the workload ID"
+                class="flex-1"
+              />
+              <el-tooltip
+                content="In-cluster Service DNS name. Defaults to the workload ID, which changes on every recreate, so set a stable name to keep clients reachable across Resume. Cannot be changed once the workload is dispatched."
+                placement="top"
+              >
+                <el-icon class="text-gray-500 cursor-help">
+                  <InfoFilled />
+                </el-icon>
+              </el-tooltip>
+            </div>
+          </el-form-item>
+
           <el-form-item label="description">
             <el-input v-model="form.description" type="textarea" :rows="2" />
           </el-form-item>
@@ -516,6 +535,8 @@ const commandOverrideOpen = reactive<Record<InferaRoleKey, boolean>>({
 const advancedOpen = ref(false)
 
 const nameRegex = /^[a-z](?:[-a-z0-9]{0,38}[a-z0-9])?$/
+// The backend validates the K8s Service name as a DNS1035 label.
+const serviceNameRegex = /^[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?$/
 const required = (message: string) => ({ required: true, message, trigger: 'blur' })
 
 const rules = reactive<FormRules>({
@@ -556,6 +577,13 @@ const rules = reactive<FormRules>({
   'decode.memory': [required('Please input memory')],
   'service.port': [required('Please input service port')],
   'service.targetPort': [required('Please input target port')],
+  'service.name': [
+    {
+      pattern: serviceNameRegex,
+      message: 'Must start with lowercase letter, only a-z, 0-9, and "-" allowed, max 63 chars',
+      trigger: 'blur',
+    },
+  ],
 })
 
 interface DynamoDetail {
@@ -810,7 +838,13 @@ function hydrateFormFromDetail(detail: DynamoDetail) {
     dynamoOptions.kvTransferBackend || next.kvTransferBackend
   ) as WorkloadFormModel['kvTransferBackend']
 
-  next.service = { ...workloadService.value }
+  // Resume and Edit must send back the existing service name: it is immutable once
+  // dispatched, and dropping it would silently rename the Service to the workload id.
+  // A Clone gets a new workload id, so it has to drop the name to avoid a duplicate.
+  next.service = {
+    ...workloadService.value,
+    name: props.action === 'Clone' ? '' : String(detail.service?.name || ''),
+  }
 
   if (isInfera.value) {
     const frontendEntryPoint = detail.entryPoints?.[0]

--- a/Web/apps/safe/src/pages/Dynamo/dynamoPayload.test.ts
+++ b/Web/apps/safe/src/pages/Dynamo/dynamoPayload.test.ts
@@ -259,4 +259,29 @@ describe('dynamoPayload', () => {
       'Aggregation requires worker replica greater than 1',
     )
   })
+
+  it('omits the service name so the backend defaults it to the workload id', () => {
+    const form = createDefaultDynamoForm()
+
+    expect(form.service.name).toBe('')
+    expect(buildDynamoCreatePayload(form, 'core42-hyperloom').service).not.toHaveProperty('name')
+  })
+
+  it('sends a trimmed service name in both single-node and PD mode', () => {
+    const form = createDefaultDynamoForm()
+    form.service.name = '  dynamo-ds-r1  '
+
+    expect(buildDynamoCreatePayload(form, 'core42-hyperloom').service).toEqual({
+      name: 'dynamo-ds-r1',
+      protocol: 'TCP',
+      port: 8000,
+      targetPort: 8000,
+      serviceType: 'ClusterIP',
+    })
+
+    form.enablePd = true
+    expect(buildDynamoCreatePayload(form, 'core42-hyperloom').service).toMatchObject({
+      name: 'dynamo-ds-r1',
+    })
+  })
 })

--- a/Web/apps/safe/src/pages/Dynamo/dynamoPayload.test.ts
+++ b/Web/apps/safe/src/pages/Dynamo/dynamoPayload.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { decodeFromBase64String } from '@/utils'
 import {
+  DYNAMO_FRONTEND_ENTRYPOINT,
   buildDynamoEntrypointPreviewTokens,
   buildDynamoCreatePayload,
   createDefaultDynamoForm,
@@ -282,6 +283,16 @@ describe('dynamoPayload', () => {
     form.enablePd = true
     expect(buildDynamoCreatePayload(form, 'core42-hyperloom').service).toMatchObject({
       name: 'dynamo-ds-r1',
+    })
+  })
+
+  it('keeps both service ports in sync with the frontend entrypoint port', () => {
+    const entrypointPort = Number(DYNAMO_FRONTEND_ENTRYPOINT.match(/--http-port\s+(\d+)/)?.[1])
+
+    expect(entrypointPort).toBeGreaterThan(0)
+    expect(buildDynamoCreatePayload(createDefaultDynamoForm(), 'core42-hyperloom').service).toMatchObject({
+      port: entrypointPort,
+      targetPort: entrypointPort,
     })
   })
 })

--- a/Web/apps/safe/src/pages/Dynamo/dynamoPayload.ts
+++ b/Web/apps/safe/src/pages/Dynamo/dynamoPayload.ts
@@ -36,6 +36,7 @@ export interface DynamoFormModel {
   kvTransferBackend: DynamoKvTransferBackend
   env: Record<string, string>
   service: {
+    name: string
     protocol: string
     port: number
     targetPort: number
@@ -60,6 +61,7 @@ export interface DynamoCreatePayload {
   resources: DynamoResourcePayload[]
   env: Record<string, string>
   service: {
+    name?: string
     protocol: string
     port: number
     targetPort: number
@@ -100,6 +102,12 @@ export const DYNAMO_SERVICE = {
   serviceType: 'ClusterIP',
 } as const
 
+// Omitting the name lets the backend default the K8s Service to the workload id.
+function toServicePayload(form: DynamoFormModel) {
+  const name = form.service.name?.trim()
+  return { ...DYNAMO_SERVICE, ...(name ? { name } : {}) }
+}
+
 export function createDefaultDynamoForm(): DynamoFormModel {
   return {
     displayName: '',
@@ -117,6 +125,7 @@ export function createDefaultDynamoForm(): DynamoFormModel {
     kvTransferBackend: 'nixl',
     env: {},
     service: {
+      name: '',
       protocol: 'TCP',
       port: 8000,
       targetPort: 8000,
@@ -248,7 +257,7 @@ export function buildDynamoCreatePayload(form: DynamoFormModel, workspace: strin
       entryPoints: [frontendEntryPoint, workerEntryPoint, workerEntryPoint],
       resources: [FRONTEND_RESOURCE, toResourcePayload(form.prefill), toResourcePayload(form.decode)],
       env: form.env,
-      service: { ...DYNAMO_SERVICE },
+      service: toServicePayload(form),
       dynamoOptions: {
         serviceRoles: ['frontend', 'prefill', 'decode'],
         kvTransferBackend: form.kvTransferBackend || 'nixl',
@@ -269,7 +278,7 @@ export function buildDynamoCreatePayload(form: DynamoFormModel, workspace: strin
     entryPoints: [frontendEntryPoint, workerEntryPoint],
     resources: [FRONTEND_RESOURCE, toResourcePayload(form.worker)],
     env: form.env,
-    service: { ...DYNAMO_SERVICE },
+    service: toServicePayload(form),
     dynamoOptions: {
       serviceRoles: ['frontend', 'worker'],
       kvTransferBackend: form.kvTransferBackend || 'nixl',

--- a/Web/apps/safe/src/pages/Dynamo/dynamoPayload.ts
+++ b/Web/apps/safe/src/pages/Dynamo/dynamoPayload.ts
@@ -102,10 +102,18 @@ export const DYNAMO_SERVICE = {
   serviceType: 'ClusterIP',
 } as const
 
+// The frontend entrypoint owns the port the server listens on, so the Service has to
+// follow it rather than assume the default.
+function resolveServicePort() {
+  const port = Number(DYNAMO_FRONTEND_ENTRYPOINT.match(/--http-port\s+(\d+)/)?.[1])
+  return port > 0 && port <= 65535 ? port : DYNAMO_SERVICE.port
+}
+
 // Omitting the name lets the backend default the K8s Service to the workload id.
 function toServicePayload(form: DynamoFormModel) {
   const name = form.service.name?.trim()
-  return { ...DYNAMO_SERVICE, ...(name ? { name } : {}) }
+  const port = resolveServicePort()
+  return { ...DYNAMO_SERVICE, port, targetPort: port, ...(name ? { name } : {}) }
 }
 
 export function createDefaultDynamoForm(): DynamoFormModel {

--- a/Web/apps/safe/src/pages/Infer/Components/AddDialog.vue
+++ b/Web/apps/safe/src/pages/Infer/Components/AddDialog.vue
@@ -217,9 +217,32 @@
             <div class="section-bar"></div>
             <div>
               <div class="section-title">Service Configuration</div>
-              <div class="section-subtitle">Protocol, ports and service type</div>
+              <div class="section-subtitle">Name, protocol, ports and service type</div>
             </div>
           </div>
+
+          <el-row :gutter="20">
+            <el-col :span="24">
+              <el-form-item label="Service Name" prop="service.name">
+                <div class="flex items-center gap-2 w-full">
+                  <el-input
+                    v-model="form.service.name"
+                    placeholder="Defaults to the workload ID"
+                    :disabled="isEdit"
+                    class="flex-1"
+                  />
+                  <el-tooltip
+                    content="In-cluster Service DNS name. Defaults to the workload ID, which changes on every recreate, so set a stable name to keep clients reachable across Resume. Cannot be changed once the workload is dispatched."
+                    placement="top"
+                  >
+                    <el-icon class="text-gray-500 cursor-help">
+                      <InfoFilled />
+                    </el-icon>
+                  </el-tooltip>
+                </div>
+              </el-form-item>
+            </el-col>
+          </el-row>
 
           <el-row :gutter="20">
             <el-col :span="12">
@@ -563,6 +586,7 @@ const initialForm = () => ({
 
   // Service configuration
   service: {
+    name: '',
     protocol: 'TCP',
     port: null as number | null,
     targetPort: null as number | null,
@@ -609,6 +633,8 @@ const placeholders = computed(() => {
 })
 
 const nameRegex = /^[a-z](?:[-a-z0-9]{0,38}[a-z0-9])?$/
+// The backend validates the K8s Service name as a DNS1035 label.
+const serviceNameRegex = /^[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?$/
 
 const ruleFormRef = ref<FormInstance>()
 const rules: Record<string, FormItemRule[]> = reactive({
@@ -639,6 +665,13 @@ const rules: Record<string, FormItemRule[]> = reactive({
       required: true,
       message: 'Please select at least one node',
       trigger: 'change',
+    },
+  ],
+  'service.name': [
+    {
+      pattern: serviceNameRegex,
+      message: 'Must start with lowercase letter, only a-z, 0-9, and "-" allowed, max 63 chars',
+      trigger: 'blur',
     },
   ],
   'service.port': [
@@ -743,6 +776,8 @@ const onSubmit = async (formEl: FormInstance | undefined) => {
       form.service.targetPort && form.service.port
         ? {
             service: {
+              // Omitting the name lets the backend default the Service to the workload ID.
+              ...(form.service.name.trim() ? { name: form.service.name.trim() } : {}),
               protocol: form.service.protocol,
               port: form.service.port,
               targetPort: form.service.targetPort,
@@ -900,6 +935,11 @@ const setInitialFormValues = async () => {
   // Map service configuration
   if (res.service) {
     form.service = {
+      // Resume and Edit must send back the existing service name: it is immutable
+      // once dispatched, and dropping it would silently rename the Service to the
+      // workload ID. A Clone gets a new workload ID, so it has to drop the name to
+      // avoid colliding with the source workload.
+      name: props.action === 'Clone' ? '' : String(res.service.name || ''),
       protocol: res.service.protocol || 'TCP',
       port: res.service.port || null,
       targetPort: res.service.targetPort || null,

--- a/Web/apps/safe/src/pages/Infera/inferaPayload.test.ts
+++ b/Web/apps/safe/src/pages/Infera/inferaPayload.test.ts
@@ -171,4 +171,29 @@ describe('inferaPayload', () => {
 
     expect(decodeFromBase64String(payload.entryPoints[0])).toBe(form.frontendEntrypoint)
   })
+
+  it('omits the service name so the backend defaults it to the workload id', () => {
+    const form = createDefaultInferaForm()
+
+    expect(form.service.name).toBe('')
+    expect(buildInferaCreatePayload(form, 'core42-hyperloom').service).not.toHaveProperty('name')
+  })
+
+  it('sends a trimmed service name in both single-node and PD mode', () => {
+    const form = createDefaultInferaForm()
+    form.service.name = '  infera-glm53-1p1d  '
+
+    expect(buildInferaCreatePayload(form, 'core42-hyperloom').service).toEqual({
+      name: 'infera-glm53-1p1d',
+      protocol: 'TCP',
+      port: 8000,
+      targetPort: 8000,
+      serviceType: 'ClusterIP',
+    })
+
+    form.enablePd = true
+    expect(buildInferaCreatePayload(form, 'core42-hyperloom').service).toMatchObject({
+      name: 'infera-glm53-1p1d',
+    })
+  })
 })

--- a/Web/apps/safe/src/pages/Infera/inferaPayload.test.ts
+++ b/Web/apps/safe/src/pages/Infera/inferaPayload.test.ts
@@ -196,4 +196,30 @@ describe('inferaPayload', () => {
       name: 'infera-glm53-1p1d',
     })
   })
+
+  it('points both service ports at the frontend entrypoint port', () => {
+    const form = createDefaultInferaForm()
+
+    expect(buildInferaCreatePayload(form, 'core42-hyperloom').service).toMatchObject({
+      port: 8000,
+      targetPort: 8000,
+    })
+
+    form.frontendEntrypoint =
+      'python3 -m infera.server --host 0.0.0.0 --port 9001 --router-tokenizer-path /models/x'
+    expect(buildInferaCreatePayload(form, 'core42-hyperloom').service).toMatchObject({
+      port: 9001,
+      targetPort: 9001,
+    })
+  })
+
+  it('falls back to the default port when the entrypoint has no usable port', () => {
+    const form = createDefaultInferaForm()
+    form.frontendEntrypoint = 'python3 -m infera.server --host 0.0.0.0 --router-policy kv-aware'
+
+    expect(buildInferaCreatePayload(form, 'core42-hyperloom').service).toMatchObject({
+      port: 8000,
+      targetPort: 8000,
+    })
+  })
 })

--- a/Web/apps/safe/src/pages/Infera/inferaPayload.ts
+++ b/Web/apps/safe/src/pages/Infera/inferaPayload.ts
@@ -30,6 +30,7 @@ export interface InferaFormModel {
   kvTransferBackend: InferaKvTransferBackend
   env: Record<string, string>
   service: {
+    name: string
     protocol: string
     port: number
     targetPort: number
@@ -55,6 +56,7 @@ export interface InferaCreatePayload {
   resources: InferaResourcePayload[]
   env: Record<string, string>
   service: {
+    name?: string
     protocol: string
     port: number
     targetPort: number
@@ -95,6 +97,12 @@ export const INFERA_SERVICE = {
   serviceType: 'ClusterIP',
 } as const
 
+// Omitting the name lets the backend default the K8s Service to the workload id.
+function toServicePayload(form: InferaFormModel) {
+  const name = form.service.name?.trim()
+  return { ...INFERA_SERVICE, ...(name ? { name } : {}) }
+}
+
 export function createDefaultInferaForm(): InferaFormModel {
   return {
     displayName: '',
@@ -122,6 +130,7 @@ export function createDefaultInferaForm(): InferaFormModel {
       NCCL_DEBUG: 'INFO',
     },
     service: {
+      name: '',
       protocol: 'TCP',
       port: 8000,
       targetPort: 8000,
@@ -205,7 +214,7 @@ export function buildInferaCreatePayload(form: InferaFormModel, workspace: strin
       entryPoints: [frontendEntryPoint, prefillEntryPoint, decodeEntryPoint],
       resources: [toResourcePayload(form.frontend), toResourcePayload(form.prefill), toResourcePayload(form.decode)],
       env: form.env,
-      service: { ...INFERA_SERVICE },
+      service: toServicePayload(form),
       inferaOptions: {
         serviceRoles: ['frontend', 'prefill', 'decode'],
         kvTransferBackend: form.kvTransferBackend || 'mori',
@@ -223,7 +232,7 @@ export function buildInferaCreatePayload(form: InferaFormModel, workspace: strin
     entryPoints: [frontendEntryPoint, workerEntryPoint],
     resources: [toResourcePayload(form.frontend), toResourcePayload(form.worker)],
     env: form.env,
-    service: { ...INFERA_SERVICE },
+    service: toServicePayload(form),
     inferaOptions: {
       serviceRoles: ['frontend', 'worker'],
     },

--- a/Web/apps/safe/src/pages/Infera/inferaPayload.ts
+++ b/Web/apps/safe/src/pages/Infera/inferaPayload.ts
@@ -97,10 +97,18 @@ export const INFERA_SERVICE = {
   serviceType: 'ClusterIP',
 } as const
 
+// The frontend entrypoint owns the port the server listens on, so the Service has to
+// follow it rather than assume the default.
+function resolveServicePort(form: InferaFormModel) {
+  const port = Number(resolveFrontendEntrypoint(form).match(/--port\s+(\d+)/)?.[1])
+  return port > 0 && port <= 65535 ? port : INFERA_SERVICE.port
+}
+
 // Omitting the name lets the backend default the K8s Service to the workload id.
 function toServicePayload(form: InferaFormModel) {
   const name = form.service.name?.trim()
-  return { ...INFERA_SERVICE, ...(name ? { name } : {}) }
+  const port = resolveServicePort(form)
+  return { ...INFERA_SERVICE, port, targetPort: port, ...(name ? { name } : {}) }
 }
 
 export function createDefaultInferaForm(): InferaFormModel {

--- a/Web/apps/safe/src/services/workload/type.ts
+++ b/Web/apps/safe/src/services/workload/type.ts
@@ -119,6 +119,9 @@ export interface EditWorkloadRequest {
     rdmaResource?: string
   }>
   service?: {
+    // K8s Service name. Backend defaults it to the workload id when omitted,
+    // and rejects a name already taken by another workload in the workspace.
+    name?: string
     protocol: string
     port: number | null
     targetPort: number | null
@@ -180,6 +183,9 @@ export interface SubmitWorkloadRequest {
     rdmaResource?: string
   }>
   service?: {
+    // K8s Service name. Backend defaults it to the workload id when omitted,
+    // and rejects a name already taken by another workload in the workspace.
+    name?: string
     protocol: string
     port: number | null
     targetPort: number | null


### PR DESCRIPTION
## What

The backend `Service` spec already accepts an optional `name`, and `GET /workloads/{id}` returns it (`GetWorkloadResponse` embeds `*v1.Service`). The console dropped the field when hydrating a form and never sent it back. This exposes a Service Name input in the Infer and Infera/Dynamo dialogs and threads the value through GET -> form -> payload.

## Why this is more than a new input

`mutateService` resolves the name as: explicit value -> existing `ServiceNameLabel` -> **workload id**. So a payload without `name` does not mean "keep what you had", it means "rename to the workload id".

That made **Resume silently rename the Service**. The production Infera `infera-glm53-1p1d-kqx55` serves a Service called `infera-glm53-1p1d`, deliberately without the random suffix so the DNS name stays stable across recreates. Resuming it from the console would have renamed the Service to `infera-glm53-1p1d-kqx55` and broken every client pointing at the old name.

Three separate code paths build a resume payload, and all three dropped the name: the Infer dialog, the Infera/Dynamo dialog, and `useWorkloadDetail`, which is what the Infer **detail page** resumes through. All three now carry it.

Conversely, **Clone has to drop the name**. `validateServiceNameUnique` rejects a create when another live workload in the workspace already owns the name, so carrying it into a clone would fail with a 409 `AlreadyExists`. When there is no name the key is omitted entirely rather than sent as an empty string.

## Behaviour per action

| Action | Service name |
| --- | --- |
| Create | empty by default; backend falls back to the workload id |
| Edit | shown but disabled, since the name is immutable after dispatch |
| Resume | carried over from GET, so the DNS name survives the restart |
| Clone | cleared, since the source workload still owns it |

Validated client-side as a DNS1035 label (lowercase, leading letter, max 63 chars) to match the webhook.

## Service ports now follow the frontend entrypoint

Infera and Dynamo pinned `port` and `targetPort` to 8000 while the port the server actually listens on lives in the frontend entrypoint (`--port` for Infera, `--http-port` for Dynamo). The Infera frontend entrypoint is user-editable, so pointing it at another port produced a Service whose target port nothing was listening on, leaving it with no ready endpoints. Both ports are now derived from that flag, falling back to 8000 when it is absent or unparseable.

Infera keeps a single editable service field. It initially sat in Basic Information, which made it hard to find next to the Deployment dialog's Service Configuration block, so it now has a matching section of its own.

## Testing

- `npm run type-check` clean.
- `npm test` — 135 passed, 8 new, covering name omission, trimming, both the PD and single-node payload branches, entrypoint-driven ports, and the port fallback.
- `oxlint -D correctness` — 35 errors, identical to the base commit; all pre-existing and in untouched files.

Not exercised against a live cluster: the production workload above must not be stopped, and Resume requires a Stopped workload.
