### PR TITLE
fix(safe): carry an ssh reverse forward on one exec instead of one per connection

### DIFF
--- a/SaFE/apiserver/cmd/safe-rfwd-mux/main.go
+++ b/SaFE/apiserver/cmd/safe-rfwd-mux/main.go
@@ -1,0 +1,319 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+// Command safe-rfwd-mux is the pod-side half of an SSH reverse forward.
+//
+// The apiserver injects it into the target container and runs it under a single
+// long-lived Kubernetes exec. It owns the forwarded listen socket and carries
+// every connection made to that socket over its stdin and stdout, so a forward
+// costs one exec however many connections travel through it.
+//
+// It is deliberately self-contained: no configuration file, no network calls of
+// its own, and nothing to clean up afterwards - it removes its own image from the
+// container as soon as the socket is bound.
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/AMD-AIG-AIMA/SAFE/apiserver/pkg/handlers/ssh-handlers/rfwdmux"
+)
+
+const (
+	// keepaliveInterval keeps the apiserver's idea of this session fresh, and is
+	// what stops the idle timeout below from firing on a quiet but healthy forward.
+	keepaliveInterval = 30 * time.Second
+	// idleTimeout is how long this process waits for any frame before deciding the
+	// apiserver is gone. It is the answer to the orphan the socat relay had none
+	// for: an exec stream that is neither readable nor closed used to leave the pod
+	// holding the listen port until the pod itself died.
+	idleTimeout = 5 * time.Minute
+	// statInterval is how often the counters go to the apiserver's log.
+	statInterval = time.Minute
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fatal("usage: safe-rfwd-mux listen <addr> <port> | safe-rfwd-mux check")
+	}
+	switch os.Args[1] {
+	case "check":
+		// Running at all is the answer: it is how the installer tells a binary that
+		// matches the container's architecture and sits on an executable filesystem
+		// from one that does not.
+		fmt.Println("safe-rfwd-mux ok")
+	case "listen":
+		if err := listen(os.Args[2:]); err != nil {
+			fatal("%v", err)
+		}
+	default:
+		fatal("unknown command %q", os.Args[1])
+	}
+}
+
+// fatal reports a failure the way the apiserver reads it and stops.
+func fatal(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "%s %s\n", rfwdmux.ErrMarker, fmt.Sprintf(format, args...))
+	os.Exit(1)
+}
+
+// listen binds the forwarded port and carries what arrives on it.
+func listen(args []string) error {
+	fs := flag.NewFlagSet("listen", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	maxStreams := fs.Int("max-streams", rfwdmux.DefaultMaxStreams,
+		"how many connections this forward carries at once")
+	removeDir := fs.String("remove-dir", "",
+		"directory to delete once the socket is bound, so nothing is left in the container")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 2 {
+		return errors.New("usage: safe-rfwd-mux listen [flags] <addr> <port>")
+	}
+	addr := fs.Arg(0)
+	port, err := strconv.ParseUint(fs.Arg(1), 10, 16)
+	if err != nil {
+		return fmt.Errorf("listen port %q is not a port: %v", fs.Arg(1), err)
+	}
+
+	// Bind before anything else is announced: a forward that cannot have its port
+	// must fail here, where the reason is still known, rather than as a connection
+	// that quietly goes nowhere.
+	ln, err := net.Listen("tcp4", net.JoinHostPort(addr, strconv.FormatUint(port, 10)))
+	if err != nil {
+		return fmt.Errorf("failed to listen on %s:%d: %v", addr, port, err)
+	}
+	defer ln.Close()
+
+	// The image is of no further use to anyone: the running process keeps its own
+	// inode, so removing it now means no cleanup can be missed later, whatever ends
+	// this process.
+	removeSelf(*removeDir)
+
+	session := rfwdmux.NewSession(
+		rfwdmux.Join(os.Stdin, os.Stdout, os.Stdin, os.Stdout),
+		rfwdmux.Config{
+			MaxStreams:        *maxStreams,
+			Initiator:         true,
+			KeepaliveInterval: keepaliveInterval,
+			IdleTimeout:       idleTimeout,
+			Logf:              diagf,
+		})
+
+	// Closing the listener is what makes the accept loop below return, and it is
+	// the moment the pod lets go of the port. Everything that ends this process
+	// goes through here: the apiserver ending the exec's stdin, the session idling
+	// out, or the container runtime signalling us.
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		select {
+		case <-session.Done():
+		case sig := <-signals:
+			diagf("stopping on %s", sig)
+			_ = session.Close()
+		}
+		_ = ln.Close()
+	}()
+
+	go reportStats(session)
+
+	fmt.Fprintln(os.Stderr, rfwdmux.ReadyMarker)
+	serve(ln, session)
+	// The accept loop ending is the end of the forward, whatever ended it. Without
+	// this a listener that stopped accepting would sit here with the port still
+	// bound and the session still answering keepalives - a forward that looks
+	// healthy from the apiserver and answers nothing, which is the failure this
+	// whole design exists to remove.
+	_ = session.Close()
+	<-session.Done()
+	return nil
+}
+
+// serve hands every accepted connection to a stream, or refuses it.
+func serve(ln net.Listener, session *rfwdmux.Session) {
+	var conns sync.WaitGroup
+	defer conns.Wait()
+	// A pod that has run out of file descriptors recovers; the forward should not
+	// be over because one accept failed while it did.
+	backoff := time.Duration(0)
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if !isTemporary(err) {
+				return
+			}
+			if backoff == 0 {
+				backoff = 5 * time.Millisecond
+			} else if backoff < time.Second {
+				backoff *= 2
+			}
+			diagf("accept failed, retrying in %s: %v", backoff, err)
+			select {
+			case <-time.After(backoff):
+			case <-session.Done():
+				return
+			}
+			continue
+		}
+		backoff = 0
+		stream, err := session.Open(originOf(conn.RemoteAddr()))
+		if err != nil {
+			if errors.Is(err, rfwdmux.ErrTooManyStreams) {
+				// Refuse now rather than queue. A connection held in a queue nobody
+				// is draining is what turned a busy proxy into a listener that
+				// accepted and then never answered; a refused connection at least
+				// fails where the caller can see it.
+				session.CountDropped()
+				diagf("refusing a connection from %s: already carrying %d",
+					conn.RemoteAddr(), session.NumStreams())
+			}
+			reset(conn)
+			continue
+		}
+		conns.Add(1)
+		go func() {
+			defer conns.Done()
+			splice(conn, stream, session)
+		}()
+	}
+}
+
+// isTemporary reports whether an accept failure is worth retrying. A listener that
+// has been closed, which is how this process is stopped, is not.
+func isTemporary(err error) bool {
+	if errors.Is(err, net.ErrClosed) {
+		return false
+	}
+	// The errnos come first. Accept wraps every failure in a *net.OpError, which is
+	// itself a net.Error, so a net.Error test placed above this one matches
+	// everything and answers Timeout() - false for exactly the exhaustion errors
+	// this is here to survive.
+	for _, errno := range []syscall.Errno{
+		syscall.EMFILE, syscall.ENFILE, syscall.ENOBUFS, syscall.ENOMEM,
+		syscall.ECONNABORTED, syscall.EINTR,
+	} {
+		if errors.Is(err, errno) {
+			return true
+		}
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return netErr.Timeout()
+	}
+	return false
+}
+
+// originOf splits a peer address into the parts a forwarded-tcpip channel names.
+func originOf(addr net.Addr) (string, uint32) {
+	tcpAddr, ok := addr.(*net.TCPAddr)
+	if !ok || tcpAddr.IP == nil {
+		return "127.0.0.1", 0
+	}
+	return tcpAddr.IP.String(), uint32(tcpAddr.Port)
+}
+
+// reset refuses a connection abruptly. A lingerless close sends a TCP reset, so
+// the process inside the pod gets an error on the spot instead of a connection
+// that was accepted and will never be answered.
+func reset(conn net.Conn) {
+	if tcpConn, ok := conn.(*net.TCPConn); ok {
+		_ = tcpConn.SetLinger(0)
+	}
+	_ = conn.Close()
+}
+
+// splice copies one accepted connection onto its stream in both directions.
+func splice(conn net.Conn, stream *rfwdmux.Stream, session *rfwdmux.Session) {
+	done := make(chan struct{})
+	var once sync.Once
+	finish := func() { once.Do(func() { close(done) }) }
+
+	// A session that ends must not leave connections waiting on it.
+	go func() {
+		select {
+		case <-done:
+		case <-session.Done():
+		}
+		_ = conn.Close()
+		_ = stream.Close()
+	}()
+
+	// Each direction ends on its own. One side finishing is a half-close, which
+	// only closes that direction; an error is a broken connection and takes the
+	// pair down.
+	var copying sync.WaitGroup
+	copying.Add(2)
+	go func() {
+		defer copying.Done()
+		if _, err := io.Copy(stream, conn); err != nil {
+			finish()
+		}
+		_ = stream.CloseWrite()
+	}()
+	go func() {
+		defer copying.Done()
+		if _, err := io.Copy(conn, stream); err != nil {
+			finish()
+		}
+		if tcpConn, ok := conn.(*net.TCPConn); ok {
+			_ = tcpConn.CloseWrite()
+		}
+	}()
+	copying.Wait()
+	finish()
+}
+
+// reportStats gives the apiserver's log the two numbers that say whether a forward
+// is healthy: what it is carrying, and what it had to turn away.
+func reportStats(session *rfwdmux.Session) {
+	ticker := time.NewTicker(statInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-session.Done():
+			opened, open, dropped := session.Stats()
+			fmt.Fprintf(os.Stderr, "%s streams=%d opened=%d dropped=%d stopped=%v\n",
+				rfwdmux.StatMarker, open, opened, dropped, session.Err())
+			return
+		case <-ticker.C:
+			opened, open, dropped := session.Stats()
+			fmt.Fprintf(os.Stderr, "%s streams=%d opened=%d dropped=%d\n",
+				rfwdmux.StatMarker, open, opened, dropped)
+		}
+	}
+}
+
+// removeSelf deletes this binary and the directory it was installed into. On Linux
+// a running executable keeps its inode after the name is gone, so the process
+// carries on with nothing left behind for a later session to trip over.
+func removeSelf(dir string) {
+	if dir == "" {
+		return
+	}
+	if self, err := os.Executable(); err == nil && filepath.Dir(self) == filepath.Clean(dir) {
+		_ = os.Remove(self)
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		diagf("could not remove %s: %v", dir, err)
+	}
+}
+
+// diagf writes a diagnostic line, which reaches the apiserver's log unmarked.
+func diagf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+}

--- a/SaFE/apiserver/cmd/safe-rfwd-mux/main_test.go
+++ b/SaFE/apiserver/cmd/safe-rfwd-mux/main_test.go
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+package main
+
+import (
+	"net"
+	"syscall"
+	"testing"
+
+	testifyassert "github.com/stretchr/testify/assert"
+)
+
+// TestIsTemporaryReadsTheErrorAcceptActuallyBuilds pins the ordering inside
+// isTemporary. Accept wraps every failure in a *net.OpError, which is itself a
+// net.Error, so testing for net.Error before the errnos would match all of these
+// and answer Timeout() - false - turning a pod that briefly ran out of file
+// descriptors into a forward that is over.
+func TestIsTemporaryReadsTheErrorAcceptActuallyBuilds(t *testing.T) {
+	for _, errno := range []syscall.Errno{
+		syscall.EMFILE, syscall.ENFILE, syscall.ENOBUFS,
+		syscall.ENOMEM, syscall.ECONNABORTED, syscall.EINTR,
+	} {
+		err := &net.OpError{Op: "accept", Net: "tcp", Err: errno}
+		testifyassert.Truef(t, isTemporary(err), "accept should be retried after %v", errno)
+	}
+
+	// A closed listener is how this process is stopped, and a genuine failure is
+	// not worth spinning on.
+	testifyassert.False(t, isTemporary(net.ErrClosed))
+	testifyassert.False(t, isTemporary(&net.OpError{Op: "accept", Err: net.ErrClosed}))
+	testifyassert.False(t, isTemporary(&net.OpError{Op: "accept", Err: syscall.EINVAL}))
+}
+
+func TestOriginOfNamesAnUnknownPeer(t *testing.T) {
+	addr, port := originOf(&net.TCPAddr{IP: net.ParseIP("10.0.0.9"), Port: 51234})
+	testifyassert.Equal(t, "10.0.0.9", addr)
+	testifyassert.Equal(t, uint32(51234), port)
+
+	// forwarded-tcpip has no spelling for "unknown", so something has to be sent.
+	addr, port = originOf(&net.UnixAddr{Name: "/tmp/s", Net: "unix"})
+	testifyassert.Equal(t, "127.0.0.1", addr)
+	testifyassert.Equal(t, uint32(0), port)
+}

--- a/SaFE/apiserver/installer/Dockerfile
+++ b/SaFE/apiserver/installer/Dockerfile
@@ -16,6 +16,10 @@ ENV GOPATH="/workspace/primus-safe/go"
 COPY ./SaFE /workspace/primus-safe
 WORKDIR /workspace/primus-safe
 RUN mkdir dist && mkdir dist/logs
+# The pod-side reverse-forward multiplexer is embedded in the apiserver and
+# injected into a user's container over an exec, so it has to exist before the
+# apiserver is compiled and has to cover every architecture a workload may run on.
+RUN sh ./apiserver/installer/build-rfwd-mux.sh
 RUN GOOS=linux GOARCH=amd64  go build -o dist/apiserver ./apiserver/cmd/main.go
 
 FROM  ${REGISTRY}/library/ubuntu:22.04

--- a/SaFE/apiserver/installer/build-rfwd-mux.sh
+++ b/SaFE/apiserver/installer/build-rfwd-mux.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Build the pod-side reverse-forward multiplexer for every architecture the
+# apiserver can inject, and put the results where go:embed picks them up.
+#
+# The image build runs this before building the apiserver, so the binaries it
+# carries are always the ones built from this tree. The tests do not need it: they
+# build their own copy for the machine they run on.
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+out="$root/apiserver/pkg/handlers/ssh-handlers/muxbin"
+
+for arch in amd64 arm64; do
+  # Static and stripped: it is written into a container whose libc is unknown and
+  # streamed over an exec for every forward, so size is a latency cost.
+  # go build refuses to overwrite the committed placeholder, which is not an
+  # object file.
+  rm -f "$out/mux-linux-$arch"
+  CGO_ENABLED=0 GOOS=linux GOARCH="$arch" \
+    go build -trimpath -ldflags "-s -w" \
+    -o "$out/mux-linux-$arch" "$root/apiserver/cmd/safe-rfwd-mux"
+  echo "built $out/mux-linux-$arch"
+done

--- a/SaFE/apiserver/pkg/handlers/ssh-handlers/muxbin/embed.go
+++ b/SaFE/apiserver/pkg/handlers/ssh-handlers/muxbin/embed.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+// Package muxbin carries the pod-side reverse-forward multiplexer inside the
+// apiserver binary, so that opening a forward does not depend on anything being
+// present in the user's image.
+//
+// The files here are placeholders in the source tree and real binaries in the
+// container image; build-rfwd-mux.sh replaces them, and the image build runs it.
+// Shipping placeholders rather than committed binaries keeps the repository free of
+// build output while still letting a clean checkout compile and test - the tests
+// that need a multiplexer that runs build their own.
+package muxbin
+
+import (
+	"bytes"
+	_ "embed"
+	"fmt"
+)
+
+//go:embed mux-linux-amd64
+var linuxAMD64 []byte
+
+//go:embed mux-linux-arm64
+var linuxARM64 []byte
+
+// elfMagic is how a real binary is told from the placeholder standing in for one.
+var elfMagic = []byte{0x7f, 'E', 'L', 'F'}
+
+// For returns the multiplexer built for the container's architecture, named the
+// way `uname -m` spells it.
+func For(machine string) ([]byte, string, error) {
+	var binary []byte
+	var arch string
+	switch machine {
+	case "x86_64", "amd64", "x64":
+		binary, arch = linuxAMD64, "linux/amd64"
+	case "aarch64", "arm64", "armv8l", "armv8b":
+		binary, arch = linuxARM64, "linux/arm64"
+	default:
+		return nil, "", fmt.Errorf("no reverse forward multiplexer is built for machine %q", machine)
+	}
+	if !bytes.HasPrefix(binary, elfMagic) {
+		return nil, arch, fmt.Errorf("this apiserver was built without the %s reverse forward "+
+			"multiplexer; run SaFE/apiserver/installer/build-rfwd-mux.sh before building the image", arch)
+	}
+	return binary, arch, nil
+}
+
+// Available reports whether a usable binary is embedded for machine, which is how
+// a test decides whether it can inject one.
+func Available(machine string) bool {
+	_, _, err := For(machine)
+	return err == nil
+}

--- a/SaFE/apiserver/pkg/handlers/ssh-handlers/muxbin/mux-linux-amd64
+++ b/SaFE/apiserver/pkg/handlers/ssh-handlers/muxbin/mux-linux-amd64
@@ -1,0 +1,5 @@
+This file is a placeholder for the pod-side reverse-forward multiplexer built for
+linux/amd64. It is committed so the apiserver compiles from a clean checkout; the
+container image build replaces it with the real binary.
+
+Build it with SaFE/apiserver/installer/build-rfwd-mux.sh before building the image.

--- a/SaFE/apiserver/pkg/handlers/ssh-handlers/muxbin/mux-linux-arm64
+++ b/SaFE/apiserver/pkg/handlers/ssh-handlers/muxbin/mux-linux-arm64
@@ -1,0 +1,5 @@
+This file is a placeholder for the pod-side reverse-forward multiplexer built for
+linux/arm64. It is committed so the apiserver compiles from a clean checkout; the
+container image build replaces it with the real binary.
+
+Build it with SaFE/apiserver/installer/build-rfwd-mux.sh before building the image.

--- a/SaFE/apiserver/pkg/handlers/ssh-handlers/pod_listener.go
+++ b/SaFE/apiserver/pkg/handlers/ssh-handlers/pod_listener.go
@@ -66,6 +66,12 @@ const muxIdleTimeout = 5 * time.Minute
 // up on the connection. It is a variable so tests do not wait it out.
 var installTimeout = 60 * time.Second
 
+// installCleanupTimeout bounds the exec that removes a half-finished install. It is
+// deliberately much shorter than installTimeout: it runs on the failure path, inside
+// the same global request that has already spent its install budget, and leaving the
+// pod tidy is not worth pushing that request past what an ssh client will wait.
+var installCleanupTimeout = 10 * time.Second
+
 // listenerReadyTimeout bounds how long we wait for the Pod-side listener to bind.
 // It is a variable so a test can reach the branch where the pod never binds.
 var listenerReadyTimeout = 15 * time.Second
@@ -132,6 +138,10 @@ type execPodListener struct {
 	dir       string
 	bindAddr  string
 	bindPort  uint32
+	// token names everything this listener creates inside the pod. It is kept
+	// apart from dir because the probe writes under it in whichever candidate
+	// directory it is trying, before any of them has been chosen.
+	token string
 
 	session *rfwdmux.Session
 	cancel  context.CancelFunc
@@ -164,20 +174,24 @@ func newExecPodListener(ctx context.Context, userInfo *UserInfo,
 		container:  userInfo.Container,
 		bindAddr:   bindAddr,
 		bindPort:   bindPort,
+		token:      token,
 		cancel:     cancel,
 		doneCh:     make(chan struct{}),
 		streamDone: make(chan struct{}),
 	}
 
+	// Both failure arms clean up, because neither of the pod's own cleanup routes
+	// has started yet: the run script's trap needs the run script, and the
+	// multiplexer removes its own files only once the port is bound. What is left
+	// behind otherwise stays for the life of the pod, under a fresh token each
+	// time, so a client that keeps retrying keeps adding copies.
 	if err = l.install(runCtx, token); err != nil {
 		cancel()
+		l.removeInstall()
 		return nil, err
 	}
 	if err = l.run(runCtx); err != nil {
 		_ = l.Close()
-		// The run script's trap and the multiplexer's own cleanup both need the
-		// multiplexer to have started. This is the path where neither did, and
-		// nothing else in the pod would ever clear the install away.
 		l.removeInstall()
 		return nil, err
 	}
@@ -280,18 +294,29 @@ func (l *execPodListener) run(ctx context.Context) error {
 	return nil
 }
 
-// removeInstall deletes the install directory from the container. It runs on its own
-// context: the forward's is cancelled by the time this is wanted, and leaving a
-// binary in a user's pod is worse than one more short exec.
+// removeInstall deletes whatever this listener put in the container.
+//
+// It names every candidate directory rather than the one that was chosen, because
+// the probe writes a test file under the token before any directory has been
+// settled on - so a setup cancelled during the probe leaves something behind that
+// dir alone would not describe. The paths are built from installDirs and a hex
+// token, so nothing here comes from outside this process.
+//
+// It runs on its own context: the forward's is cancelled by the time this is
+// wanted, and leaving a binary in a user's pod is worse than one more short exec.
 func (l *execPodListener) removeInstall() {
-	if l.dir == "" {
+	if l.token == "" {
 		return
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), installTimeout)
+	paths := make([]string, 0, len(installDirs))
+	for _, dir := range installDirs {
+		paths = append(paths, dir+"/.safe-rfwd-"+l.token)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), installCleanupTimeout)
 	defer cancel()
-	if _, _, err := l.runSetup(ctx, "rm -rf "+l.dir, nil); err != nil {
-		klog.Warningf("could not remove %s from pod %s/%s: %v",
-			l.dir, l.userInfo.Namespace, l.userInfo.Pod, err)
+	if _, _, err := l.runSetup(ctx, "rm -rf "+strings.Join(paths, " "), nil); err != nil {
+		klog.Warningf("could not remove the reverse forward install from pod %s/%s: %v",
+			l.userInfo.Namespace, l.userInfo.Pod, err)
 	}
 }
 

--- a/SaFE/apiserver/pkg/handlers/ssh-handlers/pod_listener.go
+++ b/SaFE/apiserver/pkg/handlers/ssh-handlers/pod_listener.go
@@ -7,12 +7,12 @@ package ssh_handlers
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
 	"io"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -23,52 +23,62 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/klog/v2"
 
+	"github.com/AMD-AIG-AIMA/SAFE/apiserver/pkg/handlers/ssh-handlers/muxbin"
+	"github.com/AMD-AIG-AIMA/SAFE/apiserver/pkg/handlers/ssh-handlers/rfwdmux"
 	commonclient "github.com/AMD-AIG-AIMA/SAFE/common/pkg/k8sclient"
 )
 
-// Markers exchanged with the relay script running inside the Pod. The acceptor
-// script announces its state with these prefixes; every other line is diagnostics.
+// Markers exchanged with the multiplexer running inside the Pod. Every other line
+// on its stderr is a diagnostic.
 const (
-	rfwdReadyMarker = "SAFE-RFWD-READY"
-	rfwdConnMarker  = "SAFE-RFWD-CONN"
-	rfwdErrMarker   = "SAFE-RFWD-ERR"
-	// rfwdDropMarker reports that one connection could not be handed over, as
-	// opposed to the listener itself failing. It deliberately does not start with
-	// the connection marker, so neither prefix test can match the other.
-	rfwdDropMarker = "SAFE-RFWD-DROP"
+	rfwdReadyMarker = rfwdmux.ReadyMarker
+	rfwdErrMarker   = rfwdmux.ErrMarker
+	rfwdStatMarker  = rfwdmux.StatMarker
 )
 
-// relayMaxLineBytes caps a single line of relay output. socat can be verbose about
-// a failure, and the scanner's default line is 64 KiB.
+// relayMaxLineBytes caps a single line of Pod-side output, whose default scanner
+// line is 64 KiB.
 const relayMaxLineBytes = 1 << 20
 
-// maxConcurrentRelayExecs bounds how many per-connection exec streams one listener
-// holds against the target cluster at once. The per-session forward limit counts
-// listeners, not the connections through them, so a single `pip install` behind
-// HTTPS_PROXY would otherwise open hundreds of streams to one API server.
-const maxConcurrentRelayExecs = 32
+// muxMaxStreams bounds the connections one forward carries at once. Past it the
+// Pod side refuses the connection rather than queueing it: the failure the
+// multiplexer replaces was a listener that accepted connections it had no capacity
+// to serve and left them waiting for the life of the session.
+const muxMaxStreams = rfwdmux.DefaultMaxStreams
 
-// relayHalfCloseGrace is how long a relay keeps a half-closed connection open.
-// socat's default is half a second, after which one direction ending closes the
-// whole connection - which turns every half-close into a truncation, because the
-// side still talking has barely started.
-//
-// Two minutes, not an hour. It has to outlast a request waiting on its reply, which
-// is seconds; the reason not to make it generous is that a relay whose watcher has
-// gone lives exactly this long, and after a fifty-seven minute forward a handful of
-// them were still sitting in the pod. Long enough for any exchange worth carrying,
-// short enough that what escapes the watcher is gone in minutes.
-const relayHalfCloseGrace = 120
+// muxKeepaliveInterval feeds the Pod side's own idle timer. Without traffic in
+// either direction the multiplexer decides the apiserver is gone and gives the
+// listen port back, so a healthy but quiet forward has to say so.
+const muxKeepaliveInterval = 30 * time.Second
+
+// muxIdleTimeout ends a forward whose pod side has stopped answering. Both ends run
+// the same timer against the same keepalive, so a wedged exec stream is reported as
+// a listener that stopped - which the client can act on by asking again - rather
+// than as a forward that is up and silently carries nothing. That silence is the
+// shape the failure this replaces took.
+const muxIdleTimeout = 5 * time.Minute
+
+// installTimeout bounds the two short execs that put the multiplexer into the
+// container. It shares a budget with forwardResolveTimeout and
+// listenerReadyTimeout: all three run inside one SSH global request, which is
+// answered before the next request on the connection is looked at, and their sum
+// has to stay inside the roughly three minutes a client tolerates before it gives
+// up on the connection. It is a variable so tests do not wait it out.
+var installTimeout = 60 * time.Second
 
 // listenerReadyTimeout bounds how long we wait for the Pod-side listener to bind.
-// It shares a budget with forwardResolveTimeout: both run inside one global request,
-// which is answered before the next one on the connection is looked at.
 // It is a variable so a test can reach the branch where the pod never binds.
 var listenerReadyTimeout = 15 * time.Second
 
-// listenerShutdownGrace bounds how long Close waits for the Pod-side relay to exit
-// and give the listen port back. It is a variable so tests do not wait it out.
+// listenerShutdownGrace bounds how long Close waits for the Pod-side multiplexer
+// to exit and give the listen port back. It is a variable so tests do not wait it out.
 var listenerShutdownGrace = 5 * time.Second
+
+// installDirs are the directories the Pod side may install the multiplexer into,
+// in the order it tries them. A container whose /tmp is mounted noexec still has
+// somewhere to run from, and restricting the set means the path the Pod reports
+// back cannot become a path we did not choose.
+var installDirs = []string{"/tmp", "/dev/shm", "/var/tmp"}
 
 // podListener is a TCP listener living inside the target Pod's network namespace.
 type podListener interface {
@@ -90,9 +100,13 @@ type podConn interface {
 	OriginPort() uint32
 }
 
-// newPodExecutor builds the exec that runs one relay script in the target
-// container. It is a variable so tests can drive the listener without a
-// Kubernetes API server.
+// muxBinaryFor looks up the embedded multiplexer for a container's architecture. It
+// is a variable so tests can drive the listener without the image build having
+// produced the binaries, which a source checkout has not.
+var muxBinaryFor = muxbin.For
+
+// newPodExecutor builds the exec that runs one command in the target container. It
+// is a variable so tests can drive the listener without a Kubernetes API server.
 var newPodExecutor = func(l *execPodListener, script string, stdin bool) (remotecommand.Executor, error) {
 	return l.newExecutor(script, stdin)
 }
@@ -102,21 +116,15 @@ var newPodExecutor = func(l *execPodListener, script string, stdin bool) (remote
 type podListenerFactory func(ctx context.Context, userInfo *UserInfo,
 	clients *commonclient.ClientFactory, bindAddr string, bindPort uint32) (podListener, error)
 
-// acceptedConn is one connection announcement emitted by the Pod-side acceptor.
-type acceptedConn struct {
-	id       string
-	peerAddr string
-	peerPort uint32
-}
-
-// execPodListener implements podListener by exec'ing a socat relay inside the Pod.
+// execPodListener implements podListener with one long-lived exec per forward.
 //
-// A long-lived acceptor exec runs `socat TCP-LISTEN:<port>,bind=<addr>,fork`.
-// For every accepted connection socat forks a child whose stdin/stdout are the
-// accepted socket; the child announces itself on the exec's stderr and then
-// re-publishes the socket as a unix socket under a private directory. The
-// apiserver picks that connection up with a second, short-lived exec that pipes
-// the unix socket to its own stdin/stdout.
+// A short exec reports the container's architecture and a directory it can execute
+// from; a second writes the matching multiplexer there; a third runs it, with the
+// exec's stdin and stdout carrying every forwarded connection as a multiplexed
+// stream. One forward therefore costs one exec no matter how much traffic goes
+// through it, which is the whole point: the previous design took an exec per
+// connection, ran out of them, and left a listener that accepted and never
+// answered.
 type execPodListener struct {
 	clients   *commonclient.ClientFactory
 	userInfo  *UserInfo
@@ -125,25 +133,23 @@ type execPodListener struct {
 	bindAddr  string
 	bindPort  uint32
 
-	accepted chan acceptedConn
-	cancel   context.CancelFunc
-	// execSlots bounds the per-connection exec streams this listener holds at once.
-	execSlots chan struct{}
-	// stdinW is never written to. Closing it is how the acceptor script inside the
-	// Pod is told the session has ended.
+	session *rfwdmux.Session
+	cancel  context.CancelFunc
+	// stdinW is the write half of the multiplexed session, and closing it is how
+	// the Pod side is told the forward has ended.
 	stdinW *io.PipeWriter
 
 	closeOnce sync.Once
 	doneCh    chan struct{}
-	// streamDone closes when the acceptor exec has ended, which is the moment the
-	// Pod-side relay has let go of the listen port.
+	// streamDone closes when the run exec has ended, which is the moment the Pod
+	// has let go of the listen port.
 	streamDone chan struct{}
 
 	mu  sync.Mutex
 	err error
 }
 
-// newExecPodListener starts the acceptor script in the Pod and waits for it to bind.
+// newExecPodListener installs the multiplexer in the Pod and starts it.
 func newExecPodListener(ctx context.Context, userInfo *UserInfo,
 	clients *commonclient.ClientFactory, bindAddr string, bindPort uint32) (podListener, error) {
 	token, err := randomToken()
@@ -156,28 +162,67 @@ func newExecPodListener(ctx context.Context, userInfo *UserInfo,
 		clients:    clients,
 		userInfo:   userInfo,
 		container:  userInfo.Container,
-		dir:        "/tmp/.safe-rfwd-" + token,
 		bindAddr:   bindAddr,
 		bindPort:   bindPort,
-		accepted:   make(chan acceptedConn, 16),
-		execSlots:  make(chan struct{}, maxConcurrentRelayExecs),
 		cancel:     cancel,
 		doneCh:     make(chan struct{}),
 		streamDone: make(chan struct{}),
 	}
 
-	// The acceptor reads stdin only to learn when it ends, so it needs a stdin
-	// stream even though nothing is ever sent on it.
-	// The script gives up a little before we do, so its account of what went wrong
-	// is the one that reaches the caller.
-	readySeconds := int(listenerReadyTimeout.Seconds()) - 3
-	if readySeconds < 1 {
-		readySeconds = 1
-	}
-	executor, err := newPodExecutor(l, acceptorScript(l.dir, bindAddr, bindPort, readySeconds), true)
-	if err != nil {
+	if err = l.install(runCtx, token); err != nil {
 		cancel()
 		return nil, err
+	}
+	if err = l.run(runCtx); err != nil {
+		_ = l.Close()
+		// The run script's trap and the multiplexer's own cleanup both need the
+		// multiplexer to have started. This is the path where neither did, and
+		// nothing else in the pod would ever clear the install away.
+		l.removeInstall()
+		return nil, err
+	}
+
+	klog.Infof("reverse forward listener ready in pod %s/%s on %s:%d",
+		userInfo.Namespace, userInfo.Pod, bindAddr, bindPort)
+	return l, nil
+}
+
+// install puts the multiplexer into the container and records where it went.
+func (l *execPodListener) install(ctx context.Context, token string) error {
+	installCtx, cancel := context.WithTimeout(ctx, installTimeout)
+	defer cancel()
+
+	stdout, stderr, err := l.runSetup(installCtx, probeScript(token), nil)
+	if err != nil {
+		return fmt.Errorf("failed to inspect pod %s: %v%s", l.userInfo.Pod, err, reportedReason(stderr))
+	}
+	machine, base, err := parseProbe(stdout)
+	if err != nil {
+		return fmt.Errorf("failed to inspect pod %s: %v%s", l.userInfo.Pod, err, reportedReason(stderr))
+	}
+
+	binary, arch, err := muxBinaryFor(machine)
+	if err != nil {
+		return err
+	}
+	l.dir = base + "/.safe-rfwd-" + token
+
+	if _, stderr, err = l.runSetup(installCtx, installScript(l.dir), bytes.NewReader(binary)); err != nil {
+		return fmt.Errorf("failed to install the %s reverse forward multiplexer in pod %s: %v%s",
+			arch, l.userInfo.Pod, err, reportedReason(stderr))
+	}
+	klog.V(2).Infof("installed the %s reverse forward multiplexer in pod %s/%s at %s",
+		arch, l.userInfo.Namespace, l.userInfo.Pod, l.dir)
+	return nil
+}
+
+// run starts the multiplexer and waits for it to report the port bound.
+func (l *execPodListener) run(ctx context.Context) error {
+	executor, err := newPodExecutor(l, runScript(l.dir, l.bindAddr, l.bindPort), true)
+	if err != nil {
+		// Nothing was started, so nothing will close this - and Close waits on it.
+		close(l.streamDone)
+		return err
 	}
 
 	readyCh := make(chan error, 1)
@@ -186,17 +231,16 @@ func newExecPodListener(ctx context.Context, userInfo *UserInfo,
 	stderrR, stderrW := io.Pipe()
 	l.stdinW = stdinW
 
-	go l.scan(stdoutR, readyCh)
 	go l.scan(stderrR, readyCh)
 	go func() {
 		defer close(l.streamDone)
-		streamErr := executor.StreamWithContext(runCtx, remotecommand.StreamOptions{
+		streamErr := executor.StreamWithContext(ctx, remotecommand.StreamOptions{
 			Stdin:  stdinR,
 			Stdout: stdoutW,
 			Stderr: stderrW,
 		})
 		if streamErr == nil {
-			streamErr = fmt.Errorf("pod listener on %s:%d exited", bindAddr, bindPort)
+			streamErr = fmt.Errorf("pod listener on %s:%d exited", l.bindAddr, l.bindPort)
 		}
 		l.fail(streamErr)
 		_ = stdinR.CloseWithError(streamErr)
@@ -208,26 +252,65 @@ func newExecPodListener(ctx context.Context, userInfo *UserInfo,
 		}
 	}()
 
+	// The session is started before the port is known to be bound, because the
+	// multiplexer speaks the moment it is up and nothing must be read late.
+	l.session = rfwdmux.NewSession(rfwdmux.Join(stdoutR, stdinW, stdoutR, stdinW), rfwdmux.Config{
+		MaxStreams:        muxMaxStreams,
+		KeepaliveInterval: muxKeepaliveInterval,
+		IdleTimeout:       muxIdleTimeout,
+		Logf: func(format string, args ...any) {
+			klog.V(4).Infof("pod %s reverse forward: %s", l.userInfo.Pod, fmt.Sprintf(format, args...))
+		},
+	})
+	go func() {
+		<-l.session.Done()
+		l.fail(l.session.Err())
+	}()
+
 	select {
 	case err = <-readyCh:
 		if err != nil {
-			_ = l.Close()
-			return nil, err
+			return err
 		}
 	case <-time.After(listenerReadyTimeout):
-		_ = l.Close()
-		return nil, fmt.Errorf("timed out waiting for pod listener on %s:%d", bindAddr, bindPort)
-	case <-runCtx.Done():
-		_ = l.Close()
-		return nil, runCtx.Err()
+		return fmt.Errorf("timed out waiting for pod listener on %s:%d", l.bindAddr, l.bindPort)
+	case <-ctx.Done():
+		return ctx.Err()
 	}
-
-	klog.Infof("reverse forward listener ready in pod %s/%s on %s:%d",
-		userInfo.Namespace, userInfo.Pod, bindAddr, bindPort)
-	return l, nil
+	return nil
 }
 
-// scan consumes one relay output stream, turning marker lines into events.
+// removeInstall deletes the install directory from the container. It runs on its own
+// context: the forward's is cancelled by the time this is wanted, and leaving a
+// binary in a user's pod is worse than one more short exec.
+func (l *execPodListener) removeInstall() {
+	if l.dir == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), installTimeout)
+	defer cancel()
+	if _, _, err := l.runSetup(ctx, "rm -rf "+l.dir, nil); err != nil {
+		klog.Warningf("could not remove %s from pod %s/%s: %v",
+			l.dir, l.userInfo.Namespace, l.userInfo.Pod, err)
+	}
+}
+
+// runSetup runs one short-lived command in the container and collects its output.
+func (l *execPodListener) runSetup(ctx context.Context, script string, stdin io.Reader) (string, string, error) {
+	executor, err := newPodExecutor(l, script, stdin != nil)
+	if err != nil {
+		return "", "", err
+	}
+	var stdout, stderr bytes.Buffer
+	err = executor.StreamWithContext(ctx, remotecommand.StreamOptions{
+		Stdin:  stdin,
+		Stdout: &limitedWriter{w: &stdout, left: relayMaxLineBytes},
+		Stderr: &limitedWriter{w: &stderr, left: relayMaxLineBytes},
+	})
+	return stdout.String(), stderr.String(), err
+}
+
+// scan consumes the multiplexer's stderr, turning marker lines into events.
 func (l *execPodListener) scan(r *io.PipeReader, readyCh chan<- error) {
 	// Whatever ends this loop, the stream is still writing into the other end of
 	// this pipe. Leaving it there strands the copier mid-write, so the exec never
@@ -251,103 +334,41 @@ func (l *execPodListener) scan(r *io.PipeReader, readyCh chan<- error) {
 			case readyCh <- err:
 			default:
 			}
-		case strings.HasPrefix(line, rfwdDropMarker):
-			// One connection lost, not the listener: the pod-side application sees
-			// its connection close, and every other one carries on.
-			klog.Warningf("pod %s dropped a reverse forward connection:%s",
-				l.userInfo.Pod, strings.TrimPrefix(line, rfwdDropMarker))
-		case strings.HasPrefix(line, rfwdConnMarker):
-			conn, ok := parseConnAnnouncement(line)
-			if !ok {
-				klog.Warningf("ignoring malformed reverse forward announcement: %q", line)
-				continue
-			}
-			select {
-			case l.accepted <- conn:
-			case <-l.doneCh:
-				return
-			}
+		case strings.HasPrefix(line, rfwdStatMarker):
+			klog.V(2).Infof("pod %s reverse forward on %s:%d:%s", l.userInfo.Pod,
+				l.bindAddr, l.bindPort, strings.TrimPrefix(line, rfwdStatMarker))
 		default:
 			if line != "" {
-				klog.V(4).Infof("pod %s reverse forward relay: %s", l.userInfo.Pod, line)
+				klog.V(4).Infof("pod %s reverse forward: %s", l.userInfo.Pod, line)
 			}
 		}
 	}
 	// Reaching here without an error is the stream ending, which the exec goroutine
-	// already reports. With one, the relay has stopped being readable while the
-	// listener still looks alive - say so, or Accept waits for announcements that
+	// already reports. With one, the multiplexer has stopped being readable while
+	// the listener still looks alive - say so, or Accept waits for connections that
 	// are never coming and nothing in the log explains it.
 	if err := scanner.Err(); err != nil {
 		l.fail(fmt.Errorf("pod listener output could not be read: %v", err))
 	}
 }
 
-// Accept waits for the Pod-side acceptor to report a connection, then opens a
-// byte stream carrying it.
+// Accept waits for the Pod side to hand over the next connection it accepted.
 func (l *execPodListener) Accept(ctx context.Context) (podConn, error) {
-	for {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-l.doneCh:
-			return nil, l.closeErr()
-		case conn := <-l.accepted:
-			pc, err := l.dial(ctx, conn)
-			if err != nil {
-				// One connection failing to hand off must not kill the listener.
-				klog.ErrorS(err, "failed to attach to pod reverse forward connection",
-					"pod", l.userInfo.Pod, "id", conn.id)
-				continue
-			}
-			return pc, nil
-		}
-	}
-}
-
-// dial attaches to the unix socket the announced socat child is listening on.
-func (l *execPodListener) dial(ctx context.Context, conn acceptedConn) (podConn, error) {
-	select {
-	case l.execSlots <- struct{}{}:
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case <-l.doneCh:
-		return nil, l.closeErr()
-	}
-	executor, err := newPodExecutor(l, connectScript(l.dir, conn.id), true)
+	stream, err := l.session.Accept(ctx)
 	if err != nil {
-		<-l.execSlots
+		select {
+		case <-l.doneCh:
+			// The listener's own account of what happened is the useful one; the
+			// session only knows that its connection ended.
+			return nil, l.closeErr()
+		default:
+		}
 		return nil, err
 	}
-
-	runCtx, cancel := context.WithCancel(ctx)
-	stdinR, stdinW := io.Pipe()
-	stdoutR, stdoutW := io.Pipe()
-	c := &execPodConn{
-		stdinW:     stdinW,
-		stdoutR:    stdoutR,
-		cancel:     cancel,
-		originAddr: conn.peerAddr,
-		originPort: conn.peerPort,
-	}
-
-	go func() {
-		streamErr := executor.StreamWithContext(runCtx, remotecommand.StreamOptions{
-			Stdin:  stdinR,
-			Stdout: stdoutW,
-			Stderr: newLogWriter(l.userInfo.Pod),
-		})
-		if streamErr == nil {
-			streamErr = io.EOF
-		}
-		_ = stdoutW.CloseWithError(streamErr)
-		_ = stdinR.CloseWithError(streamErr)
-		cancel()
-		<-l.execSlots
-	}()
-	return c, nil
+	return stream, nil
 }
 
-// execRequest builds the exec request that runs one relay script in the container.
+// execRequest builds the exec request that runs one command in the container.
 // It is separate from newExecutor so a test can read back what we ask the API server
 // for without needing an API server to ask.
 func (l *execPodListener) execRequest(script string, stdin bool) *rest.Request {
@@ -371,20 +392,22 @@ func (l *execPodListener) newExecutor(script string, stdin bool) (remotecommand.
 	return remotecommand.NewSPDYExecutor(l.clients.RestConfig(), "POST", l.execRequest(script, stdin).URL())
 }
 
-// Close stops the acceptor exec; the script's trap removes the Pod-side sockets.
+// Close stops the multiplexer; it removes its own files inside the Pod.
 func (l *execPodListener) Close() error {
 	l.fail(fmt.Errorf("pod listener on %s:%d closed", l.bindAddr, l.bindPort))
-	// Ending stdin is the script's shutdown signal, and it is the only one that
+	// Ending the session ends the exec's stdin, which is the shutdown signal that
 	// reaches a runtime that leaves the exec'd process running after the stream is
-	// torn down. Closing it also releases the stream's stdin copier.
-	if l.stdinW != nil {
+	// torn down. It also releases every connection still on the session.
+	if l.session != nil {
+		_ = l.session.Close()
+	} else if l.stdinW != nil {
 		_ = l.stdinW.Close()
 	}
-	// Wait for the relay to actually exit before reporting the listener gone. A
-	// client that reconnects asks for the same port straight away, and reuseaddr
+	// Wait for the multiplexer to actually exit before reporting the listener gone.
+	// A client that reconnects asks for the same port straight away, and reuseaddr
 	// does not cover a socket another live process is still listening on - so
 	// returning early turns a reconnect into "the port you just released is busy".
-	// Bounded, because a stuck relay must not hold up the rest of the teardown.
+	// Bounded, because a stuck exec must not hold up the rest of the teardown.
 	select {
 	case <-l.streamDone:
 	case <-time.After(listenerShutdownGrace):
@@ -396,6 +419,9 @@ func (l *execPodListener) Close() error {
 
 // fail records the first terminal error and releases everyone blocked on the listener.
 func (l *execPodListener) fail(err error) {
+	if err == nil {
+		err = io.EOF
+	}
 	l.mu.Lock()
 	if l.err == nil {
 		l.err = err
@@ -414,243 +440,123 @@ func (l *execPodListener) closeErr() error {
 	return io.EOF
 }
 
-// execPodConn bridges one Pod-side connection over an exec stream.
-type execPodConn struct {
-	stdinW  *io.PipeWriter
-	stdoutR *io.PipeReader
-	cancel  context.CancelFunc
-
-	originAddr string
-	originPort uint32
-
-	closeOnce sync.Once
+// probeScript reports the container's architecture and a directory the multiplexer
+// can be executed from.
+//
+// Both answers have to come from inside the container: the node's architecture is
+// not necessarily the container's, and an image whose /tmp is mounted noexec would
+// otherwise fail with nothing but "permission denied" at the moment of running the
+// binary, long after the reason could be explained.
+//
+// The candidates are shared, world-writable directories, so the probe path is named
+// by the same unguessable token as the install and is created with a plain mkdir.
+// Neither is decoration: a predictable name plus `mkdir -p` is a directory another
+// process in the container can pre-create as a symlink, in which case the probe
+// would write its test file wherever that symlink pointed.
+func probeScript(token string) string {
+	return fmt.Sprintf(`M=$(uname -m 2>/dev/null) || M=
+if [ -z "$M" ]; then
+  echo "%[2]s uname is not available in the container" >&2
+  exit 1
+fi
+echo "ARCH $M"
+for D in %[1]s; do
+  [ -d "$D" ] || continue
+  P="$D/.safe-rfwd-%[3]s"
+  # No -p, and no removing whatever is already there: mkdir must be what creates
+  # this directory, so that anything else of that name is a reason to move on.
+  # -m rather than a following chmod: otherwise it exists, briefly, with whatever
+  # the image's umask allows.
+  mkdir -m 700 "$P" 2>/dev/null || continue
+  if printf '#!/bin/sh\nexit 0\n' > "$P/t" 2>/dev/null && chmod 700 "$P/t" 2>/dev/null &&
+     "$P/t" 2>/dev/null; then
+    rm -rf "$P"
+    echo "DIR $D"
+    exit 0
+  fi
+  rm -rf "$P"
+done
+echo "%[2]s no directory among %[1]s is both writable and executable" >&2
+exit 1
+`, strings.Join(installDirs, " "), rfwdErrMarker, token)
 }
 
-func (c *execPodConn) Read(p []byte) (int, error) { return c.stdoutR.Read(p) }
-
-// CloseWrite ends the relay's stdin, which is how the Pod-side socket learns the
-// other end has finished writing, without disturbing what it is still sending back.
-func (c *execPodConn) CloseWrite() error { return c.stdinW.Close() }
-
-func (c *execPodConn) Write(p []byte) (int, error) { return c.stdinW.Write(p) }
-func (c *execPodConn) OriginAddr() string          { return c.originAddr }
-func (c *execPodConn) OriginPort() uint32          { return c.originPort }
-
-// Close tears down the exec stream carrying this connection.
-func (c *execPodConn) Close() error {
-	c.closeOnce.Do(func() {
-		c.cancel()
-		_ = c.stdinW.Close()
-		_ = c.stdoutR.Close()
-	})
-	return nil
+// installScript writes the multiplexer arriving on stdin and proves it runs.
+//
+// dir is built from a hex token and one of installDirs, so nothing interpolated
+// here comes from outside this process. As in the probe, mkdir has to be what
+// creates it: these are shared directories, and a path that already exists is one
+// this process did not make.
+func installScript(dir string) string {
+	return fmt.Sprintf(`set -e
+D=%[1]s
+if ! mkdir -m 700 "$D" 2>/dev/null; then
+  echo "%[2]s could not create $D in this container" >&2
+  exit 1
+fi
+cat > "$D/mux"
+chmod 700 "$D/mux"
+# Proving it runs here turns the two failures that look identical later - a binary
+# for the wrong architecture, and a filesystem that turned out not to be executable
+# after all - into a reason reported before any connection depends on it.
+if ! "$D/mux" check >/dev/null 2>&1; then
+  echo "%[2]s the multiplexer written to $D could not run in this container" >&2
+  rm -rf "$D"
+  exit 1
+fi
+`, dir, rfwdErrMarker)
 }
 
-// parseConnAnnouncement parses "SAFE-RFWD-CONN <id> <peer-addr> <peer-port>".
-func parseConnAnnouncement(line string) (acceptedConn, bool) {
-	fields := strings.Fields(line)
-	if len(fields) != 4 || fields[0] != rfwdConnMarker {
-		return acceptedConn{}, false
-	}
-	// The id becomes a path component of the rendezvous socket, so it must not be
-	// able to escape the private directory.
-	id := fields[1]
-	if !isRendezvousID(id) {
-		return acceptedConn{}, false
-	}
-	port, err := strconv.ParseUint(fields[3], 10, 16)
-	if err != nil {
-		return acceptedConn{}, false
-	}
-	addr := fields[2]
-	if addr == "" {
-		addr = "127.0.0.1"
-	}
-	return acceptedConn{id: id, peerAddr: addr, peerPort: uint32(port)}, true
+// runScript runs the multiplexer with the exec's stdin and stdout as its session.
+//
+// The multiplexer removes its own directory once the port is bound, so the trap is
+// only for the paths where it never got that far.
+func runScript(dir, bindAddr string, bindPort uint32) string {
+	return fmt.Sprintf(`D=%[1]s
+trap 'rm -rf "$D"' EXIT INT TERM
+"$D/mux" listen -max-streams %[4]d -remove-dir "$D" %[2]s %[3]d
+`, dir, bindAddr, bindPort, muxMaxStreams)
 }
 
-// isRendezvousID reports whether id is safe to interpolate into a socket path.
-func isRendezvousID(id string) bool {
-	if id == "" || len(id) > 32 {
-		return false
-	}
-	for _, r := range id {
-		if r < '0' || r > '9' {
-			return false
+// parseProbe reads the architecture and install directory out of the probe's output.
+func parseProbe(stdout string) (machine, dir string, err error) {
+	for _, line := range strings.Split(stdout, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		switch fields[0] {
+		case "ARCH":
+			machine = fields[1]
+		case "DIR":
+			dir = fields[1]
 		}
 	}
-	return true
+	if machine == "" {
+		return "", "", fmt.Errorf("the container did not report its architecture")
+	}
+	// The directory is checked against the list we asked for rather than trusted:
+	// it becomes a path this process writes to and executes.
+	for _, allowed := range installDirs {
+		if dir == allowed {
+			return machine, dir, nil
+		}
+	}
+	return "", "", fmt.Errorf("the container reported no directory it can execute from")
 }
 
-// acceptorScript builds the long-lived relay script that owns the Pod listen socket.
-//
-// bindAddr is always one of the configured literal addresses and bindPort has
-// already been range-checked, so neither can inject shell syntax here.
-//
-// The per-connection work lives in a script file rather than inline in the SYSTEM:
-// address. socat parses its address strings itself - splitting on commas to find
-// options and consuming quotes - before handing the command to a shell, which
-// silently mangles anything more involved than a plain command. Keeping the
-// SYSTEM: command down to a single `sh <dir>/child.sh` leaves nothing to mangle.
-func acceptorScript(dir, bindAddr string, bindPort uint32, readySeconds int) string {
-	script := fmt.Sprintf(`set -e
-for tool in socat awk cat date grep mkdir readlink sleep; do
-  if ! command -v "$tool" >/dev/null 2>&1; then
-    echo "%[4]s $tool is not installed in the container" >&2
-    exit 127
-  fi
-done
-if [ ! -r /proc/net/tcp ]; then
-  echo "%[4]s /proc/net/tcp is not readable, cannot confirm the listen port" >&2
-  exit 1
-fi
-D=%[1]s
-rm -rf "$D"
-# -m rather than a following chmod: otherwise the directory exists, briefly, with
-# whatever the image's umask allows.
-mkdir -m 700 -p "$D"
-cat > "$D/child.sh" <<'SAFE_RFWD_CHILD_EOF'
-CHILD_SCRIPT_PLACEHOLDER
-SAFE_RFWD_CHILD_EOF
-socat -t %[7]d TCP-LISTEN:%[3]d,bind=%[2]s,reuseaddr,fork SYSTEM:'sh %[1]s/child.sh' &
-SPID=$!
-# The exec stream going away is how a session ends, and it shows up here as EOF on
-# stdin. A background job's stdin is /dev/null unless it is handed our own, so dup
-# it first - otherwise this watcher fires immediately.
-exec 3<&0
-( cat <&3 >/dev/null 2>&1; kill "$SPID" 2>/dev/null ) >/dev/null 2>&1 &
-WPID=$!
-# If the runtime kills this script outright, the trap never runs. A detached
-# watcher reaps the listener once the script that owns it is gone, so the pod is
-# not left with a bound port after the SSH session ends.
-MPID=$$
-( while [ -e "/proc/$MPID" ] && [ -e "/proc/$SPID" ]; do sleep 2; done
-  kill "$SPID" "$WPID" 2>/dev/null || true
-  rm -rf "$D" ) >/dev/null 2>&1 &
-# set -e is still in force inside the trap, and by the time it runs the processes
-# it kills have usually exited already - without the || true, that failed kill would
-# end the trap before the rendezvous directory is removed.
-trap 'kill "$SPID" "$WPID" 2>/dev/null || true; rm -rf "$D"' EXIT INT TERM
-# Ready has to mean the port is bound, not that socat has not died yet: a fixed wait
-# is both too long on an idle node and too short on a busy one, and a bind that fails
-# slowly would be reported as success. Ask the kernel instead - state 0A is LISTEN.
-#
-# A listening port alone is not the answer either, because something else may already
-# hold it - which is precisely the case where our socat is about to die. Match the
-# listening socket's inode against socat's own descriptors, so what we report is that
-# this relay bound the port, not that somebody did.
-HEXPORT=$(printf '%%04X' %[3]d)
-# Give up before the apiserver does, so the reason below is what the user is told
-# rather than a generic "timed out waiting for pod listener" - and so a bind that
-# lands late is still ours to report rather than something already abandoned.
-DEADLINE=$(( $(date +%%s) + %[6]d ))
-READY=
-while [ -z "$READY" ]; do
-  # Every row for this port, not just the first: something else in the pod may hold
-  # the same port on another address, and the kernel lists them in its own order. One
-  # of these inodes is ours; taking whichever came first would have us wait out the
-  # deadline while our own listener sat there bound.
-  for INODE in $(awk -v p=":$HEXPORT" '$2 ~ (p "$") && $4 == "0A" { print $10 }' /proc/net/tcp 2>/dev/null); do
-    for FD in /proc/$SPID/fd/*; do
-      if [ "$(readlink "$FD" 2>/dev/null)" = "socket:[$INODE]" ]; then
-        READY=1
-        break
-      fi
-    done
-    if [ -n "$READY" ]; then
-      break
-    fi
-  done
-  if [ -n "$READY" ]; then
-    break
-  fi
-  # A socat that lost the bind is an unreaped zombie here, and a zombie answers
-  # kill -0, so ask /proc whether it is actually still running.
-  if [ ! -r "/proc/$SPID/status" ] || grep -qi '^State:[[:space:]]*Z' "/proc/$SPID/status"; then
-    echo "%[4]s failed to listen on %[2]s:%[3]d" >&2
-    exit 1
-  fi
-  if [ "$(date +%%s)" -ge "$DEADLINE" ]; then
-    echo "%[4]s timed out waiting for %[2]s:%[3]d to be listening" >&2
-    exit 1
-  fi
-  sleep 0.1 2>/dev/null || sleep 1
-done
-echo "%[5]s"
-wait "$SPID"
-`, dir, bindAddr, bindPort, rfwdErrMarker, rfwdReadyMarker, readySeconds, relayHalfCloseGrace)
-	return strings.Replace(script, "CHILD_SCRIPT_PLACEHOLDER", childScript(dir), 1)
+// reportedReason picks the Pod side's own account out of a failed setup exec, so
+// the user is told what the container said rather than only that a command failed.
+func reportedReason(stderr string) string {
+	for _, line := range strings.Split(stderr, "\n") {
+		if line = strings.TrimSpace(line); strings.HasPrefix(line, rfwdErrMarker) {
+			return ":" + strings.TrimPrefix(line, rfwdErrMarker)
+		}
+	}
+	return ""
 }
 
-// childScript is what socat runs for each accepted connection, with the accepted
-// socket as its stdin and stdout. It republishes that socket as a unix socket the
-// apiserver can attach to and only then announces itself, because socat fails a
-// UNIX-CONNECT to a socket that does not exist yet outright instead of retrying.
-func childScript(dir string) string {
-	return fmt.Sprintf(`D=%[1]s
-# Claim an id. The PID alone will not do: it is unique among running processes but
-# comes back once one exits, and a returning id would have this child take a path an
-# earlier connection is still announced under, handing one connection's bytes to the
-# other's channel. Pairing it with the clock is enough - the same PID twice in one
-# second would need millions of forks - so ids do not repeat and the directory can be
-# released when the connection ends, rather than piling up for the life of a forward
-# until the claim loop below runs out of room.
-N=$(date +%%s)$$
-c=0
-while ! mkdir "$D/$N" 2>/dev/null; do
-  N=$((N+1))
-  c=$((c+1))
-  # Bounded, because mkdir can also be failing for a reason moving on will never
-  # fix - the rendezvous directory is gone because the forward ended, or there is
-  # no mkdir to run - and an unbounded retry would spin on a core forever.
-  if [ $c -ge 100 ]; then
-    echo "%[3]s could not claim a rendezvous id under $D" >&2
-    exit 1
-  fi
-done
-S=$D/$N/s
-# The accepted socket arrives as this script's stdin and stdout, but a shell gives a
-# background job /dev/null for stdin. Without this dup socat would relay an
-# immediate EOF and nothing from the pod would ever reach the client.
-exec 3<&0
-socat -t %[4]d - UNIX-LISTEN:"$S" <&3 &
-P=$!
-# Wait on the clock, not the CPU. A spin here is both useless - socat cannot fork
-# and bind inside a few hundred shell iterations - and harmful, because this pod may
-# have a CPU limit and the spin would spend it starving the socat being waited for.
-i=0
-while [ ! -S "$S" ] && [ $i -lt 100 ]; do
-  sleep 0.1 2>/dev/null || sleep 1
-  i=$((i+1))
-done
-# Announce only what the apiserver can actually attach to. Falling out of the spin
-# without a socket means socat never got it published, and announcing anyway would
-# send the apiserver to a path that is never going to exist.
-if [ ! -S "$S" ]; then
-  echo "%[3]s the relay socket for $N never appeared" >&2
-  kill "$P" 2>/dev/null || true
-  rm -rf "$D/$N"
-  exit 1
-fi
-echo "%[2]s $N ${SOCAT_PEERADDR:-127.0.0.1} ${SOCAT_PEERPORT:-0}" >&2
-# A connection the apiserver never attaches to would otherwise hold this pair open
-# for as long as the pod lives; the rendezvous directory disappearing is how the
-# forward reports that it has ended.
-( while [ -d "$D" ] && [ -e "/proc/$P" ]; do sleep 2; done
-  kill "$P" 2>/dev/null ) >/dev/null 2>&1 &
-wait "$P"
-rm -rf "$D/$N"`, dir, rfwdConnMarker, rfwdDropMarker, relayHalfCloseGrace)
-}
-
-// connectScript builds the short-lived script that hands one accepted connection
-// to the apiserver over the exec stream.
-func connectScript(dir, id string) string {
-	// Each child owns a directory named by its id, with the socket inside it.
-	return fmt.Sprintf("exec socat -t %d - UNIX-CONNECT:%s/%s/s,retry=100,interval=0.1",
-		relayHalfCloseGrace, dir, id)
-}
-
-// randomToken returns a hex token used to name the Pod-side rendezvous directory.
+// randomToken returns a hex token used to name the Pod-side install directory.
 func randomToken() (string, error) {
 	buf := make([]byte, 8)
 	if _, err := rand.Read(buf); err != nil {
@@ -659,14 +565,25 @@ func randomToken() (string, error) {
 	return hex.EncodeToString(buf), nil
 }
 
-// logWriter forwards relay stderr to the apiserver log.
-type logWriter struct{ pod string }
+// limitedWriter keeps a container's output from becoming this process's memory.
+type limitedWriter struct {
+	w    io.Writer
+	left int
+}
 
-func newLogWriter(pod string) io.Writer { return &logWriter{pod: pod} }
-
-func (w *logWriter) Write(p []byte) (int, error) {
-	if msg := strings.TrimSpace(string(p)); msg != "" {
-		klog.V(4).Infof("pod %s reverse forward relay: %s", w.pod, msg)
+func (l *limitedWriter) Write(p []byte) (int, error) {
+	// Everything is accounted for even once nothing more is kept: a short write
+	// would be reported as an error and abort the exec stream.
+	total := len(p)
+	if l.left <= 0 {
+		return total, nil
 	}
-	return len(p), nil
+	if len(p) > l.left {
+		p = p[:l.left]
+	}
+	l.left -= len(p)
+	if _, err := l.w.Write(p); err != nil {
+		return 0, err
+	}
+	return total, nil
 }

--- a/SaFE/apiserver/pkg/handlers/ssh-handlers/pod_listener_test.go
+++ b/SaFE/apiserver/pkg/handlers/ssh-handlers/pod_listener_test.go
@@ -6,7 +6,7 @@
 package ssh_handlers
 
 import (
-	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -17,7 +17,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"testing"
 	"time"
 
@@ -26,193 +25,734 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
 
+	"github.com/AMD-AIG-AIMA/SAFE/apiserver/pkg/handlers/ssh-handlers/muxbin"
+	"github.com/AMD-AIG-AIMA/SAFE/apiserver/pkg/handlers/ssh-handlers/rfwdmux"
 	commonclient "github.com/AMD-AIG-AIMA/SAFE/common/pkg/k8sclient"
 )
 
-// TestAcceptorScriptAgainstRealSocat runs the scripts we send into the Pod against a
-// real socat, so the shell the apiserver depends on is exercised rather than only
-// string-matched. It is skipped where socat is unavailable.
-func TestAcceptorScriptAgainstRealSocat(t *testing.T) {
-	if _, err := exec.LookPath("socat"); err != nil {
-		t.Skip("socat is not installed")
-	}
+// --- the scripts we send into the pod, against a real shell -----------------
 
-	dir := filepath.Join(t.TempDir(), "rfwd")
-	port := freeTCPPort(t)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-
-	acceptor := startAcceptor(t, ctx, dir, port)
-	announcements := acceptor.stderr
-
-	// A connection to the Pod-side port is announced with its peer address.
-	client, err := net.Dial("tcp", net.JoinHostPort("127.0.0.1", itoa(port)))
-	testifyassert.NoError(t, err)
-	defer client.Close()
-
-	var announced acceptedConn
-	var diagnostics []string
-	deadline := time.After(30 * time.Second)
-	for announced.id == "" {
-		select {
-		case line := <-announcements:
-			if conn, ok := parseConnAnnouncement(line); ok {
-				announced = conn
-				break
-			}
-			diagnostics = append(diagnostics, line)
-		case <-deadline:
-			t.Fatalf("timed out waiting for a connection announcement; relay said: %v", diagnostics)
-		}
-	}
-	testifyassert.Equal(t, "127.0.0.1", announced.peerAddr)
-	testifyassert.NotZero(t, announced.peerPort)
-
-	// Attaching to the announced rendezvous socket yields that connection's bytes.
-	attach := exec.CommandContext(ctx, "/bin/sh", "-c", connectScript(dir, announced.id))
-	attachIn, err := attach.StdinPipe()
-	testifyassert.NoError(t, err)
-	attachOut, err := attach.StdoutPipe()
-	testifyassert.NoError(t, err)
-	attachErr, err := attach.StderrPipe()
-	testifyassert.NoError(t, err)
-	attachDiag := make(chan string, 64)
-	go scanLines(attachErr, attachDiag)
-	defer func() {
-		for {
-			select {
-			case line := <-attachDiag:
-				t.Logf("attach stderr: %s", line)
-			default:
-				return
-			}
-		}
-	}()
-	testifyassert.NoError(t, attach.Start())
-	defer func() {
-		_ = attach.Process.Kill()
-		_, _ = attach.Process.Wait()
-	}()
-
-	// Pod -> apiserver.
-	_, err = client.Write([]byte("from-pod\n"))
-	testifyassert.NoError(t, err)
-	line, err := bufio.NewReader(attachOut).ReadString('\n')
-	testifyassert.NoError(t, err)
-	testifyassert.Equal(t, "from-pod\n", line)
-
-	// apiserver -> Pod.
-	_, err = attachIn.Write([]byte("from-client\n"))
-	testifyassert.NoError(t, err)
-	_ = client.SetReadDeadline(time.Now().Add(30 * time.Second))
-	back, err := bufio.NewReader(client).ReadString('\n')
-	testifyassert.NoError(t, err)
-	testifyassert.Equal(t, "from-client\n", back)
-
-	// SIGKILL is what the container runtime uses, and it leaves the script no
-	// chance to run its trap: only the detached watcher can free the Pod port.
-	_ = acceptor.cmd.Process.Kill()
-	_, _ = acceptor.cmd.Process.Wait()
-	waitForPortFree(t, port)
-	waitFor(t, func() bool {
-		_, statErr := os.Stat(dir)
-		return os.IsNotExist(statErr)
-	}, "the rendezvous directory to be removed")
-}
-
-// TestAcceptorScriptStdinCloseStopsListener pins the shutdown signal the apiserver
-// actually sends: it ends the exec's stdin rather than signalling the script, which
-// is the only teardown a runtime that leaves the exec'd process running will honour.
-func TestAcceptorScriptStdinCloseStopsListener(t *testing.T) {
-	if _, err := exec.LookPath("socat"); err != nil {
-		t.Skip("socat is not installed")
-	}
-
-	dir := filepath.Join(t.TempDir(), "rfwd")
-	port := freeTCPPort(t)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-
-	acceptor := startAcceptor(t, ctx, dir, port)
-
-	// A connection the apiserver never attached to still has a relay pair behind it
-	// in the pod, and ending the session has to release that too.
-	orphan, err := net.Dial("tcp", net.JoinHostPort("127.0.0.1", itoa(port)))
-	testifyassert.NoError(t, err)
-	defer orphan.Close()
-	select {
-	case line := <-acceptor.stderr:
-		_, ok := parseConnAnnouncement(line)
-		testifyassert.Truef(t, ok, "unexpected relay output: %s", line)
-	case <-time.After(30 * time.Second):
-		t.Fatal("timed out waiting for the pod-side relay to announce the connection")
-	}
-
-	testifyassert.NoError(t, acceptor.stdin.Close())
-
-	waitForPortFree(t, port)
-	waitFor(t, func() bool {
-		_, statErr := os.Stat(dir)
-		return os.IsNotExist(statErr)
-	}, "the rendezvous directory to be removed")
-
-	_ = orphan.SetReadDeadline(time.Now().Add(15 * time.Second))
-	_, err = orphan.Read(make([]byte, 1))
-	testifyassert.ErrorIs(t, err, io.EOF, "the pod-side relay must let the connection go")
-}
-
-// runningAcceptor is an acceptor script started for a test, with the streams the
-// apiserver would hold open in production.
-type runningAcceptor struct {
-	cmd    *exec.Cmd
-	stdin  io.WriteCloser
-	stderr chan string
-}
-
-// startAcceptor runs the acceptor script and returns once it reports it is bound.
-func startAcceptor(t *testing.T, ctx context.Context, dir string, port uint32) *runningAcceptor {
+// runScriptLocally runs one of the pod-side scripts the way a container would, so
+// the shell the apiserver depends on is exercised rather than only string-matched.
+func runScriptLocally(t *testing.T, script string, stdin io.Reader) (string, string, error) {
 	t.Helper()
-
-	script := acceptorScript(dir, "127.0.0.1", port, 12)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
 	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", script)
-	// The acceptor backgrounds socat and two watchers, which outlive the shell. Put
-	// them in one process group so the cleanup takes the lot, rather than leaving a
-	// socat on the machine for every run.
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	// The exec stream's stdin stays open for the life of the session; without it
-	// the script would read EOF at once and shut itself down.
-	stdin, err := cmd.StdinPipe()
-	testifyassert.NoError(t, err)
-	stdout, err := cmd.StdoutPipe()
-	testifyassert.NoError(t, err)
-	stderr, err := cmd.StderrPipe()
-	testifyassert.NoError(t, err)
-	testifyassert.NoError(t, cmd.Start())
-	t.Cleanup(func() {
-		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
-		_, _ = cmd.Process.Wait()
-	})
-
-	ready := make(chan string, 64)
-	go scanLines(stdout, ready)
-	announcements := make(chan string, 64)
-	go scanLines(stderr, announcements)
-
-	// The listener announces readiness only once it is actually bound.
-	select {
-	case line := <-ready:
-		testifyassert.Equal(t, rfwdReadyMarker, line)
-	case line := <-announcements:
-		t.Fatalf("pod listener failed to bind: %s", line)
-	case <-time.After(30 * time.Second):
-		t.Fatal("timed out waiting for the pod listener to bind")
-	}
-	return &runningAcceptor{cmd: cmd, stdin: stdin, stderr: announcements}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = stdin, &stdout, &stderr
+	err := cmd.Run()
+	return stdout.String(), stderr.String(), err
 }
 
-// waitForPortFree blocks until nothing in the pod holds the listen port any more.
+func TestProbeScriptReportsArchitectureAndAnExecutableDirectory(t *testing.T) {
+	stdout, stderr, err := runScriptLocally(t, probeScript(testToken(t)), nil)
+	testifyassert.NoError(t, err, stderr)
+
+	machine, dir, err := parseProbe(stdout)
+	testifyassert.NoError(t, err)
+	testifyassert.NotEmpty(t, machine)
+	testifyassert.Contains(t, installDirs, dir)
+}
+
+// TestProbeScriptFallsPastADirectoryItCannotUse covers the noexec /tmp the plan
+// calls out: the probe has to keep looking rather than report the first writable
+// directory it finds.
+func TestProbeScriptFallsPastADirectoryItCannotUse(t *testing.T) {
+	unusable := filepath.Join(t.TempDir(), "not-a-directory")
+	testifyassert.NoError(t, os.WriteFile(unusable, []byte("x"), 0o600))
+	restore := installDirs
+	installDirs = []string{unusable, "/tmp"}
+	t.Cleanup(func() { installDirs = restore })
+
+	stdout, stderr, err := runScriptLocally(t, probeScript(testToken(t)), nil)
+	testifyassert.NoError(t, err, stderr)
+	_, dir, err := parseProbe(stdout)
+	testifyassert.NoError(t, err)
+	testifyassert.Equal(t, "/tmp", dir)
+}
+
+// TestInstallScriptRefusesADirectoryItDidNotCreate covers the shared, world-writable
+// directories the multiplexer is installed into: mkdir has to be what creates the
+// path, so that something already sitting there - a symlink another process in the
+// container put in the way - is refused rather than written through.
+func TestInstallScriptRefusesADirectoryItDidNotCreate(t *testing.T) {
+	elsewhere := t.TempDir()
+	dir := filepath.Join(t.TempDir(), ".safe-rfwd-"+testToken(t))
+	testifyassert.NoError(t, os.Symlink(elsewhere, dir))
+
+	_, stderr, err := runScriptLocally(t, installScript(dir), strings.NewReader("payload"))
+	testifyassert.Error(t, err)
+	testifyassert.Contains(t, stderr, rfwdErrMarker)
+	testifyassert.Contains(t, stderr, "could not create")
+
+	// Nothing was written through the symlink.
+	entries, err := os.ReadDir(elsewhere)
+	testifyassert.NoError(t, err)
+	testifyassert.Empty(t, entries)
+}
+
+// TestProbeScriptNamesTheProblem keeps a container with nowhere to run from being
+// reported as a mysterious failure to listen.
+func TestProbeScriptNamesTheProblem(t *testing.T) {
+	restore := installDirs
+	installDirs = []string{filepath.Join(t.TempDir(), "absent")}
+	t.Cleanup(func() { installDirs = restore })
+
+	_, stderr, err := runScriptLocally(t, probeScript(testToken(t)), nil)
+	testifyassert.Error(t, err)
+	testifyassert.Contains(t, stderr, rfwdErrMarker)
+	testifyassert.Contains(t, stderr, "writable and executable")
+}
+
+func TestInstallScriptWritesABinaryThatRuns(t *testing.T) {
+	binary := hostMuxBinary(t)
+	dir := filepath.Join(t.TempDir(), ".safe-rfwd-"+testToken(t))
+
+	_, stderr, err := runScriptLocally(t, installScript(dir), bytes.NewReader(binary))
+	testifyassert.NoError(t, err, stderr)
+
+	info, err := os.Stat(filepath.Join(dir, "mux"))
+	testifyassert.NoError(t, err)
+	testifyassert.Equal(t, os.FileMode(0o700), info.Mode().Perm())
+	testifyassert.Equal(t, int64(len(binary)), info.Size())
+}
+
+// TestInstallScriptRejectsABinaryThatCannotRun is the check that turns the two
+// failures that look identical later - the wrong architecture, and a filesystem
+// that is not executable after all - into a reason reported before any connection
+// depends on it.
+func TestInstallScriptRejectsABinaryThatCannotRun(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), ".safe-rfwd-"+testToken(t))
+
+	_, stderr, err := runScriptLocally(t, installScript(dir), strings.NewReader("not a binary"))
+	testifyassert.Error(t, err)
+	testifyassert.Contains(t, stderr, rfwdErrMarker)
+	testifyassert.Contains(t, stderr, "could not run in this container")
+
+	// Nothing is left behind for a later session to trip over.
+	_, err = os.Stat(dir)
+	testifyassert.True(t, os.IsNotExist(err))
+}
+
+func TestRunScriptStartsTheInstalledMultiplexer(t *testing.T) {
+	script := runScript("/tmp/.safe-rfwd-abcd", "127.0.0.1", 10001)
+	testifyassert.Contains(t, script,
+		fmt.Sprintf(`"$D/mux" listen -max-streams %d -remove-dir "$D" 127.0.0.1 10001`, muxMaxStreams))
+	// The multiplexer removes its own files once the port is bound; the trap is for
+	// the paths where it never got that far.
+	testifyassert.Contains(t, script, `trap 'rm -rf "$D"' EXIT INT TERM`)
+	testifyassert.Contains(t, script, "D=/tmp/.safe-rfwd-abcd")
+}
+
+func TestParseProbe(t *testing.T) {
+	machine, dir, err := parseProbe("ARCH x86_64\nDIR /dev/shm\n")
+	testifyassert.NoError(t, err)
+	testifyassert.Equal(t, "x86_64", machine)
+	testifyassert.Equal(t, "/dev/shm", dir)
+
+	// A directory the apiserver did not offer must not become a path it writes to
+	// and executes, however the pod came to report it.
+	_, _, err = parseProbe("ARCH x86_64\nDIR /etc\n")
+	testifyassert.Error(t, err)
+	_, _, err = parseProbe("ARCH x86_64\n")
+	testifyassert.Error(t, err)
+	_, _, err = parseProbe("DIR /tmp\n")
+	testifyassert.Error(t, err)
+}
+
+func TestMuxBinaryForUnknownMachine(t *testing.T) {
+	_, _, err := muxbin.For("s390x")
+	testifyassert.ErrorContains(t, err, "s390x")
+	testifyassert.True(t, muxbin.Available("x86_64") == muxbin.Available("amd64"))
+}
+
+// testToken names the paths a script test creates. The probe writes into the same
+// shared directories production does, so a fixed name would collide with a leftover
+// from an interrupted run or with another copy of the suite running beside it.
+func testToken(t *testing.T) string {
+	t.Helper()
+	token, err := randomToken()
+	testifyassert.NoError(t, err)
+	return token
+}
+
+// hostMux is the multiplexer built for the machine running the tests, built once
+// for the whole run.
+var hostMux struct {
+	once   sync.Once
+	binary []byte
+	err    error
+}
+
+// hostMuxBinary returns a multiplexer the tests can actually inject.
+//
+// It builds one rather than reading the embedded copy: a source checkout carries a
+// placeholder, and the tests that exercise the real binary - the install script, and
+// the whole stack over a local exec - are the ones most worth not skipping. The
+// build is the same one the image build runs, and Go caches it after the first.
+func hostMuxBinary(t *testing.T) []byte {
+	t.Helper()
+	hostMux.once.Do(func() {
+		if _, err := exec.LookPath("go"); err != nil {
+			hostMux.err = fmt.Errorf("no go toolchain to build the multiplexer with: %v", err)
+			return
+		}
+		out := filepath.Join(t.TempDir(), "safe-rfwd-mux")
+		build := exec.Command("go", "build", "-o", out,
+			"github.com/AMD-AIG-AIMA/SAFE/apiserver/cmd/safe-rfwd-mux")
+		build.Env = append(os.Environ(), "CGO_ENABLED=0")
+		if output, err := build.CombinedOutput(); err != nil {
+			hostMux.err = fmt.Errorf("could not build the multiplexer: %v: %s", err, output)
+			return
+		}
+		hostMux.binary, hostMux.err = os.ReadFile(out)
+	})
+	if hostMux.err != nil {
+		t.Skipf("%v", hostMux.err)
+	}
+	return hostMux.binary
+}
+
+// injectHostMux makes the listener install a multiplexer that really runs, in place
+// of whatever the tree has embedded.
+func injectHostMux(t *testing.T) {
+	t.Helper()
+	binary := hostMuxBinary(t)
+	previous := muxBinaryFor
+	muxBinaryFor = func(machine string) ([]byte, string, error) {
+		return binary, "linux/" + machine, nil
+	}
+	t.Cleanup(func() { muxBinaryFor = previous })
+}
+
+// --- the go side of the listener, without a Kubernetes API server ------------
+
+// podScript is which of the three scripts an exec is running.
+type podScript int
+
+const (
+	probeExec podScript = iota
+	installExec
+	runExec
+	cleanupExec
+)
+
+// classify tells the scripts apart the way a reader of the exec log would.
+func classify(script string) podScript {
+	switch {
+	case strings.Contains(script, "uname -m"):
+		return probeExec
+	case strings.Contains(script, `cat > "$D/mux"`):
+		return installExec
+	case strings.HasPrefix(script, "rm -rf "):
+		return cleanupExec
+	default:
+		return runExec
+	}
+}
+
+// fakePodBehaviour bends what the stubbed pod does, so a test can reach the
+// failures a real container would produce.
+type fakePodBehaviour struct {
+	probeStdout   string
+	probeStderr   string
+	probeErr      error
+	installStdin  io.Writer
+	installErr    error
+	installStderr string
+	// silent models a multiplexer that starts but never reports the port bound.
+	silent    bool
+	runErr    error
+	runStderr string
+	// linger models a run exec that keeps going after its stdin ends, which is what
+	// a runtime that leaves the exec'd process running looks like.
+	linger bool
+}
+
+// fakePod stands in for one target container across the three execs a forward takes.
+type fakePod struct {
+	t         *testing.T
+	behave    fakePodBehaviour
+	release   chan struct{}
+	installed chan []byte
+	cleaned   chan string
+
+	mu          sync.Mutex
+	scripts     map[podScript]string
+	stdinSet    map[podScript]bool
+	session     *rfwdmux.Session
+	sessionUp   chan struct{}
+	sessionOnce sync.Once
+}
+
+// testMuxBinary stands in for the embedded multiplexer. Its leading bytes are what
+// muxbin uses to tell a real binary from the placeholder a source checkout carries.
+var testMuxBinary = append([]byte{0x7f, 'E', 'L', 'F'}, []byte(" not really a multiplexer")...)
+
+// stubMuxBinary answers for the architectures the apiserver builds for, and refuses
+// the rest the way the real lookup does.
+func stubMuxBinary(t *testing.T) {
+	t.Helper()
+	previous := muxBinaryFor
+	muxBinaryFor = func(machine string) ([]byte, string, error) {
+		switch machine {
+		case "x86_64", "amd64":
+			return testMuxBinary, "linux/amd64", nil
+		case "aarch64", "arm64":
+			return testMuxBinary, "linux/arm64", nil
+		default:
+			return nil, "", fmt.Errorf("no reverse forward multiplexer is built for machine %q", machine)
+		}
+	}
+	t.Cleanup(func() { muxBinaryFor = previous })
+}
+
+// stubPod routes every exec to a fake container for the test's duration.
+func stubPod(t *testing.T, behave fakePodBehaviour) *fakePod {
+	t.Helper()
+	stubMuxBinary(t)
+	p := &fakePod{
+		t:         t,
+		behave:    behave,
+		release:   make(chan struct{}),
+		installed: make(chan []byte, 1),
+		cleaned:   make(chan string, 4),
+		scripts:   map[podScript]string{},
+		stdinSet:  map[podScript]bool{},
+		sessionUp: make(chan struct{}),
+	}
+	previous := newPodExecutor
+	newPodExecutor = func(_ *execPodListener, script string, stdin bool) (remotecommand.Executor, error) {
+		kind := classify(script)
+		p.mu.Lock()
+		p.scripts[kind] = script
+		p.stdinSet[kind] = stdin
+		p.mu.Unlock()
+		return &fakeExec{pod: p, kind: kind}, nil
+	}
+	t.Cleanup(func() {
+		newPodExecutor = previous
+		close(p.release)
+	})
+	return p
+}
+
+// podSession is the multiplexer end of the run exec, once it is up.
+func (p *fakePod) podSession() *rfwdmux.Session {
+	select {
+	case <-p.sessionUp:
+	case <-time.After(20 * time.Second):
+		p.t.Fatal("the run exec never started a session")
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.session
+}
+
+// script returns what the apiserver asked the container to run.
+func (p *fakePod) script(kind podScript) string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.scripts[kind]
+}
+
+// wantsStdin reports whether an exec was given a stdin stream.
+func (p *fakePod) wantsStdin(kind podScript) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.stdinSet[kind]
+}
+
+// fakeExec is one exec against the fake container.
+type fakeExec struct {
+	pod  *fakePod
+	kind podScript
+}
+
+func (f *fakeExec) Stream(opts remotecommand.StreamOptions) error {
+	return f.StreamWithContext(context.Background(), opts)
+}
+
+func (f *fakeExec) StreamWithContext(ctx context.Context, opts remotecommand.StreamOptions) error {
+	b := f.pod.behave
+	switch f.kind {
+	case probeExec:
+		stdout := b.probeStdout
+		if stdout == "" {
+			stdout = "ARCH x86_64\nDIR /tmp\n"
+		}
+		_, _ = io.WriteString(opts.Stdout, stdout)
+		if b.probeStderr != "" {
+			_, _ = io.WriteString(opts.Stderr, b.probeStderr+"\n")
+		}
+		return b.probeErr
+	case cleanupExec:
+		select {
+		case f.pod.cleaned <- f.pod.script(cleanupExec):
+		default:
+		}
+		return nil
+	case installExec:
+		var written bytes.Buffer
+		if opts.Stdin != nil {
+			_, _ = io.Copy(&written, opts.Stdin)
+		}
+		select {
+		case f.pod.installed <- written.Bytes():
+		default:
+		}
+		if b.installStderr != "" {
+			_, _ = io.WriteString(opts.Stderr, b.installStderr+"\n")
+		}
+		return b.installErr
+	default:
+		return f.runStream(ctx, opts)
+	}
+}
+
+// runStream behaves like the multiplexer: it speaks the real framing over the
+// exec's stdin and stdout, and stops when its stdin ends.
+func (f *fakeExec) runStream(ctx context.Context, opts remotecommand.StreamOptions) error {
+	b := f.pod.behave
+	if b.runStderr != "" {
+		_, _ = io.WriteString(opts.Stderr, b.runStderr+"\n")
+	}
+	if b.runErr != nil {
+		return b.runErr
+	}
+	session := rfwdmux.NewSession(
+		rfwdmux.Join(opts.Stdin, opts.Stdout),
+		rfwdmux.Config{Initiator: true})
+	f.pod.mu.Lock()
+	f.pod.session = session
+	f.pod.mu.Unlock()
+	f.pod.sessionOnce.Do(func() { close(f.pod.sessionUp) })
+
+	if !b.silent {
+		_, _ = io.WriteString(opts.Stderr, rfwdmux.ReadyMarker+"\n")
+	}
+	select {
+	case <-session.Done():
+		if b.linger {
+			// The stream is gone but the process is not; only tearing the exec down
+			// ends it.
+			<-ctx.Done()
+			return ctx.Err()
+		}
+		return nil
+	case <-ctx.Done():
+		_ = session.Close()
+		return ctx.Err()
+	case <-f.pod.release:
+		return nil
+	}
+}
+
+// newTestListener starts a listener against the fake container.
+func newTestListener(t *testing.T) (podListener, *fakePod) {
+	t.Helper()
+	pod := stubPod(t, fakePodBehaviour{})
+	listener, err := newExecPodListener(context.Background(),
+		&UserInfo{Namespace: "ns", Pod: "pod-0", Container: "main"}, nil, "127.0.0.1", 10001)
+	testifyassert.NoError(t, err)
+	if err != nil {
+		t.FailNow()
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	return listener, pod
+}
+
+// TestExecPodListenerInstallsTheMultiplexer pins the shape of a forward's setup:
+// one probe, one install carrying the binary itself, and one long-lived run exec.
+func TestExecPodListenerInstallsTheMultiplexer(t *testing.T) {
+	_, pod := newTestListener(t)
+
+	testifyassert.False(t, pod.wantsStdin(probeExec), "the probe has nothing to be sent")
+	testifyassert.True(t, pod.wantsStdin(installExec), "the binary arrives on the install exec's stdin")
+	testifyassert.True(t, pod.wantsStdin(runExec), "ending stdin is how the multiplexer is stopped")
+
+	select {
+	case written := <-pod.installed:
+		testifyassert.True(t, bytes.Equal(testMuxBinary, written),
+			"the install exec carries the embedded binary itself")
+	case <-time.After(20 * time.Second):
+		t.Fatal("nothing was written to the install exec")
+	}
+
+	// The install directory is under the probe's answer, named by a token, and the
+	// run exec is the one that binds the port.
+	testifyassert.Contains(t, pod.script(installExec), "/tmp/.safe-rfwd-")
+	testifyassert.Contains(t, pod.script(runExec), "127.0.0.1 10001")
+}
+
+// TestExecPodListenerAcceptCarriesAConnection is the whole point of the session:
+// a connection the pod accepted arrives as a stream, with its origin intact.
+func TestExecPodListenerAcceptCarriesAConnection(t *testing.T) {
+	listener, pod := newTestListener(t)
+
+	podStream, err := pod.podSession().Open("10.0.0.9", 51234)
+	testifyassert.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	conn, err := listener.Accept(ctx)
+	testifyassert.NoError(t, err)
+	testifyassert.Equal(t, "10.0.0.9", conn.OriginAddr())
+	testifyassert.Equal(t, uint32(51234), conn.OriginPort())
+
+	_, err = podStream.Write([]byte("from-pod"))
+	testifyassert.NoError(t, err)
+	buf := make([]byte, len("from-pod"))
+	_, err = io.ReadFull(conn, buf)
+	testifyassert.NoError(t, err)
+	testifyassert.Equal(t, "from-pod", string(buf))
+
+	// And a half-close in the other direction leaves the reply on its way.
+	_, err = conn.Write([]byte("from-apiserver"))
+	testifyassert.NoError(t, err)
+	testifyassert.NoError(t, conn.CloseWrite())
+	got, err := io.ReadAll(podStream)
+	testifyassert.NoError(t, err)
+	testifyassert.Equal(t, "from-apiserver", string(got))
+}
+
+// TestExecPodListenerCloseEndsTheSession pins the shutdown signal the apiserver
+// sends to the pod: it ends the run exec's stdin, which is the only teardown a
+// runtime honours when it leaves the exec'd process running.
+func TestExecPodListenerCloseEndsTheSession(t *testing.T) {
+	listener, pod := newTestListener(t)
+	session := pod.podSession()
+
+	testifyassert.NoError(t, listener.Close())
+	select {
+	case <-session.Done():
+	case <-time.After(20 * time.Second):
+		t.Fatal("the pod-side session was never told the forward ended")
+	}
+
+	// Accept must not block once the listener is gone.
+	_, err := listener.Accept(context.Background())
+	testifyassert.Error(t, err)
+}
+
+// TestExecPodListenerCloseGivesUpOnAStuckRun keeps one wedged container from
+// holding up the rest of a session's teardown.
+func TestExecPodListenerCloseGivesUpOnAStuckRun(t *testing.T) {
+	previous := listenerShutdownGrace
+	listenerShutdownGrace = 200 * time.Millisecond
+	t.Cleanup(func() { listenerShutdownGrace = previous })
+
+	stubPod(t, fakePodBehaviour{linger: true})
+	listener, err := newExecPodListener(context.Background(),
+		&UserInfo{Namespace: "ns", Pod: "pod-0", Container: "main"}, nil, "127.0.0.1", 10001)
+	testifyassert.NoError(t, err)
+
+	start := time.Now()
+	testifyassert.NoError(t, listener.Close())
+	testifyassert.Less(t, time.Since(start), 5*time.Second)
+}
+
+// TestExecPodListenerCloseIsPromptWithABacklog covers teardown while connections
+// nobody has accepted are queued: the queue must not be what Close waits on.
+func TestExecPodListenerCloseIsPromptWithABacklog(t *testing.T) {
+	previous := listenerShutdownGrace
+	listenerShutdownGrace = 5 * time.Second
+	t.Cleanup(func() { listenerShutdownGrace = previous })
+
+	listener, pod := newTestListener(t)
+	session := pod.podSession()
+	for i := 0; i < 64; i++ {
+		_, err := session.Open("10.0.0.9", uint32(40000+i))
+		testifyassert.NoError(t, err)
+	}
+	waitFor(t, func() bool { return session.NumStreams() == 64 }, "the backlog to build")
+
+	start := time.Now()
+	testifyassert.NoError(t, listener.Close())
+	testifyassert.Less(t, time.Since(start), 2*time.Second,
+		"Close waited out its grace because a backlog was left unread")
+}
+
+// TestExecPodListenerReportsPodSideFailure pins the consumer of the error marker.
+// Without it a pod that cannot bind - the port already taken - would leave the
+// caller waiting out the readiness timeout instead of being told what went wrong.
+func TestExecPodListenerReportsPodSideFailure(t *testing.T) {
+	stubPod(t, fakePodBehaviour{
+		silent:    true,
+		runStderr: rfwdErrMarker + " failed to listen on 127.0.0.1:10001",
+	})
+	_, err := newExecPodListener(context.Background(),
+		&UserInfo{Namespace: "ns", Pod: "pod-0", Container: "main"}, nil, "127.0.0.1", 10001)
+	testifyassert.ErrorContains(t, err, "failed to listen on 127.0.0.1:10001")
+}
+
+// TestExecPodListenerReportsTheRunExecDying covers the multiplexer exiting before
+// it ever reports itself ready.
+func TestExecPodListenerReportsTheRunExecDying(t *testing.T) {
+	stubPod(t, fakePodBehaviour{runErr: fmt.Errorf("command terminated with exit code 126")})
+	_, err := newExecPodListener(context.Background(),
+		&UserInfo{Namespace: "ns", Pod: "pod-0", Container: "main"}, nil, "127.0.0.1", 10001)
+	testifyassert.ErrorContains(t, err, "exit code 126")
+}
+
+// TestExecPodListenerRemovesAnInstallThatNeverRan covers the one path where nothing
+// inside the pod would clear the multiplexer away: the run script's trap and the
+// multiplexer's own cleanup both need it to have started, and here it never did.
+func TestExecPodListenerRemovesAnInstallThatNeverRan(t *testing.T) {
+	previous := listenerReadyTimeout
+	listenerReadyTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { listenerReadyTimeout = previous })
+
+	pod := stubPod(t, fakePodBehaviour{silent: true})
+	_, err := newExecPodListener(context.Background(),
+		&UserInfo{Namespace: "ns", Pod: "pod-0", Container: "main"}, nil, "127.0.0.1", 10001)
+	testifyassert.Error(t, err)
+
+	select {
+	case script := <-pod.cleaned:
+		testifyassert.Contains(t, script, "rm -rf /tmp/.safe-rfwd-")
+	case <-time.After(20 * time.Second):
+		t.Fatal("a failed setup left the multiplexer in the pod")
+	}
+}
+
+// TestExecPodListenerTimesOutOnASilentPod keeps a container that starts the
+// multiplexer but never binds from holding the SSH global request forever.
+func TestExecPodListenerTimesOutOnASilentPod(t *testing.T) {
+	previous := listenerReadyTimeout
+	listenerReadyTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { listenerReadyTimeout = previous })
+
+	stubPod(t, fakePodBehaviour{silent: true})
+	_, err := newExecPodListener(context.Background(),
+		&UserInfo{Namespace: "ns", Pod: "pod-0", Container: "main"}, nil, "127.0.0.1", 10001)
+	testifyassert.ErrorContains(t, err, "timed out waiting for pod listener")
+}
+
+// TestExecPodListenerReportsAnUnreachableProbe surfaces the container's own words
+// rather than only that a command failed.
+func TestExecPodListenerReportsAnUnreachableProbe(t *testing.T) {
+	stubPod(t, fakePodBehaviour{
+		probeErr:    fmt.Errorf("command terminated with exit code 1"),
+		probeStderr: rfwdErrMarker + " no directory among /tmp is both writable and executable",
+	})
+	_, err := newExecPodListener(context.Background(),
+		&UserInfo{Namespace: "ns", Pod: "pod-0", Container: "main"}, nil, "127.0.0.1", 10001)
+	testifyassert.ErrorContains(t, err, "writable and executable")
+}
+
+// TestExecPodListenerReportsAnUnsupportedArchitecture stops before writing
+// anything, because there is nothing that would run.
+func TestExecPodListenerReportsAnUnsupportedArchitecture(t *testing.T) {
+	stubPod(t, fakePodBehaviour{probeStdout: "ARCH s390x\nDIR /tmp\n"})
+	_, err := newExecPodListener(context.Background(),
+		&UserInfo{Namespace: "ns", Pod: "pod-0", Container: "main"}, nil, "127.0.0.1", 10001)
+	testifyassert.ErrorContains(t, err, "s390x")
+}
+
+// TestExecPodListenerReportsAFailedInstall names the install rather than leaving
+// the caller to guess which of the three execs failed.
+func TestExecPodListenerReportsAFailedInstall(t *testing.T) {
+	stubPod(t, fakePodBehaviour{
+		installErr:    fmt.Errorf("command terminated with exit code 1"),
+		installStderr: rfwdErrMarker + " the multiplexer written to /tmp/x could not run in this container",
+	})
+	_, err := newExecPodListener(context.Background(),
+		&UserInfo{Namespace: "ns", Pod: "pod-0", Container: "main"}, nil, "127.0.0.1", 10001)
+	testifyassert.ErrorContains(t, err, "could not run in this container")
+}
+
+// TestExecPodListenerSurvivesChatter keeps diagnostics from the container - which
+// are neither markers nor connections - from being read as anything else.
+func TestExecPodListenerSurvivesChatter(t *testing.T) {
+	pod := stubPod(t, fakePodBehaviour{runStderr: "libfoo: warning about nothing in particular"})
+	listener, err := newExecPodListener(context.Background(),
+		&UserInfo{Namespace: "ns", Pod: "pod-0", Container: "main"}, nil, "127.0.0.1", 10001)
+	testifyassert.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+	session := pod.podSession()
+
+	stream, err := session.Open("10.0.0.9", 1)
+	testifyassert.NoError(t, err)
+	defer stream.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	conn, err := listener.Accept(ctx)
+	testifyassert.NoError(t, err)
+	testifyassert.NoError(t, conn.Close())
+}
+
+// TestExecPodListenerRefusesPastTheCap is the overload contract seen from the
+// apiserver: the cap is what the pod side is told to enforce, and the session on
+// this end enforces the same number.
+func TestExecPodListenerRefusesPastTheCap(t *testing.T) {
+	listener, pod := newTestListener(t)
+	testifyassert.Contains(t, pod.script(runExec), fmt.Sprintf("-max-streams %d", muxMaxStreams))
+
+	l, ok := listener.(*execPodListener)
+	testifyassert.True(t, ok)
+	testifyassert.Equal(t, muxMaxStreams, l.session.MaxStreams())
+}
+
+func TestExecRequestShape(t *testing.T) {
+	clientSet, err := kubernetes.NewForConfig(&rest.Config{Host: "https://example.invalid"})
+	testifyassert.NoError(t, err)
+	clients := commonclient.NewClientFactoryWithOnlyClient(context.Background(), "c1", clientSet)
+	clients.AttachRestConfigForTest(&rest.Config{Host: "https://example.invalid"})
+
+	l := &execPodListener{
+		clients:   clients,
+		userInfo:  &UserInfo{Namespace: "ns", Pod: "pod-0", Container: "main"},
+		container: "main",
+	}
+
+	url := l.execRequest("echo hello", true).URL()
+	testifyassert.Contains(t, url.Path, "/namespaces/ns/pods/pod-0/exec")
+	query := url.Query()
+	testifyassert.Equal(t, "main", query.Get("container"))
+	// The multiplexer learns the session ended from its stdin closing, so the exec
+	// has to carry one; stdout carries the multiplexed session and stderr the
+	// readiness marker.
+	testifyassert.Equal(t, "true", query.Get("stdin"))
+	testifyassert.Equal(t, "true", query.Get("stdout"))
+	testifyassert.Equal(t, "true", query.Get("stderr"))
+	// A false flag is left out of the query rather than spelled out.
+	testifyassert.Empty(t, query.Get("tty"))
+	testifyassert.Equal(t, []string{"/bin/sh", "-c", "echo hello"}, query["command"])
+
+	// An exec that does not need stdin must not be given one.
+	testifyassert.Empty(t, l.execRequest("echo hello", false).URL().Query().Get("stdin"))
+
+	executor, err := l.newExecutor("echo hello", true)
+	testifyassert.NoError(t, err)
+	testifyassert.NotNil(t, executor)
+}
+
+func TestLimitedWriterAbsorbsAFlood(t *testing.T) {
+	var sink bytes.Buffer
+	w := &limitedWriter{w: &sink, left: 8}
+	// A short write would abort the exec stream, so everything is accounted for
+	// even once nothing more is kept.
+	n, err := w.Write([]byte("0123456789"))
+	testifyassert.NoError(t, err)
+	testifyassert.Equal(t, 10, n)
+	n, err = w.Write([]byte("more"))
+	testifyassert.NoError(t, err)
+	testifyassert.Equal(t, 4, n)
+	testifyassert.Equal(t, "01234567", sink.String())
+}
+
+func TestReportedReason(t *testing.T) {
+	testifyassert.Equal(t, ": nothing is executable",
+		reportedReason("some noise\n"+rfwdErrMarker+" nothing is executable\n"))
+	testifyassert.Empty(t, reportedReason("just noise\n"))
+}
+
+// --- shared port helpers ----------------------------------------------------
+
+// waitForPortFree blocks until nothing holds the listen port any more.
 func waitForPortFree(t *testing.T, port uint32) {
 	t.Helper()
 	waitFor(t, func() bool {
@@ -223,59 +763,6 @@ func waitForPortFree(t *testing.T, port uint32) {
 		_ = l.Close()
 		return true
 	}, "the pod listen port to be released")
-}
-
-// TestAcceptorScriptWithoutSocat verifies the script reports a usable error when the
-// workload image has no socat, instead of hanging until the readiness timeout.
-func TestAcceptorScriptWithoutSocat(t *testing.T) {
-	dir := filepath.Join(t.TempDir(), "rfwd")
-	cmd := exec.Command("/bin/sh", "-c", acceptorScript(dir, "127.0.0.1", 10001, 12))
-	// An empty PATH makes `command -v socat` fail the way a stripped image would.
-	cmd.Env = append(os.Environ(), "PATH=")
-	out, err := cmd.CombinedOutput()
-	testifyassert.Error(t, err)
-	testifyassert.Contains(t, string(out), rfwdErrMarker)
-	testifyassert.Contains(t, string(out), "socat is not installed")
-}
-
-// TestAcceptorScriptNamesTheMissingTool covers the preflight for every tool the
-// relay needs, not just socat. Readiness is decided by reading the kernel's listen
-// table with awk, and the script runs under set -e: an image without awk would exit
-// on the first read with no marker at all, leaving the operator with nothing but
-// "pod listener exited".
-func TestAcceptorScriptNamesTheMissingTool(t *testing.T) {
-	socat, err := exec.LookPath("socat")
-	if err != nil {
-		t.Skip("socat is not installed")
-	}
-
-	// A PATH holding socat and nothing else.
-	onlySocat := t.TempDir()
-	testifyassert.NoError(t, os.Symlink(socat, filepath.Join(onlySocat, "socat")))
-
-	cmd := exec.Command("/bin/sh", "-c", acceptorScript(filepath.Join(t.TempDir(), "rfwd"), "127.0.0.1", 10001, 12))
-	cmd.Env = append(os.Environ(), "PATH="+onlySocat)
-	out, err := cmd.CombinedOutput()
-
-	testifyassert.Error(t, err)
-	testifyassert.Contains(t, string(out), rfwdErrMarker)
-	testifyassert.Contains(t, string(out), "awk is not installed")
-	testifyassert.NotContains(t, string(out), rfwdReadyMarker)
-}
-
-// scanLines forwards each line of r onto ch until r ends.
-func scanLines(r io.Reader, ch chan<- string) {
-	scanner := bufio.NewScanner(r)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
-			continue
-		}
-		select {
-		case ch <- line:
-		default:
-		}
-	}
 }
 
 // freeTCPPort returns a loopback port that is free right now.
@@ -293,813 +780,26 @@ func itoa(port uint32) string {
 	return strconv.FormatUint(uint64(port), 10)
 }
 
-// --- the Go side of the listener, without a Kubernetes API server ------------
+// TestExecPodListenerFailsPromptlyWhenTheRunExecCannotStart covers teardown of a
+// listener that never got as far as a stream: Close has nothing to wait for, and
+// must not sit out its grace discovering that.
+func TestExecPodListenerFailsPromptlyWhenTheRunExecCannotStart(t *testing.T) {
+	previous := listenerShutdownGrace
+	listenerShutdownGrace = 30 * time.Second
+	t.Cleanup(func() { listenerShutdownGrace = previous })
 
-// fakePodExec stands in for one exec'd relay script inside the Pod.
-type fakePodExec struct {
-	script string
-	stdin  bool
-
-	mu   sync.Mutex
-	opts remotecommand.StreamOptions
-	// stdinEOF records that stdin ended cleanly. A stream torn down underneath the
-	// script is a different thing and must not look like one.
-	stdinEOF  bool
-	output    *acceptorOutput
-	release   chan struct{}
-	started   chan struct{}
-	copied    chan struct{}
-	startOnce sync.Once
-}
-
-func newFakePodExec(script string, stdin bool) *fakePodExec {
-	return &fakePodExec{
-		script:  script,
-		stdin:   stdin,
-		started: make(chan struct{}),
-		copied:  make(chan struct{}),
-		release: make(chan struct{}),
-	}
-}
-
-// finish lets a stubbed relay exit, standing in for the pod-side script returning.
-func (f *fakePodExec) finish() { close(f.release) }
-
-// acceptorOutput overrides what a stubbed acceptor writes instead of reporting
-// itself ready: relay diagnostics, or a failure the pod side detected.
-type acceptorOutput struct {
-	stdout, stderr string
-	exitErr        error
-	// stuck models a relay that keeps running after its stdin ends; hold models one
-	// that exits only when the test says so; announce is how many connections the
-	// stream reports before doing anything else, which is how a backlog is built
-	// from inside the stream rather than beside it.
-	stuck    bool
-	hold     bool
-	announce int
-}
-
-func (f *fakePodExec) Stream(opts remotecommand.StreamOptions) error {
-	return f.StreamWithContext(context.Background(), opts)
-}
-
-// StreamWithContext behaves like the relay script: it reports itself ready and then
-// runs until either its stdin ends or the exec stream is torn down.
-func (f *fakePodExec) StreamWithContext(ctx context.Context, opts remotecommand.StreamOptions) error {
-	f.mu.Lock()
-	f.opts = opts
-	f.mu.Unlock()
-	f.startOnce.Do(func() { close(f.started) })
-
-	if strings.Contains(f.script, "UNIX-CONNECT") {
-		// An attached connection: echo whatever the apiserver writes back at it.
-		_, err := io.Copy(opts.Stdout, opts.Stdin)
-		return err
-	}
-
-	if f.output != nil {
-		if f.output.stdout != "" {
-			_, _ = io.WriteString(opts.Stdout, f.output.stdout+"\n")
+	stubPod(t, fakePodBehaviour{})
+	wrapped := newPodExecutor
+	newPodExecutor = func(l *execPodListener, script string, stdin bool) (remotecommand.Executor, error) {
+		if classify(script) == runExec {
+			return nil, fmt.Errorf("no route to the api server")
 		}
-		if f.output.stderr != "" {
-			_, _ = io.WriteString(opts.Stderr, f.output.stderr+"\n")
-		}
-		if f.output.exitErr != nil {
-			return f.output.exitErr
-		}
-	} else {
-		_, _ = io.WriteString(opts.Stdout, rfwdReadyMarker+"\n")
+		return wrapped(l, script, stdin)
 	}
-	// Reported from inside the stream, so a queue nobody drains parks the stream
-	// itself on the write - which is how a real exec's copier behaves.
-	if f.output != nil {
-		for i := 0; i < f.output.announce; i++ {
-			_, _ = io.WriteString(opts.Stderr, fmt.Sprintf("%s %d 10.0.0.9 51234\n", rfwdConnMarker, 7000+i))
-		}
-	}
-	go func() {
-		defer close(f.copied)
-		_, err := io.Copy(io.Discard, opts.Stdin)
-		f.mu.Lock()
-		f.stdinEOF = err == nil
-		f.mu.Unlock()
-	}()
-	select {
-	case <-ctx.Done():
-		// A real container keeps reading until its stdin actually ends, so an EOF
-		// already in flight must be seen before the stream is reported as gone.
-		select {
-		case <-f.copied:
-		case <-time.After(time.Second):
-		}
-		return ctx.Err()
-	case <-f.copied:
-		// The script has been told to stop; it exits when it is done, or never if
-		// this stub is standing in for one that hangs.
-		if f.output != nil && f.output.stuck {
-			<-ctx.Done()
-			return ctx.Err()
-		}
-		if f.output != nil && f.output.hold {
-			select {
-			case <-f.release:
-			case <-ctx.Done():
-				return ctx.Err()
-			}
-		}
-		return nil
-	}
-}
-
-// announce feeds a connection announcement down the acceptor's stderr.
-func (f *fakePodExec) announce(t *testing.T, line string) {
-	t.Helper()
-	<-f.started
-	f.mu.Lock()
-	stderr := f.opts.Stderr
-	f.mu.Unlock()
-	_, err := io.WriteString(stderr, line+"\n")
-	testifyassert.NoError(t, err)
-}
-
-// announceQuietly writes a line without touching the test, for use from a goroutine
-// that may outlive it.
-func (f *fakePodExec) announceQuietly(line string) {
-	<-f.started
-	f.mu.Lock()
-	stderr := f.opts.Stderr
-	f.mu.Unlock()
-	_, _ = io.WriteString(stderr, line+"\n")
-}
-
-// stdinEnded reports whether the exec's stdin reached EOF, which is how the relay
-// script learns the session is over.
-func (f *fakePodExec) stdinEnded() bool {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	return f.stdinEOF
-}
-
-// stubPodExec routes every relay script to a recorded fake for the test's duration.
-func stubPodExec(t *testing.T, output ...*acceptorOutput) *sync.Map {
-	t.Helper()
-	execs := &sync.Map{}
-	previous := newPodExecutor
-	newPodExecutor = func(_ *execPodListener, script string, stdin bool) (remotecommand.Executor, error) {
-		fake := newFakePodExec(script, stdin)
-		if len(output) > 0 && !strings.Contains(script, "UNIX-CONNECT") {
-			fake.output = output[0]
-		}
-		key := "connect"
-		if !strings.Contains(script, "UNIX-CONNECT") {
-			key = "acceptor"
-		}
-		execs.Store(key, fake)
-		return fake, nil
-	}
-	t.Cleanup(func() { newPodExecutor = previous })
-	return execs
-}
-
-// execFor returns the fake standing in for the named relay script.
-func execFor(t *testing.T, execs *sync.Map, key string) *fakePodExec {
-	t.Helper()
-	var fake *fakePodExec
-	waitFor(t, func() bool {
-		value, ok := execs.Load(key)
-		if !ok {
-			return false
-		}
-		fake = value.(*fakePodExec)
-		return true
-	}, "the "+key+" exec to be started")
-	return fake
-}
-
-// TestExecPodListenerCloseEndsStdin pins the shutdown signal the apiserver sends to
-// the Pod: the acceptor exec must carry a stdin stream, and closing the listener
-// must end it. That is the only teardown a runtime honours when it leaves the
-// exec'd process running after the stream is torn down.
-func TestExecPodListenerCloseEndsStdin(t *testing.T) {
-	execs := stubPodExec(t)
-
-	listener, err := newExecPodListener(context.Background(),
-		&UserInfo{Namespace: "ns", Pod: "pod-0", Container: "main"}, nil, "127.0.0.1", 10001)
-	testifyassert.NoError(t, err)
-
-	acceptor := execFor(t, execs, "acceptor")
-	testifyassert.True(t, acceptor.stdin, "the acceptor exec must request stdin")
-	testifyassert.False(t, acceptor.stdinEnded())
-
-	testifyassert.NoError(t, listener.Close())
-	waitFor(t, acceptor.stdinEnded, "the acceptor's stdin to end")
-
-	// Accept must not block once the listener is gone.
-	_, err = listener.Accept(context.Background())
-	testifyassert.Error(t, err)
-}
-
-// TestExecPodListenerAcceptBridgesAnnouncedConn verifies an announcement from the
-// Pod turns into a byte stream attached to that connection.
-func TestExecPodListenerAcceptBridgesAnnouncedConn(t *testing.T) {
-	execs := stubPodExec(t)
-
-	listener, err := newExecPodListener(context.Background(),
-		&UserInfo{Namespace: "ns", Pod: "pod-0", Container: "main"}, nil, "127.0.0.1", 10001)
-	testifyassert.NoError(t, err)
-	t.Cleanup(func() { _ = listener.Close() })
-
-	execFor(t, execs, "acceptor").announce(t, rfwdConnMarker+" 4242 10.0.0.9 51234")
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	conn, err := listener.Accept(ctx)
-	testifyassert.NoError(t, err)
-	testifyassert.Equal(t, "10.0.0.9", conn.OriginAddr())
-	testifyassert.Equal(t, uint32(51234), conn.OriginPort())
-
-	// The connect exec attaches to the announced rendezvous socket, not another one.
-	connect := execFor(t, execs, "connect")
-	testifyassert.Contains(t, connect.script, "/4242")
-	testifyassert.True(t, connect.stdin)
-
-	_, err = conn.Write([]byte("to-pod\n"))
-	testifyassert.NoError(t, err)
-	line, err := bufio.NewReader(conn).ReadString('\n')
-	testifyassert.NoError(t, err)
-	testifyassert.Equal(t, "to-pod\n", line)
-
-	testifyassert.NoError(t, conn.Close())
-}
-
-// TestExecPodListenerIgnoresMalformedAnnouncement verifies a garbled announcement is
-// dropped rather than becoming a connection or killing the listener.
-func TestExecPodListenerIgnoresMalformedAnnouncement(t *testing.T) {
-	execs := stubPodExec(t)
-
-	listener, err := newExecPodListener(context.Background(),
-		&UserInfo{Namespace: "ns", Pod: "pod-0", Container: "main"}, nil, "127.0.0.1", 10001)
-	testifyassert.NoError(t, err)
-	t.Cleanup(func() { _ = listener.Close() })
-
-	acceptor := execFor(t, execs, "acceptor")
-	acceptor.announce(t, rfwdConnMarker+" ../escape 10.0.0.9 51234")
-	acceptor.announce(t, rfwdConnMarker+" 4242 10.0.0.9 51234")
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	conn, err := listener.Accept(ctx)
-	testifyassert.NoError(t, err)
-	connect := execFor(t, execs, "connect")
-	testifyassert.Contains(t, connect.script, "/4242")
-	testifyassert.NotContains(t, connect.script, "escape")
-	testifyassert.NoError(t, conn.Close())
-}
-
-// TestChildScriptDoesNotAnnounceWithoutItsSocket pins that a child which never
-// managed to publish its rendezvous socket says so instead of announcing a
-// connection. An announcement without a socket sends the apiserver to attach to a
-// path that will never exist, and the pod-side application waits out the connect
-// retries before its connection dies for no stated reason.
-func TestChildScriptDoesNotAnnounceWithoutItsSocket(t *testing.T) {
-	dir := t.TempDir()
-	// Shadow socat rather than emptying PATH: without mkdir the script never gets
-	// as far as the branch this test is about, and both assertions would still hold.
-	shadow := t.TempDir()
-	testifyassert.NoError(t, os.WriteFile(filepath.Join(shadow, "socat"),
-		[]byte("#!/bin/sh\nexit 127\n"), 0o755))
-	cmd := exec.Command("/bin/sh", "-c", childScript(dir))
-	cmd.Env = append(os.Environ(), "PATH="+shadow+":"+os.Getenv("PATH"))
-	cmd.Stdin = strings.NewReader("")
-	out, err := cmd.CombinedOutput()
-
-	testifyassert.Error(t, err, "a child with no socket must not exit successfully")
-	testifyassert.NotContains(t, string(out), rfwdConnMarker,
-		"a connection was announced although its rendezvous socket never appeared")
-	// A child that cannot publish its socket loses that one connection; the
-	// listener itself is fine, so this must not be the listener's error marker.
-	testifyassert.Contains(t, string(out), rfwdDropMarker)
-	testifyassert.NotContains(t, string(out), rfwdErrMarker)
-}
-
-// runningChild is a started child relay, kept so a test can end one deliberately.
-type runningChild struct {
-	cmd   *exec.Cmd
-	stdin io.WriteCloser
-}
-
-var childGroups = map[string]runningChild{}
-
-// endChildNormally lets a child run its own cleanup, rather than killing it: the
-// line that releases or keeps an id only runs on the way out.
-func endChildNormally(t *testing.T, dir, id string) {
-	t.Helper()
-	child, ok := childGroups[dir+"/"+id]
-	testifyassert.Truef(t, ok, "no child recorded for id %s", id)
-
-	// Attaching and letting go closes both of the relay's directions, which is what
-	// ends its socat; closing the accepted socket alone only half-closes it.
-	conn, err := net.Dial("unix", filepath.Join(dir, id, "s"))
-	testifyassert.NoError(t, err)
-	_ = conn.Close()
-	_ = child.stdin.Close()
-
-	done := make(chan struct{})
-	go func() { _, _ = child.cmd.Process.Wait(); close(done) }()
-	select {
-	case <-done:
-	case <-time.After(10 * time.Second):
-		t.Fatal("the child never finished on its own")
-	}
-}
-
-// startChild runs one child relay and returns the id it announced, leaving it alive.
-func startChild(t *testing.T, ctx context.Context, dir string) string {
-	t.Helper()
-
-	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", childScript(dir))
-	// The child backgrounds socat and a watcher, which outlive it. Put the lot in
-	// one process group so the cleanup below takes them all, rather than leaving a
-	// socat behind on the machine for every run of this test.
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	// The accepted socket is the child's stdin; hold it open so the child stays up.
-	stdin, err := cmd.StdinPipe()
-	testifyassert.NoError(t, err)
-	t.Cleanup(func() { _ = stdin.Close() })
-	stderr, err := cmd.StderrPipe()
-	testifyassert.NoError(t, err)
-	testifyassert.NoError(t, cmd.Start())
-	t.Cleanup(func() {
-		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
-		_, _ = cmd.Process.Wait()
-	})
-
-	announcements := make(chan string, 8)
-	go scanLines(stderr, announcements)
-	select {
-	case line := <-announcements:
-		conn, ok := parseConnAnnouncement(line)
-		testifyassert.Truef(t, ok, "unexpected child output: %s", line)
-		childGroups[dir+"/"+conn.id] = runningChild{cmd: cmd, stdin: stdin}
-		return conn.id
-	case <-time.After(30 * time.Second):
-		t.Fatal("the child never announced itself")
-		return ""
-	}
-}
-
-// TestExecPodListenerSurvivesADroppedConnection pins the difference between "this
-// listener never came up" and "this one connection could not be handed over". Both
-// are reported by the relay on the same stream, and treating the second as the first
-// would take a user's whole forward down because one connection went wrong.
-func TestExecPodListenerSurvivesADroppedConnection(t *testing.T) {
-	execs := stubPodExec(t)
-
-	listener, err := newExecPodListener(context.Background(),
-		&UserInfo{Namespace: "ns", Pod: "pod-0", Container: "main"}, nil, "127.0.0.1", 10001)
-	testifyassert.NoError(t, err)
-	t.Cleanup(func() { _ = listener.Close() })
-
-	acceptor := execFor(t, execs, "acceptor")
-	acceptor.announce(t, rfwdDropMarker+" the relay socket for 4242 never appeared")
-	acceptor.announce(t, rfwdConnMarker+" 4243 10.0.0.9 51234")
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	conn, err := listener.Accept(ctx)
-	testifyassert.NoError(t, err, "one dropped connection took the whole forward down")
-	if err == nil {
-		testifyassert.Equal(t, uint32(51234), conn.OriginPort())
-		testifyassert.NoError(t, conn.Close())
-	}
-}
-
-// TestExecRequestShape pins the exec request the relay is actually launched with.
-// The rest of the suite replaces newPodExecutor, so without this the container, the
-// command and the stdin flag would only ever be checked against a real API server.
-func TestExecRequestShape(t *testing.T) {
-	clientSet, err := kubernetes.NewForConfig(&rest.Config{Host: "https://example.invalid"})
-	testifyassert.NoError(t, err)
-	clients := commonclient.NewClientFactoryWithOnlyClient(context.Background(), "c1", clientSet)
-	clients.AttachRestConfigForTest(&rest.Config{Host: "https://example.invalid"})
-
-	l := &execPodListener{
-		clients:   clients,
-		userInfo:  &UserInfo{Namespace: "ns", Pod: "pod-0", Container: "main"},
-		container: "main",
-	}
-
-	url := l.execRequest("echo relay", true).URL()
-	testifyassert.Contains(t, url.Path, "/namespaces/ns/pods/pod-0/exec")
-	query := url.Query()
-	testifyassert.Equal(t, "main", query.Get("container"))
-	// The acceptor learns the session ended from its stdin closing, so the exec has
-	// to carry one; stdout and stderr carry the readiness and connection markers.
-	testifyassert.Equal(t, "true", query.Get("stdin"))
-	testifyassert.Equal(t, "true", query.Get("stdout"))
-	testifyassert.Equal(t, "true", query.Get("stderr"))
-	// A false flag is left out of the query rather than spelled out.
-	testifyassert.Empty(t, query.Get("tty"))
-	testifyassert.Equal(t, []string{"/bin/sh", "-c", "echo relay"}, query["command"])
-
-	// A relay that does not need stdin must not be given one.
-	testifyassert.Empty(t, l.execRequest("echo relay", false).URL().Query().Get("stdin"))
-
-	executor, err := l.newExecutor("echo relay", true)
-	testifyassert.NoError(t, err)
-	testifyassert.NotNil(t, executor)
-}
-
-// TestRelayLogWriter verifies relay diagnostics are absorbed rather than treated as
-// stream errors: a short write would make the exec stream fail mid-connection.
-func TestRelayLogWriter(t *testing.T) {
-	w := newLogWriter("pod-0")
-	for _, chunk := range []string{"socat: warning\n", "   \n", ""} {
-		n, err := w.Write([]byte(chunk))
-		testifyassert.NoError(t, err)
-		testifyassert.Equal(t, len(chunk), n, "a short write would abort the exec stream")
-	}
-}
-
-// TestExecPodListenerReportsPodSideFailure pins the consumer of the error marker the
-// relay script emits. Without it a pod that cannot bind - no socat in the image, or
-// the port already taken - would leave the caller waiting out the readiness timeout
-// instead of being told what went wrong.
-func TestExecPodListenerReportsPodSideFailure(t *testing.T) {
-	stubPodExec(t, &acceptorOutput{stderr: rfwdErrMarker + " failed to listen on 127.0.0.1:10001"})
 
 	start := time.Now()
 	_, err := newExecPodListener(context.Background(),
 		&UserInfo{Namespace: "ns", Pod: "pod-0", Container: "main"}, nil, "127.0.0.1", 10001)
-	testifyassert.Error(t, err)
-	testifyassert.Contains(t, err.Error(), "failed to listen on 127.0.0.1:10001")
-	testifyassert.Less(t, time.Since(start), listenerReadyTimeout,
-		"the failure must be reported, not waited out")
-}
-
-// TestExecPodListenerReportsRelayExit covers the other way a listener never comes up:
-// the exec stream ends before the relay reports itself ready.
-func TestExecPodListenerReportsRelayExit(t *testing.T) {
-	stubPodExec(t, &acceptorOutput{exitErr: errSSH("container terminated")})
-
-	_, err := newExecPodListener(context.Background(),
-		&UserInfo{Namespace: "ns", Pod: "pod-0", Container: "main"}, nil, "127.0.0.1", 10001)
-	testifyassert.Error(t, err)
-	testifyassert.Contains(t, err.Error(), "container terminated")
-}
-
-// TestExecPodListenerIgnoresRelayChatter verifies ordinary relay output is logged and
-// dropped rather than mistaken for a marker.
-func TestExecPodListenerIgnoresRelayChatter(t *testing.T) {
-	stubPodExec(t, &acceptorOutput{stderr: "socat: W address is opened in read-write mode", stdout: rfwdReadyMarker})
-
-	listener, err := newExecPodListener(context.Background(),
-		&UserInfo{Namespace: "ns", Pod: "pod-0", Container: "main"}, nil, "127.0.0.1", 10001)
-	testifyassert.NoError(t, err)
-	if err == nil {
-		testifyassert.NoError(t, listener.Close())
-	}
-}
-
-// TestExecPodListenerCloseWaitsForRelayExit pins that Close does not report the
-// listener gone while the pod-side relay still holds the port. A client that drops
-// and reconnects asks for the same port again - what OpenSSH does after a broken
-// link - and reuseaddr does not cover a socket another live process is still
-// listening on, so returning early makes the reconnect fail on a port we just said
-// we had released.
-func TestExecPodListenerCloseWaitsForRelayExit(t *testing.T) {
-	execs := stubPodExec(t, &acceptorOutput{stdout: rfwdReadyMarker, hold: true})
-
-	listener, err := newExecPodListener(context.Background(),
-		&UserInfo{Namespace: "ns", Pod: "pod-0", Container: "main"}, nil, "127.0.0.1", 10001)
-	testifyassert.NoError(t, err)
-
-	acceptor := execFor(t, execs, "acceptor")
-
-	closed := make(chan struct{})
-	go func() { _ = listener.Close(); close(closed) }()
-
-	waitFor(t, acceptor.stdinEnded, "the relay to be told to shut down")
-	select {
-	case <-closed:
-		t.Fatal("Close returned before the relay had exited: the port may still be held")
-	case <-time.After(150 * time.Millisecond):
-	}
-
-	acceptor.finish()
-	select {
-	case <-closed:
-	case <-time.After(5 * time.Second):
-		t.Fatal("Close never returned after the relay exited")
-	}
-}
-
-// TestExecPodListenerCloseGivesUpOnAStuckRelay verifies the wait above is bounded: a
-// relay that never exits must not hold teardown of the whole session.
-func TestExecPodListenerCloseGivesUpOnAStuckRelay(t *testing.T) {
-	previous := listenerShutdownGrace
-	listenerShutdownGrace = 120 * time.Millisecond
-	t.Cleanup(func() { listenerShutdownGrace = previous })
-
-	execs := stubPodExec(t, &acceptorOutput{stdout: rfwdReadyMarker, stuck: true})
-
-	listener, err := newExecPodListener(context.Background(),
-		&UserInfo{Namespace: "ns", Pod: "pod-0", Container: "main"}, nil, "127.0.0.1", 10001)
-	testifyassert.NoError(t, err)
-	execFor(t, execs, "acceptor")
-
-	start := time.Now()
-	testifyassert.NoError(t, listener.Close())
-	testifyassert.Less(t, time.Since(start), 3*time.Second, "a stuck relay must not block teardown")
-}
-
-// TestAcceptorReadyMeansTheePortIsBound pins what the ready marker promises. It used
-// to mean "socat is not a zombie one second later", which is neither necessary nor
-// sufficient: a busy node can take longer than the fixed wait, and the first request
-// through the forward is then refused; a bind that fails more slowly is reported as
-// success. Ready now means the port is listening, checked rather than assumed.
-func TestAcceptorReadyMeansThePortIsBound(t *testing.T) {
-	if _, err := exec.LookPath("socat"); err != nil {
-		t.Skip("socat is not installed")
-	}
-
-	dir := filepath.Join(t.TempDir(), "rfwd")
-	port := freeTCPPort(t)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-
-	start := time.Now()
-	startAcceptor(t, ctx, dir, port)
-	elapsed := time.Since(start)
-
-	// The moment it says ready, the port must accept a connection.
-	conn, err := net.Dial("tcp", net.JoinHostPort("127.0.0.1", itoa(port)))
-	testifyassert.NoError(t, err, "ready was reported before the port was bound")
-	if err == nil {
-		_ = conn.Close()
-	}
-
-	// And it must not be paying a fixed wait to say so.
-	testifyassert.Less(t, elapsed, 900*time.Millisecond,
-		"readiness is still waiting out a fixed sleep rather than checking the port")
-}
-
-// TestAcceptorReportsABindItCannotWin verifies the other direction: a port already
-// taken is reported as a failure rather than waited out.
-func TestAcceptorReportsABindItCannotWin(t *testing.T) {
-	if _, err := exec.LookPath("socat"); err != nil {
-		t.Skip("socat is not installed")
-	}
-
-	occupied, err := net.Listen("tcp", "127.0.0.1:0")
-	testifyassert.NoError(t, err)
-	defer occupied.Close()
-	port := uint32(occupied.Addr().(*net.TCPAddr).Port)
-
-	dir := filepath.Join(t.TempDir(), "rfwd")
-	cmd := exec.Command("/bin/sh", "-c", acceptorScript(dir, "127.0.0.1", port, 12))
-	stdin, err := cmd.StdinPipe()
-	testifyassert.NoError(t, err)
-	defer stdin.Close()
-
-	out, err := cmd.CombinedOutput()
-	testifyassert.Error(t, err, "binding an occupied port must fail")
-	testifyassert.Contains(t, string(out), rfwdErrMarker)
-	testifyassert.NotContains(t, string(out), rfwdReadyMarker,
-		"a listener that never bound must not report itself ready")
-}
-
-// TestExecPodListenerSurvivesALongRelayLine pins that a diagnostic longer than the
-// scanner's default line keeps the forward alive. socat can emit a very long error,
-// and a line that does not fit ends the scan: the goroutine returns, nothing marks
-// the listener failed, and Accept then waits for announcements that will never come
-// again - a forward that hangs with nothing in the log to say why.
-func TestExecPodListenerSurvivesALongRelayLine(t *testing.T) {
-	execs := stubPodExec(t)
-
-	listener, err := newExecPodListener(context.Background(),
-		&UserInfo{Namespace: "ns", Pod: "pod-0", Container: "main"}, nil, "127.0.0.1", 10001)
-	testifyassert.NoError(t, err)
-	t.Cleanup(func() { _ = listener.Close() })
-
-	acceptor := execFor(t, execs, "acceptor")
-	acceptor.announce(t, "socat: E "+strings.Repeat("x", 200*1024))
-	acceptor.announce(t, rfwdConnMarker+" 4242 10.0.0.9 51234")
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	conn, err := listener.Accept(ctx)
-	testifyassert.NoError(t, err, "a long relay line stopped the listener reporting connections")
-	if err == nil {
-		testifyassert.NoError(t, conn.Close())
-	}
-}
-
-// TestChildScriptDoesNotReuseAFinishedId pins that a connection which has finished
-// cannot have its id handed to the next one. An announcement still queued for the
-// first would otherwise be attached to the second, putting one connection's bytes on
-// the other's channel. Ids pair the PID with the clock so they do not repeat, which
-// is also what lets the directory be released instead of accumulating.
-func TestChildScriptDoesNotReuseAFinishedId(t *testing.T) {
-	if _, err := exec.LookPath("socat"); err != nil {
-		t.Skip("socat is not installed")
-	}
-
-	dir := t.TempDir()
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-
-	first := startChild(t, ctx, dir)
-	endChildNormally(t, dir, first)
-
-	second := startChild(t, ctx, dir)
-	testifyassert.NotEqual(t, first, second,
-		"a finished connection's id was handed to the next one")
-
-	// Distinctness between two live children proves nothing - PIDs already give
-	// that. What stops an id coming back is the clock in front of it.
-	testifyassert.GreaterOrEqual(t, len(second), 15,
-		"the id looks like a bare PID, which comes back once the process exits")
-	epoch, err := strconv.ParseInt(second[:10], 10, 64)
-	testifyassert.NoError(t, err)
-	testifyassert.InDelta(t, time.Now().Unix(), epoch, 300,
-		"the id does not begin with the current time, so it can repeat")
-
-	// And the finished one left nothing behind.
-	_, err = os.Stat(filepath.Join(dir, first))
-	testifyassert.Truef(t, os.IsNotExist(err),
-		"the finished connection's directory is still there: ids that do not repeat "+
-			"must not accumulate for the life of the forward")
-}
-
-// TestRelayCarriesAHalfCloseThroughRealSocat is the half-close test that matters.
-// The two in reverse_forward_test.go drive a Go fake, so they prove the bridge
-// half-closes correctly and nothing about whether the relay carries it: socat closes
-// the whole connection a short time after either direction ends, which folds a
-// half-close into a full one and truncates whatever the other side still had to say.
-func TestRelayCarriesAHalfCloseThroughRealSocat(t *testing.T) {
-	if _, err := exec.LookPath("socat"); err != nil {
-		t.Skip("socat is not installed")
-	}
-
-	dir := filepath.Join(t.TempDir(), "rfwd")
-	port := freeTCPPort(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-
-	acceptor := startAcceptor(t, ctx, dir, port)
-
-	// A process in the pod sends its request and says it is done writing.
-	podSide, err := net.Dial("tcp", net.JoinHostPort("127.0.0.1", itoa(port)))
-	testifyassert.NoError(t, err)
-	defer podSide.Close()
-	_, err = podSide.Write([]byte("req\n"))
-	testifyassert.NoError(t, err)
-	testifyassert.NoError(t, podSide.(*net.TCPConn).CloseWrite())
-
-	var announced acceptedConn
-	deadline := time.After(30 * time.Second)
-	for announced.id == "" {
-		select {
-		case line := <-acceptor.stderr:
-			if conn, ok := parseConnAnnouncement(line); ok {
-				announced = conn
-			}
-		case <-deadline:
-			t.Fatal("timed out waiting for the connection announcement")
-		}
-	}
-
-	attach := exec.CommandContext(ctx, "/bin/sh", "-c", connectScript(dir, announced.id))
-	attachIn, err := attach.StdinPipe()
-	testifyassert.NoError(t, err)
-	attachOut, err := attach.StdoutPipe()
-	testifyassert.NoError(t, err)
-	testifyassert.NoError(t, attach.Start())
-	t.Cleanup(func() { _ = attach.Process.Kill(); _, _ = attach.Process.Wait() })
-
-	line, err := bufio.NewReader(attachOut).ReadString('\n')
-	testifyassert.NoError(t, err)
-	testifyassert.Equal(t, "req\n", line)
-
-	// The reply comes back later than socat's post-EOF grace, which is the whole
-	// point: a proxy on the other end does not answer instantly.
-	time.Sleep(1500 * time.Millisecond)
-	_, err = attachIn.Write([]byte("late-reply\n"))
-	testifyassert.NoError(t, err)
-
-	_ = podSide.SetReadDeadline(time.Now().Add(10 * time.Second))
-	back, err := bufio.NewReader(podSide).ReadString('\n')
-	testifyassert.NoError(t, err, "the pod's half-close was turned into a full close")
-	testifyassert.Equal(t, "late-reply\n", back)
-}
-
-// TestAcceptorReadyWithAnotherListenerOnTheSamePort covers a pod that already has
-// something listening on the requested port, on a different address - a server bound
-// to the pod IP, or to another loopback alias, while the forward binds 127.0.0.1.
-// All of them appear in the kernel's listen table under the same port, and readiness
-// has to find ours among them rather than judging by whichever the kernel lists
-// first. The order is the kernel's hash order, so the competing listeners are many:
-// with one, a buggy check passes half the time.
-func TestAcceptorReadyWithAnotherListenerOnTheSamePort(t *testing.T) {
-	if _, err := exec.LookPath("socat"); err != nil {
-		t.Skip("socat is not installed")
-	}
-
-	port := freeTCPPort(t)
-	for i := 2; i <= 9; i++ {
-		other, err := net.Listen("tcp", net.JoinHostPort(fmt.Sprintf("127.0.0.%d", i), itoa(port)))
-		if err != nil {
-			continue
-		}
-		defer other.Close()
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-
-	// startAcceptor fails the test if readiness never arrives, which is the point:
-	// our socat binds fine, and the question is whether we notice.
-	startAcceptor(t, ctx, filepath.Join(t.TempDir(), "rfwd"), port)
-
-	conn, err := net.Dial("tcp", net.JoinHostPort("127.0.0.1", itoa(port)))
-	testifyassert.NoError(t, err, "the forward's own listener should be reachable")
-	if err == nil {
-		_ = conn.Close()
-	}
-}
-
-// TestExecPodListenerCloseIsPromptWithABacklog pins that a listener whose
-// announcements have outrun the apiserver still shuts down at once. The scan
-// goroutine parks on the full queue; if leaving it there stranded the exec's copier
-// mid-write, the stream would never end and Close would wait out its whole grace -
-// holding the pod port for exactly as long as the wait was meant to shorten.
-func TestExecPodListenerCloseIsPromptWithABacklog(t *testing.T) {
-	previous := listenerShutdownGrace
-	listenerShutdownGrace = 5 * time.Second
-	t.Cleanup(func() { listenerShutdownGrace = previous })
-
-	// The stream itself reports more connections than the queue holds and nobody
-	// accepts them, so it is the stream that ends up parked on the write.
-	stubPodExec(t, &acceptorOutput{stdout: rfwdReadyMarker, announce: 40})
-	listener, err := newExecPodListener(context.Background(),
-		&UserInfo{Namespace: "ns", Pod: "pod-0", Container: "main"}, nil, "127.0.0.1", 10001)
-	testifyassert.NoError(t, err)
-	time.Sleep(200 * time.Millisecond)
-
-	start := time.Now()
-	testifyassert.NoError(t, listener.Close())
-	testifyassert.Less(t, time.Since(start), 2*time.Second,
-		"Close waited out its grace because the relay's output was left unread")
-}
-
-// TestExecPodListenerBoundsConcurrentExecs pins the ceiling on per-connection exec
-// streams. The per-session forward limit counts listeners, not the connections
-// through them, so without this one command behind HTTPS_PROXY could hold hundreds
-// of streams open against the target cluster's API server.
-func TestExecPodListenerBoundsConcurrentExecs(t *testing.T) {
-	execs := stubPodExec(t)
-	listener, err := newExecPodListener(context.Background(),
-		&UserInfo{Namespace: "ns", Pod: "pod-0", Container: "main"}, nil, "127.0.0.1", 10001)
-	testifyassert.NoError(t, err)
-	t.Cleanup(func() { _ = listener.Close() })
-
-	l, ok := listener.(*execPodListener)
-	testifyassert.True(t, ok)
-	testifyassert.Equal(t, maxConcurrentRelayExecs, cap(l.execSlots))
-
-	acceptor := execFor(t, execs, "acceptor")
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-	defer cancel()
-
-	held := make([]podConn, 0, maxConcurrentRelayExecs)
-	for i := 0; i < maxConcurrentRelayExecs; i++ {
-		acceptor.announce(t, fmt.Sprintf("%s %d 10.0.0.9 51234", rfwdConnMarker, 6000+i))
-		conn, err := listener.Accept(ctx)
-		testifyassert.NoError(t, err)
-		held = append(held, conn)
-	}
-	testifyassert.Equal(t, maxConcurrentRelayExecs, len(l.execSlots), "every slot should be taken")
-
-	// One more has to wait for a slot rather than opening another stream.
-	acceptor.announce(t, fmt.Sprintf("%s 6999 10.0.0.9 51234", rfwdConnMarker))
-	overflow := make(chan error, 1)
-	go func() {
-		short, stop := context.WithTimeout(context.Background(), 300*time.Millisecond)
-		defer stop()
-		_, err := listener.Accept(short)
-		overflow <- err
-	}()
-	select {
-	case err := <-overflow:
-		testifyassert.Error(t, err,
-			"a connection past the ceiling was handed a stream instead of waiting for one")
-	case <-time.After(5 * time.Second):
-		t.Fatal("Accept neither took a slot nor gave up")
-	}
-
-	// Releasing one lets the next through.
-	testifyassert.NoError(t, held[0].Close())
-	waitFor(t, func() bool { return len(l.execSlots) < maxConcurrentRelayExecs }, "a slot to come free")
+	testifyassert.ErrorContains(t, err, "no route to the api server")
+	testifyassert.Less(t, time.Since(start), 5*time.Second)
 }

--- a/SaFE/apiserver/pkg/handlers/ssh-handlers/pod_listener_test.go
+++ b/SaFE/apiserver/pkg/handlers/ssh-handlers/pod_listener_test.go
@@ -617,6 +617,48 @@ func TestExecPodListenerRemovesAnInstallThatNeverRan(t *testing.T) {
 	}
 }
 
+// TestExecPodListenerRemovesAnInstallThatFailedHalfway covers the other arm of the
+// same promise: a setup that died inside the install script. The script only
+// removes its own directory on the branch where the binary would not run, so an
+// exec cut short anywhere before that - a cancelled request, a full filesystem -
+// leaves a multi-megabyte binary in the user's container for the life of the pod,
+// under a fresh token each time it is retried.
+func TestExecPodListenerRemovesAnInstallThatFailedHalfway(t *testing.T) {
+	pod := stubPod(t, fakePodBehaviour{installErr: context.Canceled})
+	_, err := newExecPodListener(context.Background(),
+		&UserInfo{Namespace: "ns", Pod: "pod-0", Container: "main"}, nil, "127.0.0.1", 10001)
+	testifyassert.Error(t, err)
+
+	select {
+	case script := <-pod.cleaned:
+		// Every directory the probe could have written under, not just the one it
+		// settled on: a setup cancelled during the probe has no chosen directory
+		// yet, and what it left behind still has to go.
+		for _, dir := range installDirs {
+			testifyassert.Containsf(t, script, dir+"/.safe-rfwd-",
+				"the cleanup must cover %s", dir)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("a failed install left the multiplexer in the pod")
+	}
+}
+
+// TestExecPodListenerCleansUpAfterAFailedProbe covers the stage before any
+// directory has been chosen, where there is no install path to name yet.
+func TestExecPodListenerCleansUpAfterAFailedProbe(t *testing.T) {
+	pod := stubPod(t, fakePodBehaviour{probeErr: context.Canceled})
+	_, err := newExecPodListener(context.Background(),
+		&UserInfo{Namespace: "ns", Pod: "pod-0", Container: "main"}, nil, "127.0.0.1", 10001)
+	testifyassert.Error(t, err)
+
+	select {
+	case script := <-pod.cleaned:
+		testifyassert.Contains(t, script, "/.safe-rfwd-")
+	case <-time.After(20 * time.Second):
+		t.Fatal("a cancelled probe left its test directory in the pod")
+	}
+}
+
 // TestExecPodListenerTimesOutOnASilentPod keeps a container that starts the
 // multiplexer but never binds from holding the SSH global request forever.
 func TestExecPodListenerTimesOutOnASilentPod(t *testing.T) {

--- a/SaFE/apiserver/pkg/handlers/ssh-handlers/reverse_forward.go
+++ b/SaFE/apiserver/pkg/handlers/ssh-handlers/reverse_forward.go
@@ -56,6 +56,14 @@ type reverseForwardPolicy struct {
 // to wait it out.
 var forwardResolveTimeout = 15 * time.Second
 
+// forwardChannelOpenTimeout bounds opening the forwarded-tcpip channel that
+// carries one pod-side connection back to the client. The SSH client answers
+// channel opens itself, and a client that has stopped answering - suspended,
+// networked away, wedged - used to leave this waiting with no deadline at all,
+// which is one goroutine and one pod-side connection held for as long as the
+// session lives. It is a variable so tests do not have to wait it out.
+var forwardChannelOpenTimeout = 30 * time.Second
+
 // Defaults applied when the configured port range cannot be used.
 const (
 	defaultForwardPortMin = 1024
@@ -143,9 +151,9 @@ func (p reverseForwardPolicy) validate(addr string, port uint32) (string, error)
 		return "", fmt.Errorf("bind address %q is not a literal IP address", addr)
 	}
 	if ip.To4() == nil {
-		// The relay binds with socat's TCP-LISTEN, which is IPv4. Refusing here
-		// turns a config mistake into a clear answer instead of a listener that
-		// fails inside the pod.
+		// The pod-side listener binds an IPv4 socket. Refusing here turns a config
+		// mistake into a clear answer instead of a listener that fails inside the
+		// pod.
 		return "", fmt.Errorf("bind address %q is not IPv4, and the pod-side listener binds an IPv4 socket", addr)
 	}
 	allowed := false
@@ -206,6 +214,14 @@ type reverseForwardManager struct {
 	resolve     podTargetResolver
 	newListener podListenerFactory
 
+	// setupCtx is cancelled by closeAll before any live forward is touched, so a
+	// listener still being started cannot outlive the SSH session that asked for
+	// it. It is separate from the forward contexts because those are the parents
+	// of the running exec streams, which have to be closed in an orderly way
+	// rather than cancelled out from under themselves.
+	setupCtx    context.Context
+	setupCancel context.CancelFunc
+
 	mu       sync.Mutex
 	forwards map[string]*reverseForward
 	closed   bool
@@ -231,6 +247,7 @@ func (h *SshHandler) resolveForwardTarget(ctx context.Context, userInfo *UserInf
 
 // newReverseForwardManager creates a forward registry scoped to one SSH connection.
 func newReverseForwardManager(ctx context.Context, h *SshHandler, conn *ssh.ServerConn) *reverseForwardManager {
+	setupCtx, setupCancel := context.WithCancel(ctx)
 	return &reverseForwardManager{
 		conn:        conn,
 		ctx:         ctx,
@@ -238,6 +255,25 @@ func newReverseForwardManager(ctx context.Context, h *SshHandler, conn *ssh.Serv
 		resolve:     h.resolveForwardTarget,
 		newListener: newExecPodListener,
 		forwards:    map[string]*reverseForward{},
+		setupCtx:    setupCtx,
+		setupCancel: setupCancel,
+	}
+}
+
+// setupAborted reports when listener setup should be given up on. A manager built
+// without a setup context - as a test does when it drives one forward directly -
+// gets a nil channel, which never fires.
+func (m *reverseForwardManager) setupAborted() <-chan struct{} {
+	if m.setupCtx == nil {
+		return nil
+	}
+	return m.setupCtx.Done()
+}
+
+// abortSetups gives up on every listener still being started.
+func (m *reverseForwardManager) abortSetups() {
+	if m.setupCancel != nil {
+		m.setupCancel()
 	}
 }
 
@@ -299,7 +335,21 @@ func (m *reverseForwardManager) handleForward(req *ssh.Request) {
 	}
 
 	fwdCtx, cancel := context.WithCancel(m.ctx)
+	// Starting a listener installs and runs a program inside the pod, which takes
+	// long enough that the SSH session can end underneath it. Until it is
+	// activated, nothing else knows this forward exists, so this is what stops it
+	// from finishing - and leaving a listen socket in the pod - after the session
+	// it belonged to has gone.
+	setupDone := make(chan struct{})
+	go func() {
+		select {
+		case <-m.setupAborted():
+			cancel()
+		case <-setupDone:
+		}
+	}()
 	listener, err := m.newListener(fwdCtx, userInfo, k8sClients, bindAddr, payload.BindPort)
+	close(setupDone)
 	if err != nil {
 		cancel()
 		m.release(key)
@@ -461,6 +511,53 @@ func (m *reverseForwardManager) forget(fwd *reverseForward) {
 	closeForward(fwd, "listener stopped")
 }
 
+// opened is the answer to one forwarded-tcpip channel request.
+type opened struct {
+	ch   ssh.Channel
+	reqs <-chan *ssh.Request
+	err  error
+}
+
+// openChannel asks the client for a forwarded-tcpip channel, giving up if the
+// client does not answer or the forward is torn down while it is being asked.
+//
+// The reply is the client's to send, so without a bound here one unresponsive
+// client holds a goroutine and a pod-side connection for the twelve hours a
+// session may last.
+func (m *reverseForwardManager) openChannel(fwd *reverseForward, payload []byte) (ssh.Channel, <-chan *ssh.Request, error) {
+	// Buffered, so the goroutine finishes and is collected even when nobody is
+	// waiting for its answer any more.
+	result := make(chan opened, 1)
+	go func() {
+		ch, reqs, err := m.conn.OpenChannel(forwardedTCPIPChannel, payload)
+		result <- opened{ch: ch, reqs: reqs, err: err}
+	}()
+
+	timer := time.NewTimer(forwardChannelOpenTimeout)
+	defer timer.Stop()
+	select {
+	case r := <-result:
+		return r.ch, r.reqs, r.err
+	case <-fwd.ctx.Done():
+		go abandonChannel(result)
+		return nil, nil, fmt.Errorf("forward %s was torn down while opening a channel",
+			forwardKey(fwd.bindAddr, fwd.bindPort))
+	case <-timer.C:
+		go abandonChannel(result)
+		return nil, nil, fmt.Errorf("the ssh client did not answer a forwarded-tcpip channel within %s",
+			forwardChannelOpenTimeout)
+	}
+}
+
+// abandonChannel closes a channel whose opener has already given up on it, so a
+// late answer does not leave the client holding one this end will never use.
+func abandonChannel(result <-chan opened) {
+	if r := <-result; r.err == nil {
+		go ssh.DiscardRequests(r.reqs)
+		_ = r.ch.Close()
+	}
+}
+
 // bridge opens a forwarded-tcpip channel and copies bytes both ways.
 func (m *reverseForwardManager) bridge(fwd *reverseForward, pc podConn) {
 	payload := ssh.Marshal(forwardChannelData{
@@ -469,7 +566,7 @@ func (m *reverseForwardManager) bridge(fwd *reverseForward, pc podConn) {
 		OriginAddr: pc.OriginAddr(),
 		OriginPort: pc.OriginPort(),
 	})
-	ch, reqs, err := m.conn.OpenChannel(forwardedTCPIPChannel, payload)
+	ch, reqs, err := m.openChannel(fwd, payload)
 	if err != nil {
 		klog.ErrorS(err, "failed to open forwarded-tcpip channel")
 		_ = pc.Close()
@@ -555,8 +652,11 @@ func (m *reverseForwardManager) closeAll() {
 		}
 	}
 	m.mu.Unlock()
+	// Listeners still starting are abandoned rather than waited for: they are not
+	// in the snapshot above, and nothing else would stop them.
+	m.abortSetups()
 
-	// Closing a forward waits for its Pod-side relay to let go of the listen port,
+	// Closing a forward waits for its Pod-side listener to let go of the listen port,
 	// so closing them one after another would make a session's teardown cost the
 	// sum of those waits. They are independent; take them together.
 	var closing sync.WaitGroup

--- a/SaFE/apiserver/pkg/handlers/ssh-handlers/reverse_forward_live_test.go
+++ b/SaFE/apiserver/pkg/handlers/ssh-handlers/reverse_forward_live_test.go
@@ -11,6 +11,9 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -33,6 +36,11 @@ const (
 // liveTarget reads the live-cluster target, skipping the test when it is absent.
 func liveTarget(t *testing.T) (*commonclient.ClientFactory, *UserInfo) {
 	t.Helper()
+
+	// The test process runs inside the target Pod, so a multiplexer built here is
+	// one that pod can run - and building it means the live tests do not depend on
+	// the image build having already replaced the committed placeholder.
+	injectHostMux(t)
 
 	kubeconfig := os.Getenv(liveKubeconfigEnv)
 	namespace, pod := os.Getenv(liveNamespaceEnv), os.Getenv(livePodEnv)
@@ -74,6 +82,7 @@ func TestLivePodListenerOverK8sExec(t *testing.T) {
 		return
 	}
 	defer listener.Close()
+	dir := installDir(t, listener)
 
 	// A process in the Pod connects to the forwarded port.
 	podSide, err := net.Dial("tcp", net.JoinHostPort("127.0.0.1", itoa(port)))
@@ -105,9 +114,125 @@ func TestLivePodListenerOverK8sExec(t *testing.T) {
 	testifyassert.NoError(t, err)
 	testifyassert.Equal(t, "from-apiserver\n", string(back))
 
+	// A half-close in one direction must leave the other one flowing, which is what
+	// every request followed by its reply depends on.
+	testifyassert.NoError(t, conn.CloseWrite())
+	_, err = podSide.Write([]byte("after-half-close\n"))
+	testifyassert.NoError(t, err)
+	tail := make([]byte, len("after-half-close\n"))
+	_, err = io.ReadFull(conn, tail)
+	testifyassert.NoError(t, err)
+	testifyassert.Equal(t, "after-half-close\n", string(tail))
+
 	// Closing the listener must free the port inside the Pod.
 	testifyassert.NoError(t, listener.Close())
 	waitForPortFree(t, port)
+	// The multiplexer removes its own files, so a forward leaves the container as
+	// it found it.
+	waitFor(t, func() bool { return installRemoved(dir) },
+		"the injected multiplexer to be removed from the pod")
+}
+
+// installDir is where the listener under test put its multiplexer.
+//
+// The check is against this one directory rather than every `.safe-rfwd-*` under the
+// install directories: a pod may well be carrying other forwards of its own, and
+// this test is not entitled to an opinion about those.
+func installDir(t *testing.T, listener podListener) string {
+	t.Helper()
+	l, ok := listener.(*execPodListener)
+	testifyassert.True(t, ok)
+	if !ok {
+		return ""
+	}
+	testifyassert.NotEmpty(t, l.dir, "the listener never recorded where it installed")
+	return l.dir
+}
+
+// installRemoved reports whether the multiplexer has taken its own files away. The
+// live tests run inside the target Pod, so this is the Pod's filesystem.
+func installRemoved(dir string) bool {
+	_, err := os.Stat(dir)
+	return os.IsNotExist(err)
+}
+
+// TestLiveReverseForwardBurstLeavesNothingBehind is the load the single-exec
+// design exists for. The socat relay took one exec per connection, capped at
+// thirty-two, and left the pod holding rendezvous directories and unattached
+// children; a burst here has to leave one exec, no leftover files, and a listen
+// port that is free the moment the forward closes.
+func TestLiveReverseForwardBurstLeavesNothingBehind(t *testing.T) {
+	clients, userInfo := liveTarget(t)
+
+	port := freeTCPPort(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	listener, err := newExecPodListener(ctx, userInfo, clients, "127.0.0.1", port)
+	testifyassert.NoError(t, err)
+	if err != nil {
+		return
+	}
+	defer listener.Close()
+	dir := installDir(t, listener)
+
+	// Serve every accepted connection with one line and hang up, so the burst is a
+	// burst of connections rather than of bytes.
+	served := make(chan struct{}, 256)
+	go func() {
+		for {
+			conn, acceptErr := listener.Accept(ctx)
+			if acceptErr != nil {
+				return
+			}
+			go func(c podConn) {
+				defer c.Close()
+				_, _ = io.Copy(c, strings.NewReader("ok\n"))
+				_ = c.CloseWrite()
+				_, _ = io.Copy(io.Discard, c)
+				served <- struct{}{}
+			}(conn)
+		}
+	}()
+
+	const connections = 150
+	var failures atomic.Int32
+	var wg sync.WaitGroup
+	for i := 0; i < connections; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c, dialErr := net.DialTimeout("tcp", net.JoinHostPort("127.0.0.1", itoa(port)), 30*time.Second)
+			if dialErr != nil {
+				failures.Add(1)
+				return
+			}
+			defer c.Close()
+			_ = c.SetDeadline(time.Now().Add(60 * time.Second))
+			if _, writeErr := c.Write([]byte("ping\n")); writeErr != nil {
+				failures.Add(1)
+				return
+			}
+			body, readErr := io.ReadAll(c)
+			if readErr != nil || string(body) != "ok\n" {
+				failures.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+	testifyassert.Zero(t, failures.Load(), "connections were lost across one forward")
+
+	// Nothing is left holding a stream once the burst is over.
+	l, ok := listener.(*execPodListener)
+	testifyassert.True(t, ok)
+	if ok {
+		waitFor(t, func() bool { return l.session.NumStreams() == 0 }, "every stream to be released")
+	}
+
+	testifyassert.NoError(t, listener.Close())
+	waitForPortFree(t, port)
+	waitFor(t, func() bool { return installRemoved(dir) },
+		"the pod to be left with no reverse forward files")
 }
 
 // TestLiveReverseForwardEndToEnd runs the whole feature against a real Pod: a real

--- a/SaFE/apiserver/pkg/handlers/ssh-handlers/reverse_forward_test.go
+++ b/SaFE/apiserver/pkg/handlers/ssh-handlers/reverse_forward_test.go
@@ -9,11 +9,11 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"os/exec"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -169,74 +169,9 @@ func TestReverseForwardDefaultPortRange(t *testing.T) {
 
 // --- pod listener plumbing ------------------------------------------------
 
-func TestParseConnAnnouncement(t *testing.T) {
-	conn, ok := parseConnAnnouncement("SAFE-RFWD-CONN 4242 127.0.0.1 51234")
-	testifyassert.True(t, ok)
-	testifyassert.Equal(t, "4242", conn.id)
-	testifyassert.Equal(t, "127.0.0.1", conn.peerAddr)
-	testifyassert.Equal(t, uint32(51234), conn.peerPort)
-
-	for _, line := range []string{
-		"",
-		"SAFE-RFWD-CONN",
-		"SAFE-RFWD-CONN 4242 127.0.0.1",
-		"SAFE-RFWD-CONN 4242 127.0.0.1 51234 extra",
-		"SAFE-RFWD-CONN ../../etc/passwd 127.0.0.1 51234",
-		"SAFE-RFWD-CONN 42;rm 127.0.0.1 51234",
-		"SAFE-RFWD-CONN 4242 127.0.0.1 notaport",
-		"SAFE-RFWD-CONN 4242 127.0.0.1 70000",
-		// An overlong id would still be digits-only, so the length bound is what
-		// keeps it from becoming an unbounded path component.
-		"SAFE-RFWD-CONN 123456789012345678901234567890123 127.0.0.1 51234",
-		"SAFE-RFWD-READY",
-	} {
-		_, ok := parseConnAnnouncement(line)
-		testifyassert.Falsef(t, ok, "expected %q to be rejected", line)
-	}
-}
-
-func TestAcceptorScript(t *testing.T) {
-	script := acceptorScript("/tmp/.safe-rfwd-abcd", "127.0.0.1", 10001, 12)
-	testifyassert.Contains(t, script, "TCP-LISTEN:10001,bind=127.0.0.1,reuseaddr,fork")
-	// Every relay socat needs the half-close grace: the default folds one direction
-	// ending into closing the whole connection half a second later.
-	testifyassert.Equal(t, 2, strings.Count(script, "socat -t 120"))
-	testifyassert.Contains(t, script, rfwdReadyMarker)
-	testifyassert.Contains(t, script, rfwdConnMarker)
-	testifyassert.Contains(t, script, rfwdErrMarker)
-	// The listener must be cleaned up when the exec stream goes away, by all three
-	// routes: the trap, the stdin watcher, and the watcher that outlives a SIGKILL.
-	testifyassert.Contains(t, script, `trap 'kill "$SPID" "$WPID" 2>/dev/null || true; rm -rf "$D"' EXIT INT TERM`)
-	testifyassert.Contains(t, script, `( cat <&3 >/dev/null 2>&1; kill "$SPID" 2>/dev/null )`)
-	testifyassert.Contains(t, script, `while [ -e "/proc/$MPID" ] && [ -e "/proc/$SPID" ]`)
-	// Both cleanup routes kill processes that have usually exited already, and the
-	// script runs under set -e: without the || true that failed kill would end the
-	// route before it removes the rendezvous directory.
-	testifyassert.Equal(t, 2, strings.Count(script, `kill "$SPID" "$WPID" 2>/dev/null || true`))
-
-	// Both scripts hand their own stdin to a background socat: a shell would
-	// otherwise give it /dev/null, and the relay would carry an instant EOF.
-	testifyassert.Contains(t, script, "socat -t 120 - UNIX-LISTEN:\"$S\" <&3 &")
-	testifyassert.Equal(t, 2, strings.Count(script, "exec 3<&0"))
-
-	// socat splits address strings on commas, so a comma anywhere in the SYSTEM:
-	// command truncates it into an unparsable address.
-	start := strings.Index(script, "SYSTEM:'")
-	testifyassert.NotEqual(t, -1, start)
-	command := script[start+len("SYSTEM:'"):]
-	command = command[:strings.Index(command, "'")]
-	testifyassert.NotContains(t, command, ",")
-}
-
-func TestConnectScript(t *testing.T) {
-	testifyassert.Equal(t,
-		"exec socat -t 120 - UNIX-CONNECT:/tmp/.safe-rfwd-abcd/4242/s,retry=100,interval=0.1",
-		connectScript("/tmp/.safe-rfwd-abcd", "4242"))
-}
-
 // --- fakes ----------------------------------------------------------------
 
-// fakePodListener stands in for a socat relay running inside a Pod.
+// fakePodListener stands in for the multiplexer running inside a Pod.
 type fakePodListener struct {
 	conns      chan podConn
 	closed     chan struct{}
@@ -554,7 +489,7 @@ func TestReverseForwardListenerStartFailureReleasesPort(t *testing.T) {
 	enableReverseForward(t, nil)
 	rig := newForwardTestRig(t)
 
-	rig.factoryErr = errSSH("socat is not installed in the container")
+	rig.factoryErr = errSSH("the multiplexer could not run in this container")
 	_, err := rig.client.ListenTCP(&net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 10001})
 	testifyassert.Error(t, err)
 
@@ -645,9 +580,9 @@ func waitFor(t *testing.T, cond func() bool, what string) {
 
 // --- whole stack, real relay scripts ---------------------------------------
 
-// localRelayExec runs a relay script as a local process. It stands in for the
-// Kubernetes exec transport so the scripts, socat and the shell that the apiserver
-// actually depends on are exercised end to end.
+// localRelayExec runs a pod-side script as a local process. It stands in for the
+// Kubernetes exec transport so the scripts, the shell and the multiplexer binary
+// the apiserver actually depends on are exercised end to end.
 type localRelayExec struct{ script string }
 
 func (e *localRelayExec) Stream(opts remotecommand.StreamOptions) error {
@@ -657,19 +592,19 @@ func (e *localRelayExec) Stream(opts remotecommand.StreamOptions) error {
 func (e *localRelayExec) StreamWithContext(ctx context.Context, opts remotecommand.StreamOptions) error {
 	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", e.script)
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = opts.Stdin, opts.Stdout, opts.Stderr
-	// The relay is killed by tearing its stream down, so it must not outlive ctx.
+	// The multiplexer is stopped by tearing its stream down, so it must not
+	// outlive ctx.
 	cmd.WaitDelay = time.Second
 	return cmd.Run()
 }
 
 // TestReverseForwardThroughRealRelay drives the whole feature: a real SSH client
-// asks for `-R`, the real relay scripts open the listen socket, and an HTTP request
-// made against that socket is served by the client side of the SSH connection.
-// Only the Kubernetes exec transport is replaced.
+// asks for `-R`, the real scripts install and run the real multiplexer, that
+// multiplexer opens the listen socket, and an HTTP request made against the socket
+// is served by the client side of the SSH connection. Only the Kubernetes exec
+// transport is replaced.
 func TestReverseForwardThroughRealRelay(t *testing.T) {
-	if _, err := exec.LookPath("socat"); err != nil {
-		t.Skip("socat is not installed")
-	}
+	injectHostMux(t)
 
 	// The policy is a port range, so pin it to one port that is free right now.
 	port := freeTCPPort(t)
@@ -718,9 +653,86 @@ func TestReverseForwardThroughRealRelay(t *testing.T) {
 	waitForPortFree(t, port)
 }
 
+// TestReverseForwardBurstThroughRealRelay is the load the single-exec design
+// exists for: many short connections through one forward, where the old path took
+// an exec apiece, ran out at thirty-two, and left the listener accepting
+// connections it never answered.
+func TestReverseForwardBurstThroughRealRelay(t *testing.T) {
+	injectHostMux(t)
+
+	port := freeTCPPort(t)
+	enableReverseForward(t, map[string]any{
+		sshReverseForwardPortMinKey: int(port),
+		sshReverseForwardPortMaxKey: int(port),
+	})
+
+	previous := newPodExecutor
+	newPodExecutor = func(_ *execPodListener, script string, _ bool) (remotecommand.Executor, error) {
+		return &localRelayExec{script: script}, nil
+	}
+	t.Cleanup(func() { newPodExecutor = previous })
+
+	rig := newForwardTestRigWith(t, func(m *reverseForwardManager) {
+		m.resolve = func(context.Context, *UserInfo) (*commonclient.ClientFactory, error) { return nil, nil }
+		m.newListener = newExecPodListener
+	})
+
+	listener, err := rig.client.ListenTCP(&net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: int(port)})
+	testifyassert.NoError(t, err)
+	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, r.URL.Path)
+	})}
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() { _ = server.Close() })
+
+	// No keepalive: every request is its own connection, which is what makes this a
+	// burst of connections rather than a burst of requests.
+	client := &http.Client{
+		Timeout:   60 * time.Second,
+		Transport: &http.Transport{DisableKeepAlives: true},
+	}
+	const requests = 120
+	var failures atomic.Int32
+	var wg sync.WaitGroup
+	for i := 0; i < requests; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			resp, getErr := client.Get(fmt.Sprintf("http://%s/%d",
+				net.JoinHostPort("127.0.0.1", itoa(port)), i))
+			if getErr != nil {
+				failures.Add(1)
+				return
+			}
+			defer resp.Body.Close()
+			body, readErr := io.ReadAll(resp.Body)
+			if readErr != nil || string(body) != fmt.Sprintf("/%d", i) {
+				failures.Add(1)
+			}
+		}(i)
+	}
+	wg.Wait()
+	testifyassert.Zero(t, failures.Load(), "connections were lost across one forward")
+
+	// And the forward is left carrying nothing, rather than holding what it served.
+	rig.manager.mu.Lock()
+	fwd := rig.manager.forwards[forwardKey("127.0.0.1", port)]
+	rig.manager.mu.Unlock()
+	testifyassert.NotNil(t, fwd)
+	if fwd == nil {
+		return
+	}
+	l, ok := fwd.listener.(*execPodListener)
+	testifyassert.True(t, ok)
+	waitFor(t, func() bool { return l.session.NumStreams() == 0 }, "every stream to be released")
+
+	rig.closeConn()
+	waitForPortFree(t, port)
+}
+
 // TestReverseForwardSessionClosingDuringSetupClosesListener covers the race where the
 // SSH connection ends while the Pod-side listener is still starting: the listener is
-// already running by then, so failing to close it would leak a socat in the Pod.
+// already running by then, so failing to close it would leave a listener in the Pod.
 func TestReverseForwardSessionClosingDuringSetupClosesListener(t *testing.T) {
 	enableReverseForward(t, nil)
 
@@ -855,6 +867,13 @@ func (c *halfClosedPodConn) Close() error {
 	c.closed = true
 	c.mu.Unlock()
 	return nil
+}
+
+// isClosed reports whether the bridge released this connection.
+func (c *halfClosedPodConn) isClosed() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.closed
 }
 
 func (c *halfClosedPodConn) OriginAddr() string { return "127.0.0.1" }
@@ -1399,4 +1418,106 @@ func TestReverseForwardRefusesWhenNoForwardsArePermitted(t *testing.T) {
 	testifyassert.Error(t, err)
 	testifyassert.Contains(t, err.Error(), "no forwards")
 	testifyassert.Empty(t, m.forwards)
+}
+
+// blockingSSHConn never answers a channel open, which is what an SSH client that
+// has been suspended or networked away looks like from this end.
+type blockingSSHConn struct {
+	ssh.Conn
+	user    string
+	opening chan struct{}
+	release chan struct{}
+}
+
+func (c *blockingSSHConn) User() string { return c.user }
+
+func (c *blockingSSHConn) OpenChannel(string, []byte) (ssh.Channel, <-chan *ssh.Request, error) {
+	select {
+	case c.opening <- struct{}{}:
+	default:
+	}
+	<-c.release
+	return nil, nil, fmt.Errorf("connection gone")
+}
+
+// TestBridgeGivesUpOnAClientThatWillNotAnswer pins the deadline on opening a
+// forwarded-tcpip channel. Without it one unresponsive client holds a goroutine and
+// a pod-side connection for the twelve hours a session may last, and the pod-side
+// process waits on a reply that is never coming.
+func TestBridgeGivesUpOnAClientThatWillNotAnswer(t *testing.T) {
+	previous := forwardChannelOpenTimeout
+	forwardChannelOpenTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { forwardChannelOpenTimeout = previous })
+
+	conn := &blockingSSHConn{user: testForwardUser, opening: make(chan struct{}, 1), release: make(chan struct{})}
+	t.Cleanup(func() { close(conn.release) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m := &reverseForwardManager{
+		conn:     &ssh.ServerConn{Conn: conn},
+		ctx:      ctx,
+		policy:   loadReverseForwardPolicy(),
+		forwards: map[string]*reverseForward{},
+	}
+	fwd := &reverseForward{bindAddr: "127.0.0.1", bindPort: 10001, ctx: ctx, cancel: cancel,
+		userInfo: &UserInfo{}, listener: newFakePodListener()}
+	pc := newHalfClosedPodConn()
+
+	done := make(chan struct{})
+	go func() { defer close(done); m.bridge(fwd, pc) }()
+
+	select {
+	case <-conn.opening:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the bridge never asked for a channel")
+	}
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the bridge waited on a client that never answered")
+	}
+	// The pod-side connection is released rather than left holding a stream.
+	waitFor(t, pc.isClosed, "the pod-side connection to be closed")
+}
+
+// TestCloseAllAbortsAListenerStillStarting covers the session ending while a
+// listener is being installed: without it the setup runs to completion and leaves
+// a listen socket in a pod whose session has gone.
+func TestCloseAllAbortsAListenerStillStarting(t *testing.T) {
+	enableReverseForward(t, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m := newReverseForwardManager(ctx, &SshHandler{}, &ssh.ServerConn{Conn: fakeSSHConn{user: testForwardUser}})
+	m.resolve = func(context.Context, *UserInfo) (*commonclient.ClientFactory, error) { return nil, nil }
+
+	starting := make(chan struct{})
+	aborted := make(chan error, 1)
+	m.newListener = func(listenerCtx context.Context, _ *UserInfo, _ *commonclient.ClientFactory,
+		_ string, _ uint32) (podListener, error) {
+		close(starting)
+		<-listenerCtx.Done()
+		aborted <- listenerCtx.Err()
+		return nil, listenerCtx.Err()
+	}
+
+	go m.handleForward(&ssh.Request{
+		Type:    tcpipForwardRequest,
+		Payload: ssh.Marshal(tcpipForwardPayload{BindAddr: "127.0.0.1", BindPort: 10001}),
+	})
+
+	select {
+	case <-starting:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the listener never started")
+	}
+	m.closeAll()
+
+	select {
+	case err := <-aborted:
+		testifyassert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("a listener still starting outlived the session that asked for it")
+	}
 }

--- a/SaFE/apiserver/pkg/handlers/ssh-handlers/rfwdmux/duplex.go
+++ b/SaFE/apiserver/pkg/handlers/ssh-handlers/rfwdmux/duplex.go
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+package rfwdmux
+
+import (
+	"io"
+	"sync"
+)
+
+// duplex presents a separate reader and writer as the one connection a session
+// runs over. Both ends of a reverse forward have exactly that shape: an exec
+// stream is a stdin and a stdout, not a socket.
+type duplex struct {
+	r         io.Reader
+	w         io.Writer
+	closers   []io.Closer
+	closeOnce sync.Once
+	closeErr  error
+}
+
+// Join builds a connection from a reader, a writer, and whatever has to be closed
+// to make a blocked read on that reader return.
+func Join(r io.Reader, w io.Writer, closers ...io.Closer) io.ReadWriteCloser {
+	return &duplex{r: r, w: w, closers: closers}
+}
+
+func (d *duplex) Read(p []byte) (int, error)  { return d.r.Read(p) }
+func (d *duplex) Write(p []byte) (int, error) { return d.w.Write(p) }
+
+func (d *duplex) Close() error {
+	d.closeOnce.Do(func() {
+		for _, c := range d.closers {
+			if err := c.Close(); err != nil && d.closeErr == nil {
+				d.closeErr = err
+			}
+		}
+	})
+	return d.closeErr
+}

--- a/SaFE/apiserver/pkg/handlers/ssh-handlers/rfwdmux/frame.go
+++ b/SaFE/apiserver/pkg/handlers/ssh-handlers/rfwdmux/frame.go
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+// Package rfwdmux carries many byte streams over one duplex connection.
+//
+// It exists because the transport underneath a reverse forward is a Kubernetes
+// exec stream, which is expensive to set up and limited in number. One exec per
+// forwarded TCP connection runs out of room; one exec per forward does not.
+//
+// The framing is deliberately small: a stream that is opened, carries bytes in
+// both directions, can be half-closed from either end, and can be aborted. What
+// it adds beyond that is per-stream credit, so that one stalled consumer cannot
+// stop every other stream sharing the connection.
+package rfwdmux
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+)
+
+// frameType identifies what a frame carries.
+type frameType uint8
+
+const (
+	// frameOpen announces a new stream. Only the initiator sends it, and the
+	// payload is the address of the peer whose connection opened the stream.
+	frameOpen frameType = 1
+	// frameData carries stream bytes.
+	frameData frameType = 2
+	// frameFin says the sender will send no more data on this stream. The other
+	// direction stays open, which is what a request followed by its reply needs.
+	frameFin frameType = 3
+	// frameReset aborts a stream in both directions, with a reason for the log.
+	frameReset frameType = 4
+	// frameWindow returns credit: the payload counts bytes the receiving
+	// application has consumed and is therefore willing to be sent again.
+	frameWindow frameType = 5
+	// framePing and framePong keep an idle session provably alive. A pod-side mux
+	// whose apiserver has vanished has no other way to learn it should let go of
+	// the listen port.
+	framePing frameType = 6
+	framePong frameType = 7
+)
+
+func (t frameType) String() string {
+	switch t {
+	case frameOpen:
+		return "OPEN"
+	case frameData:
+		return "DATA"
+	case frameFin:
+		return "FIN"
+	case frameReset:
+		return "RST"
+	case frameWindow:
+		return "WINDOW"
+	case framePing:
+		return "PING"
+	case framePong:
+		return "PONG"
+	default:
+		return fmt.Sprintf("UNKNOWN(%d)", uint8(t))
+	}
+}
+
+const (
+	// headerSize is type(1) + stream id(4) + payload length(2).
+	headerSize = 7
+	// maxFramePayload bounds one frame, and with it the read buffer each end has
+	// to hold. It is under the 16-bit length field the header carries.
+	maxFramePayload = 32 * 1024
+	// maxResetReason bounds the diagnostic text on a reset, so a peer cannot make
+	// the other end log an arbitrarily long line.
+	maxResetReason = 256
+	// maxOriginAddr bounds the address on an open. It is generous for an IPv6
+	// literal with a zone and refuses anything that is not one.
+	maxOriginAddr = 128
+)
+
+// header is the fixed part of every frame.
+type header struct {
+	typ    frameType
+	stream uint32
+	length uint16
+}
+
+// encodeHeader writes h into the first headerSize bytes of buf.
+func encodeHeader(buf []byte, h header) {
+	buf[0] = byte(h.typ)
+	binary.BigEndian.PutUint32(buf[1:5], h.stream)
+	binary.BigEndian.PutUint16(buf[5:7], h.length)
+}
+
+// decodeHeader reads a header out of buf, which must be at least headerSize long.
+func decodeHeader(buf []byte) header {
+	return header{
+		typ:    frameType(buf[0]),
+		stream: binary.BigEndian.Uint32(buf[1:5]),
+		length: binary.BigEndian.Uint16(buf[5:7]),
+	}
+}
+
+// encodeOpen builds the payload of an open frame: the origin port followed by the
+// origin address. The address is last so it needs no length of its own.
+func encodeOpen(addr string, port uint32) ([]byte, error) {
+	if len(addr) > maxOriginAddr {
+		return nil, fmt.Errorf("origin address %q is longer than %d bytes", addr, maxOriginAddr)
+	}
+	buf := make([]byte, 2+len(addr))
+	binary.BigEndian.PutUint16(buf[:2], uint16(port))
+	copy(buf[2:], addr)
+	return buf, nil
+}
+
+// decodeOpen parses an open payload.
+//
+// The address is bounded and then required to be an IP literal. It travels no
+// further than a forwarded-tcpip channel open, which the peer's SSH client logs and
+// shows; the peer is a program running in a user's container, so an address it made
+// up out of escape sequences would be the apiserver relaying them to a developer's
+// terminal.
+func decodeOpen(payload []byte) (addr string, port uint32, err error) {
+	if len(payload) < 2 {
+		return "", 0, fmt.Errorf("open frame payload is %d bytes, want at least 2", len(payload))
+	}
+	if len(payload)-2 > maxOriginAddr {
+		return "", 0, fmt.Errorf("open frame carries a %d byte origin address, over the %d limit",
+			len(payload)-2, maxOriginAddr)
+	}
+	port = uint32(binary.BigEndian.Uint16(payload[:2]))
+	addr = string(payload[2:])
+	if net.ParseIP(addr) == nil {
+		// An origin the peer could not name, or named as something that is not an
+		// address, still has to reach the SSH client as something: forwarded-tcpip
+		// has no spelling for "unknown".
+		addr = "127.0.0.1"
+	}
+	return addr, port, nil
+}
+
+// safeReason trims a peer's diagnostic to something safe to keep and to log: the
+// peer chooses these bytes, and they end up in an error string and in the log.
+func safeReason(payload []byte) string {
+	if len(payload) > maxResetReason {
+		payload = payload[:maxResetReason]
+	}
+	return strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, string(payload))
+}
+
+// writeFrame writes one frame to w. Callers hold the session write lock, because
+// a header and its payload must not be split by another stream's frame.
+func writeFrame(w io.Writer, buf []byte, h header, payload []byte) error {
+	if len(payload) > maxFramePayload {
+		return fmt.Errorf("frame payload is %d bytes, over the %d limit", len(payload), maxFramePayload)
+	}
+	h.length = uint16(len(payload))
+	encodeHeader(buf, h)
+	// One write, not two: the transport underneath is a pipe into an exec stream,
+	// and a header that reaches the peer without its payload behind it stalls the
+	// peer's reader for as long as the second write takes.
+	n := copy(buf[headerSize:], payload)
+	_, err := w.Write(buf[:headerSize+n])
+	return err
+}
+
+// frameBuffer is a scratch buffer big enough for any frame this package writes.
+func frameBuffer() []byte { return make([]byte, headerSize+maxFramePayload) }

--- a/SaFE/apiserver/pkg/handlers/ssh-handlers/rfwdmux/markers.go
+++ b/SaFE/apiserver/pkg/handlers/ssh-handlers/rfwdmux/markers.go
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+package rfwdmux
+
+// Markers the pod-side mux writes on its stderr, which is the only channel it has
+// to the apiserver besides the multiplexed session on stdout. They are defined
+// here so both ends of the exec agree on them by construction.
+const (
+	// ReadyMarker says the listen socket is bound. Nothing before it means the
+	// forward is usable.
+	ReadyMarker = "SAFE-RFWD-READY"
+	// ErrMarker prefixes a failure the pod side detected, with the reason after it.
+	ErrMarker = "SAFE-RFWD-ERR"
+	// StatMarker prefixes the periodic counters: how many connections the forward
+	// is carrying and how many it refused.
+	StatMarker = "SAFE-RFWD-STAT"
+)

--- a/SaFE/apiserver/pkg/handlers/ssh-handlers/rfwdmux/mux_test.go
+++ b/SaFE/apiserver/pkg/handlers/ssh-handlers/rfwdmux/mux_test.go
@@ -43,6 +43,31 @@ func sessionPairWith(t *testing.T, initiatorCfg, acceptorCfg Config) (initiator,
 	return initiator, acceptor
 }
 
+// frameRecordingConn reports frames after the peer has read them from the pipe.
+type frameRecordingConn struct {
+	io.ReadWriteCloser
+	writes chan header
+}
+
+func (c *frameRecordingConn) Write(p []byte) (int, error) {
+	n, err := c.ReadWriteCloser.Write(p)
+	if n >= headerSize {
+		c.writes <- decodeHeader(p[:headerSize])
+	}
+	return n, err
+}
+
+func nextWrittenFrame(t *testing.T, writes <-chan header) header {
+	t.Helper()
+	select {
+	case h := <-writes:
+		return h
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the next written frame")
+		return header{}
+	}
+}
+
 // accept takes the next stream, failing the test rather than hanging forever.
 func accept(t *testing.T, s *Session) *Stream {
 	t.Helper()
@@ -369,9 +394,18 @@ func TestTheAcceptingEndRefusesPastItsOwnCap(t *testing.T) {
 // traffic may be dropped, but the reset that ends a refused stream must still get
 // through as soon as the writer can make progress.
 func TestARefusalOutranksAFullControlQueue(t *testing.T) {
-	client, server := sessionPairWith(t,
-		Config{MaxStreams: 2},
-		Config{MaxStreams: 1})
+	const refusalCount = 16
+	a, b := net.Pipe()
+	recorded := &frameRecordingConn{
+		ReadWriteCloser: b,
+		writes:          make(chan header, 2*ctrlQueueDepth+1),
+	}
+	client := NewSession(a, Config{MaxStreams: refusalCount + 1, Initiator: true})
+	server := NewSession(recorded, Config{MaxStreams: 1})
+	t.Cleanup(func() {
+		_ = client.Close()
+		_ = server.Close()
+	})
 
 	first, err := client.Open("127.0.0.1", 1)
 	testifyassert.NoError(t, err)
@@ -395,26 +429,36 @@ func TestARefusalOutranksAFullControlQueue(t *testing.T) {
 	}
 	testifyassert.Equal(t, cap(server.ctrl), len(server.ctrl))
 
-	refused, err := client.Open("127.0.0.1", 2)
-	testifyassert.NoError(t, err)
-	waitFor(t, func() bool { return droppedOf(server) == 1 }, "the accepting end to refuse the stream")
-	waitFor(t, func() bool { return len(server.teardown) == 1 }, "the refusal reset to be queued")
+	refused := make([]*Stream, 0, refusalCount)
+	for i := 0; i < refusalCount; i++ {
+		st, openErr := client.Open("127.0.0.1", uint32(i+2))
+		testifyassert.NoError(t, openErr)
+		refused = append(refused, st)
+	}
+	waitFor(t, func() bool { return droppedOf(server) == refusalCount },
+		"the accepting end to refuse the streams")
+	waitFor(t, func() bool { return len(server.teardown) == refusalCount },
+		"the refusal resets to be queued")
 
 	server.writeMu.Unlock()
 	writeLocked = false
 
-	readDone := make(chan error, 1)
-	go func() {
-		_, err := io.ReadAll(refused)
-		readDone <- err
-	}()
-	select {
-	case err := <-readDone:
-		testifyassert.ErrorIs(t, err, ErrStreamReset)
-		testifyassert.ErrorContains(t, err, "stream limit reached")
-	case <-time.After(10 * time.Second):
-		t.Fatal("the refused stream stayed open after the writer resumed")
+	// The writer had already selected this pong before it was blocked. Once that
+	// write completes, every pending reset must drain before queued health traffic.
+	testifyassert.Equal(t, framePong, nextWrittenFrame(t, recorded.writes).typ)
+	for i, st := range refused {
+		h := nextWrittenFrame(t, recorded.writes)
+		if h.typ != frameReset {
+			t.Fatalf("frame %d after the in-flight pong was %s, want RST", i+1, h.typ)
+		}
+		testifyassert.Equal(t, st.ID(), h.stream)
 	}
+
+	_, err = io.ReadAll(refused[0])
+	testifyassert.ErrorIs(t, err, ErrStreamReset)
+	testifyassert.ErrorContains(t, err, "stream limit reached")
+	_, err = refused[0].Write([]byte("late"))
+	testifyassert.ErrorIs(t, err, ErrStreamReset)
 
 	_, err = first.Write([]byte("unaffected"))
 	testifyassert.NoError(t, err)

--- a/SaFE/apiserver/pkg/handlers/ssh-handlers/rfwdmux/mux_test.go
+++ b/SaFE/apiserver/pkg/handlers/ssh-handlers/rfwdmux/mux_test.go
@@ -700,3 +700,102 @@ func TestAHostileOriginDoesNotReachTheAcceptingEnd(t *testing.T) {
 	testifyassert.Equal(t, "127.0.0.1", st.OriginAddr())
 	testifyassert.Equal(t, uint32(0xC0DE), st.OriginPort())
 }
+
+// TestQueueCompactionLooksPastALiveHead covers a queue whose head is still worth
+// keeping while abandoned connections sit behind it. Stopping at the head refuses a
+// connection the queue had room for.
+func TestQueueCompactionLooksPastALiveHead(t *testing.T) {
+	const room = 4
+	client, server := sessionPairWith(t,
+		Config{MaxStreams: 64},
+		Config{MaxStreams: room})
+
+	// One live connection first, so it is the head of the queue.
+	live, err := client.Open("127.0.0.1", 1)
+	testifyassert.NoError(t, err)
+	waitFor(t, func() bool { return server.NumStreams() == 1 }, "the live stream to arrive")
+
+	// Then fill the rest of the queue with connections the peer abandons.
+	for i := 0; i < room-1; i++ {
+		st, openErr := client.Open("127.0.0.1", uint32(i+2))
+		testifyassert.NoError(t, openErr)
+		waitFor(t, func() bool { return server.NumStreams() == 2 }, "the open to arrive")
+		testifyassert.NoError(t, st.Close())
+		waitFor(t, func() bool { return server.NumStreams() == 1 }, "the reset to arrive")
+	}
+
+	// The queue is full, but only of one live entry and three dead ones.
+	wanted, err := client.Open("127.0.0.1", 99)
+	testifyassert.NoError(t, err)
+	_, _, dropped := server.Stats()
+	testifyassert.Equal(t, uint64(0), dropped,
+		"a connection was refused while the queue held abandoned entries")
+
+	// Both the original head and the new connection are handed over.
+	var ports []uint32
+	ports = append(ports, accept(t, server).OriginPort(), accept(t, server).OriginPort())
+	testifyassert.ElementsMatch(t, []uint32{1, 99}, ports)
+	_ = live.Close()
+	_ = wanted.Close()
+}
+
+// TestGrantWindowIsClamped keeps a peer from inflating the credit this end holds.
+// Using more than the peer really has would make the peer end the session, and an
+// unbounded counter would eventually overflow and stall the writer for good.
+func TestGrantWindowIsClamped(t *testing.T) {
+	client, server := sessionPair(t, Config{})
+	st, err := client.Open("127.0.0.1", 1)
+	testifyassert.NoError(t, err)
+	defer accept(t, server).Close()
+
+	for i := 0; i < 8; i++ {
+		st.grantWindow(initialWindow)
+	}
+	st.mu.Lock()
+	window := st.sendWindow
+	st.mu.Unlock()
+	testifyassert.Equal(t, initialWindow, window)
+}
+
+// TestARefusalBurstDoesNotEndTheSession pins the difference between refusing a
+// connection and giving up on the forward. Refusing every connection past the cap
+// is the designed overload behaviour, so a peer that runs into it repeatedly while
+// the writer is stalled must not have its whole session torn down.
+func TestARefusalBurstDoesNotEndTheSession(t *testing.T) {
+	// The production cap, because the point of the test is that a full cap's worth
+	// of refusals is more than the control queue alone would hold.
+	const cap = DefaultMaxStreams
+	client, server := sessionPairWith(t,
+		Config{MaxStreams: cap * 4},
+		Config{MaxStreams: cap})
+
+	// Hold the writer so every refusal has to wait in the queue.
+	server.writeMu.Lock()
+	unlocked := false
+	defer func() {
+		if !unlocked {
+			server.writeMu.Unlock()
+		}
+	}()
+
+	for i := 0; i < cap; i++ {
+		_, err := client.Open("127.0.0.1", uint32(i+1))
+		testifyassert.NoError(t, err)
+	}
+	waitFor(t, func() bool { return server.NumStreams() == cap }, "the accepting end to fill")
+
+	// Everything from here is refused, and every refusal is waiting on the writer.
+	refusals := cap
+	for i := 0; i < refusals; i++ {
+		_, err := client.Open("127.0.0.1", uint32(cap+i+1))
+		testifyassert.NoError(t, err)
+	}
+	waitFor(t, func() bool { return droppedOf(server) == uint64(refusals) }, "every refusal to be queued")
+
+	testifyassert.NoError(t, server.Err(), "a burst of refusals ended the session")
+	server.writeMu.Unlock()
+	unlocked = true
+
+	// And they are all delivered once the writer moves again.
+	waitFor(t, func() bool { return client.NumStreams() == cap }, "refused streams to be released")
+}

--- a/SaFE/apiserver/pkg/handlers/ssh-handlers/rfwdmux/mux_test.go
+++ b/SaFE/apiserver/pkg/handlers/ssh-handlers/rfwdmux/mux_test.go
@@ -365,6 +365,65 @@ func TestTheAcceptingEndRefusesPastItsOwnCap(t *testing.T) {
 	_ = second.Close()
 }
 
+// TestARefusalOutranksAFullControlQueue covers the overloaded writer path: health
+// traffic may be dropped, but the reset that ends a refused stream must still get
+// through as soon as the writer can make progress.
+func TestARefusalOutranksAFullControlQueue(t *testing.T) {
+	client, server := sessionPairWith(t,
+		Config{MaxStreams: 2},
+		Config{MaxStreams: 1})
+
+	first, err := client.Open("127.0.0.1", 1)
+	testifyassert.NoError(t, err)
+	firstIn := accept(t, server)
+
+	server.writeMu.Lock()
+	writeLocked := true
+	defer func() {
+		if writeLocked {
+			server.writeMu.Unlock()
+		}
+	}()
+
+	// Let the writer take one regular frame and block on writeMu, then fill every
+	// remaining regular queue slot. The refusal below must not join or be dropped
+	// from this queue.
+	server.enqueueCtrl(header{typ: framePong}, nil)
+	waitFor(t, func() bool { return len(server.ctrl) == 0 }, "the control writer to block")
+	for i := 0; i < cap(server.ctrl); i++ {
+		server.ctrl <- ctrlFrame{h: header{typ: framePong}}
+	}
+	testifyassert.Equal(t, cap(server.ctrl), len(server.ctrl))
+
+	refused, err := client.Open("127.0.0.1", 2)
+	testifyassert.NoError(t, err)
+	waitFor(t, func() bool { return droppedOf(server) == 1 }, "the accepting end to refuse the stream")
+	waitFor(t, func() bool { return len(server.teardown) == 1 }, "the refusal reset to be queued")
+
+	server.writeMu.Unlock()
+	writeLocked = false
+
+	readDone := make(chan error, 1)
+	go func() {
+		_, err := io.ReadAll(refused)
+		readDone <- err
+	}()
+	select {
+	case err := <-readDone:
+		testifyassert.ErrorIs(t, err, ErrStreamReset)
+		testifyassert.ErrorContains(t, err, "stream limit reached")
+	case <-time.After(10 * time.Second):
+		t.Fatal("the refused stream stayed open after the writer resumed")
+	}
+
+	_, err = first.Write([]byte("unaffected"))
+	testifyassert.NoError(t, err)
+	buf := make([]byte, len("unaffected"))
+	_, err = io.ReadFull(firstIn, buf)
+	testifyassert.NoError(t, err)
+	testifyassert.Equal(t, "unaffected", string(buf))
+}
+
 // TestAbandonedConnectionsDoNotFillTheAcceptQueue covers a burst the peer gives up
 // on before anything takes it. Those hold a place in the queue without carrying
 // anything, so without clearing them out a session with nothing in flight would

--- a/SaFE/apiserver/pkg/handlers/ssh-handlers/rfwdmux/mux_test.go
+++ b/SaFE/apiserver/pkg/handlers/ssh-handlers/rfwdmux/mux_test.go
@@ -1,0 +1,599 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+package rfwdmux
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	testifyassert "github.com/stretchr/testify/assert"
+)
+
+// sessionPair connects an initiating session to an accepting one over an
+// in-process pipe, which is the whole transport an exec stream amounts to.
+func sessionPair(t *testing.T, cfg Config) (initiator, acceptor *Session) {
+	t.Helper()
+	return sessionPairWith(t, cfg, cfg)
+}
+
+// sessionPairWith connects two ends configured differently, which is how the
+// accepting end's own limits are reached: with matching caps the initiator refuses
+// first and the other end's answer is never exercised.
+func sessionPairWith(t *testing.T, initiatorCfg, acceptorCfg Config) (initiator, acceptor *Session) {
+	t.Helper()
+	a, b := net.Pipe()
+	initiatorCfg.Initiator = true
+	acceptorCfg.Initiator = false
+	initiator = NewSession(a, initiatorCfg)
+	acceptor = NewSession(b, acceptorCfg)
+	t.Cleanup(func() {
+		_ = initiator.Close()
+		_ = acceptor.Close()
+	})
+	return initiator, acceptor
+}
+
+// accept takes the next stream, failing the test rather than hanging forever.
+func accept(t *testing.T, s *Session) *Stream {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	st, err := s.Accept(ctx)
+	testifyassert.NoError(t, err)
+	if st == nil {
+		t.Fatal("no stream was accepted")
+	}
+	return st
+}
+
+func TestStreamCarriesBytesBothWays(t *testing.T) {
+	client, server := sessionPair(t, Config{})
+
+	out, err := client.Open("10.0.0.9", 51234)
+	testifyassert.NoError(t, err)
+
+	in := accept(t, server)
+	testifyassert.Equal(t, "10.0.0.9", in.OriginAddr())
+	testifyassert.Equal(t, uint32(51234), in.OriginPort())
+	testifyassert.Equal(t, out.ID(), in.ID())
+
+	_, err = out.Write([]byte("request"))
+	testifyassert.NoError(t, err)
+	buf := make([]byte, len("request"))
+	_, err = io.ReadFull(in, buf)
+	testifyassert.NoError(t, err)
+	testifyassert.Equal(t, "request", string(buf))
+
+	_, err = in.Write([]byte("reply"))
+	testifyassert.NoError(t, err)
+	back := make([]byte, len("reply"))
+	_, err = io.ReadFull(out, back)
+	testifyassert.NoError(t, err)
+	testifyassert.Equal(t, "reply", string(back))
+}
+
+// TestHalfCloseLetsTheReplyThrough is the property socat's -t option was there to
+// buy: one side saying it has finished writing must not end the other direction,
+// or every request/response exchange is truncated at the reply.
+func TestHalfCloseLetsTheReplyThrough(t *testing.T) {
+	client, server := sessionPair(t, Config{})
+
+	out, err := client.Open("127.0.0.1", 4242)
+	testifyassert.NoError(t, err)
+	in := accept(t, server)
+
+	_, err = out.Write([]byte("GET /\r\n"))
+	testifyassert.NoError(t, err)
+	testifyassert.NoError(t, out.CloseWrite())
+
+	// The reader still drains what arrived before the fin, and only then sees it.
+	got, err := io.ReadAll(in)
+	testifyassert.NoError(t, err)
+	testifyassert.Equal(t, "GET /\r\n", string(got))
+
+	// And the direction that was not closed still carries the reply.
+	_, err = in.Write([]byte("HTTP/1.1 200 OK"))
+	testifyassert.NoError(t, err)
+	testifyassert.NoError(t, in.CloseWrite())
+
+	reply, err := io.ReadAll(out)
+	testifyassert.NoError(t, err)
+	testifyassert.Equal(t, "HTTP/1.1 200 OK", string(reply))
+}
+
+// TestWriteAfterCloseWriteIsRefused pins that a half-close is final for that
+// direction, rather than silently reopening on the next write.
+func TestWriteAfterCloseWriteIsRefused(t *testing.T) {
+	client, server := sessionPair(t, Config{})
+	out, err := client.Open("127.0.0.1", 1)
+	testifyassert.NoError(t, err)
+	defer accept(t, server).Close()
+
+	testifyassert.NoError(t, out.CloseWrite())
+	_, err = out.Write([]byte("late"))
+	testifyassert.ErrorIs(t, err, ErrStreamClosed)
+}
+
+// TestStreamCapRefusesAndRecovers covers the overload contract: at the cap a new
+// stream is refused straight away rather than queued, and the session goes on
+// carrying the streams it already has - and takes a new one once room is freed.
+func TestStreamCapRefusesAndRecovers(t *testing.T) {
+	client, server := sessionPair(t, Config{MaxStreams: 2})
+
+	first, err := client.Open("127.0.0.1", 1)
+	testifyassert.NoError(t, err)
+	second, err := client.Open("127.0.0.1", 2)
+	testifyassert.NoError(t, err)
+	firstIn, secondIn := accept(t, server), accept(t, server)
+
+	_, err = client.Open("127.0.0.1", 3)
+	testifyassert.ErrorIs(t, err, ErrTooManyStreams)
+
+	// The refusal is immediate, and the streams already running are untouched.
+	_, err = first.Write([]byte("still here"))
+	testifyassert.NoError(t, err)
+	buf := make([]byte, len("still here"))
+	_, err = io.ReadFull(firstIn, buf)
+	testifyassert.NoError(t, err)
+	testifyassert.Equal(t, "still here", string(buf))
+
+	testifyassert.NoError(t, second.Close())
+	_ = secondIn.Close()
+	waitFor(t, func() bool { return client.NumStreams() < 2 }, "the closed stream to free its slot")
+
+	third, err := client.Open("127.0.0.1", 4)
+	testifyassert.NoError(t, err)
+	testifyassert.Equal(t, uint32(4), accept(t, server).OriginPort())
+	_ = third.Close()
+}
+
+// TestResetEndsOneStreamAndNotTheSession is the same property from the other
+// direction: an aborted connection must not take the forward down with it.
+func TestResetEndsOneStreamAndNotTheSession(t *testing.T) {
+	client, server := sessionPair(t, Config{})
+
+	doomed, err := client.Open("127.0.0.1", 1)
+	testifyassert.NoError(t, err)
+	doomedIn := accept(t, server)
+	survivor, err := client.Open("127.0.0.1", 2)
+	testifyassert.NoError(t, err)
+	survivorIn := accept(t, server)
+
+	testifyassert.NoError(t, doomed.Close())
+
+	_, err = io.ReadAll(doomedIn)
+	testifyassert.ErrorIs(t, err, ErrStreamReset)
+
+	_, err = survivor.Write([]byte("unaffected"))
+	testifyassert.NoError(t, err)
+	buf := make([]byte, len("unaffected"))
+	_, err = io.ReadFull(survivorIn, buf)
+	testifyassert.NoError(t, err)
+	testifyassert.Equal(t, "unaffected", string(buf))
+	testifyassert.NoError(t, client.Err())
+}
+
+// TestLargeTransferCrossesTheWindow moves several windows' worth of bytes, which
+// only completes if credit is returned as the reader consumes.
+func TestLargeTransferCrossesTheWindow(t *testing.T) {
+	client, server := sessionPair(t, Config{})
+
+	out, err := client.Open("127.0.0.1", 1)
+	testifyassert.NoError(t, err)
+	in := accept(t, server)
+
+	payload := bytes.Repeat([]byte("0123456789abcdef"), 5*initialWindow/16)
+	go func() {
+		_, _ = out.Write(payload)
+		_ = out.CloseWrite()
+	}()
+
+	got, err := io.ReadAll(in)
+	testifyassert.NoError(t, err)
+	testifyassert.Equal(t, len(payload), len(got))
+	testifyassert.True(t, bytes.Equal(payload, got))
+}
+
+// TestAStalledStreamDoesNotBlockTheOthers is why the framing carries per-stream
+// credit at all. One connection whose reader has wandered off must not stop every
+// other connection sharing the exec stream - which is exactly the failure the mux
+// replaces.
+func TestAStalledStreamDoesNotBlockTheOthers(t *testing.T) {
+	client, server := sessionPair(t, Config{})
+
+	stalled, err := client.Open("127.0.0.1", 1)
+	testifyassert.NoError(t, err)
+	stalledIn := accept(t, server)
+	defer stalledIn.Close()
+
+	// Fill the stalled stream's window and leave it unread.
+	filled := make(chan struct{})
+	go func() {
+		defer close(filled)
+		_, _ = stalled.Write(bytes.Repeat([]byte("x"), 4*initialWindow))
+	}()
+	waitFor(t, func() bool {
+		stalledIn.mu.Lock()
+		defer stalledIn.mu.Unlock()
+		return stalledIn.buf.Len() >= initialWindow
+	}, "the stalled stream's window to fill")
+
+	live, err := client.Open("127.0.0.1", 2)
+	testifyassert.NoError(t, err)
+	liveIn := accept(t, server)
+	_, err = live.Write([]byte("straight through"))
+	testifyassert.NoError(t, err)
+	buf := make([]byte, len("straight through"))
+	_, err = io.ReadFull(liveIn, buf)
+	testifyassert.NoError(t, err)
+	testifyassert.Equal(t, "straight through", string(buf))
+
+	// Draining the stalled stream releases its writer.
+	go func() { _, _ = io.Copy(io.Discard, stalledIn) }()
+	select {
+	case <-filled:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the stalled stream's writer never finished once its reader caught up")
+	}
+}
+
+// TestSessionCloseReleasesEveryStream pins that teardown is prompt: nothing waits
+// on a stream whose session has gone.
+func TestSessionCloseReleasesEveryStream(t *testing.T) {
+	client, server := sessionPair(t, Config{})
+
+	var streams []*Stream
+	for i := 0; i < 8; i++ {
+		st, err := client.Open("127.0.0.1", uint32(i+1))
+		testifyassert.NoError(t, err)
+		streams = append(streams, st)
+		accept(t, server)
+	}
+
+	var blocked sync.WaitGroup
+	for _, st := range streams {
+		blocked.Add(1)
+		go func(st *Stream) {
+			defer blocked.Done()
+			_, _ = io.ReadAll(st)
+		}(st)
+	}
+
+	testifyassert.NoError(t, client.Close())
+	done := make(chan struct{})
+	go func() { blocked.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("readers were still waiting after the session closed")
+	}
+	_, err := client.Open("127.0.0.1", 99)
+	testifyassert.Error(t, err)
+}
+
+// TestPeerGoingAwayEndsTheSession is the apiserver-side half of "the listen port
+// is free promptly": the pod side sees the connection end and stops.
+func TestPeerGoingAwayEndsTheSession(t *testing.T) {
+	client, server := sessionPair(t, Config{})
+	testifyassert.NoError(t, server.Close())
+	select {
+	case <-client.Done():
+	case <-time.After(10 * time.Second):
+		t.Fatal("the session outlived its peer")
+	}
+	testifyassert.Error(t, client.Err())
+}
+
+// TestIdleTimeoutStopsAnAbandonedSession covers the orphan case the socat relay
+// had no answer for: an exec stream that is neither readable nor closed leaves the
+// pod holding a listen port until the pod dies.
+func TestIdleTimeoutStopsAnAbandonedSession(t *testing.T) {
+	a, b := net.Pipe()
+	// b is never read from and never closed, which is what an abandoned peer looks
+	// like from here.
+	t.Cleanup(func() { _ = b.Close() })
+	s := NewSession(a, Config{IdleTimeout: 200 * time.Millisecond})
+	t.Cleanup(func() { _ = s.Close() })
+
+	select {
+	case <-s.Done():
+	case <-time.After(10 * time.Second):
+		t.Fatal("an abandoned session never timed out")
+	}
+	testifyassert.ErrorContains(t, s.Err(), "no frame from the peer")
+}
+
+// TestKeepaliveIsAnswered pins that a quiet but live peer keeps the session up.
+//
+// The observation window is several idle timeouts long on purpose: with keepalives
+// off, or unanswered, both ends would be gone well before it ends, so the test
+// fails rather than merely being slow.
+func TestKeepaliveIsAnswered(t *testing.T) {
+	const idle = 100 * time.Millisecond
+	client, server := sessionPair(t, Config{
+		KeepaliveInterval: 10 * time.Millisecond,
+		IdleTimeout:       idle,
+	})
+	select {
+	case <-client.Done():
+		t.Fatalf("session ended while its peer was answering: %v", client.Err())
+	case <-server.Done():
+		t.Fatalf("session ended while its peer was answering: %v", server.Err())
+	case <-time.After(10 * idle):
+	}
+}
+
+// TestTheAcceptingEndRefusesPastItsOwnCap covers the refusal the pod side turns
+// into a reset TCP connection. It is reachable only when this end is the stricter
+// one, which is why the caps here differ.
+func TestTheAcceptingEndRefusesPastItsOwnCap(t *testing.T) {
+	client, server := sessionPairWith(t,
+		Config{MaxStreams: 8},
+		Config{MaxStreams: 2})
+
+	first, err := client.Open("127.0.0.1", 1)
+	testifyassert.NoError(t, err)
+	second, err := client.Open("127.0.0.1", 2)
+	testifyassert.NoError(t, err)
+	accept(t, server)
+	accept(t, server)
+
+	// The initiator has room, so the open goes out; the answer is the other end's.
+	refused, err := client.Open("127.0.0.1", 3)
+	testifyassert.NoError(t, err)
+	_, err = io.ReadAll(refused)
+	testifyassert.ErrorIs(t, err, ErrStreamReset)
+	testifyassert.ErrorContains(t, err, "stream limit reached")
+
+	_, _, dropped := server.Stats()
+	testifyassert.Equal(t, uint64(1), dropped)
+
+	// The refusal is one connection's, not the session's.
+	testifyassert.NoError(t, server.Err())
+	_, err = first.Write([]byte("unaffected"))
+	testifyassert.NoError(t, err)
+	_ = second.Close()
+}
+
+// TestAbandonedConnectionsDoNotFillTheAcceptQueue covers a burst the peer gives up
+// on before anything takes it. Those hold a place in the queue without carrying
+// anything, so without clearing them out a session with nothing in flight would
+// start refusing live connections.
+func TestAbandonedConnectionsDoNotFillTheAcceptQueue(t *testing.T) {
+	const cap = 4
+	client, server := sessionPairWith(t,
+		Config{MaxStreams: 64},
+		Config{MaxStreams: cap})
+
+	for i := 0; i < cap*3; i++ {
+		st, err := client.Open("127.0.0.1", uint32(i+1))
+		testifyassert.NoError(t, err)
+		// Opened and given up on before anyone accepts it.
+		waitFor(t, func() bool { return server.NumStreams() > 0 }, "the open to arrive")
+		testifyassert.NoError(t, st.Close())
+		waitFor(t, func() bool { return server.NumStreams() == 0 }, "the reset to arrive")
+	}
+	testifyassert.Equal(t, uint64(0), droppedOf(server),
+		"connections the peer abandoned are not refusals")
+
+	// A live connection still gets through.
+	live, err := client.Open("127.0.0.1", 9999)
+	testifyassert.NoError(t, err)
+	testifyassert.Equal(t, uint32(9999), accept(t, server).OriginPort())
+	_ = live.Close()
+}
+
+// droppedOf reads the refusal counter.
+func droppedOf(s *Session) uint64 {
+	_, _, dropped := s.Stats()
+	return dropped
+}
+
+// TestOpenIsRefusedOnTheAcceptingEnd keeps stream ids under one owner, so two
+// ends cannot allocate the same id for different connections.
+func TestOpenIsRefusedOnTheAcceptingEnd(t *testing.T) {
+	_, server := sessionPair(t, Config{})
+	_, err := server.Open("127.0.0.1", 1)
+	testifyassert.Error(t, err)
+}
+
+// TestOverrunningTheWindowEndsTheSession covers a peer that ignores the credit it
+// was given: the session stops rather than buffering without limit.
+func TestOverrunningTheWindowEndsTheSession(t *testing.T) {
+	a, b := net.Pipe()
+	victim := NewSession(a, Config{})
+	t.Cleanup(func() { _ = victim.Close() })
+	t.Cleanup(func() { _ = b.Close() })
+
+	go func() {
+		buf := frameBuffer()
+		payload, _ := encodeOpen("127.0.0.1", 1)
+		if err := writeFrame(b, buf, header{typ: frameOpen, stream: 1}, payload); err != nil {
+			return
+		}
+		chunk := make([]byte, maxFramePayload)
+		for i := 0; i < initialWindow/maxFramePayload+2; i++ {
+			if err := writeFrame(b, buf, header{typ: frameData, stream: 1}, chunk); err != nil {
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-victim.Done():
+	case <-time.After(10 * time.Second):
+		t.Fatal("a peer that ignored its window was allowed to keep sending")
+	}
+	testifyassert.ErrorContains(t, victim.Err(), "overran its")
+}
+
+// TestUnknownFrameTypeEndsTheSession pins that the framing is closed: a peer
+// speaking something else is stopped rather than half-understood.
+func TestUnknownFrameTypeEndsTheSession(t *testing.T) {
+	a, b := net.Pipe()
+	victim := NewSession(a, Config{})
+	t.Cleanup(func() { _ = victim.Close() })
+	t.Cleanup(func() { _ = b.Close() })
+
+	go func() { _ = writeFrame(b, frameBuffer(), header{typ: frameType(200), stream: 1}, nil) }()
+	select {
+	case <-victim.Done():
+	case <-time.After(10 * time.Second):
+		t.Fatal("an unknown frame type was accepted")
+	}
+	testifyassert.ErrorContains(t, victim.Err(), "unknown frame type")
+}
+
+// TestAcceptSkipsAConnectionAlreadyGone keeps a connection the peer gave up on
+// before anyone took it from being handed over: the caller would open a channel to
+// its own client only to find the other end had already ended.
+func TestAcceptSkipsAConnectionAlreadyGone(t *testing.T) {
+	client, server := sessionPair(t, Config{})
+
+	abandoned, err := client.Open("127.0.0.1", 7)
+	testifyassert.NoError(t, err)
+	waitFor(t, func() bool { return server.NumStreams() == 1 }, "the stream to reach the accepting end")
+	testifyassert.NoError(t, abandoned.Close())
+	waitFor(t, func() bool { return server.NumStreams() == 0 }, "the reset to reach the accepting end")
+
+	wanted, err := client.Open("127.0.0.1", 8)
+	testifyassert.NoError(t, err)
+	testifyassert.Equal(t, uint32(8), accept(t, server).OriginPort())
+	_ = wanted.Close()
+}
+
+// TestAcceptReportsWhyTheSessionStopped pins that a session ending is answered with
+// its reason rather than with a connection that has no transport left to carry it.
+func TestAcceptReportsWhyTheSessionStopped(t *testing.T) {
+	client, server := sessionPair(t, Config{})
+	_, err := client.Open("127.0.0.1", 7)
+	testifyassert.NoError(t, err)
+	waitFor(t, func() bool { return server.NumStreams() == 1 }, "the stream to reach the accepting end")
+
+	testifyassert.NoError(t, client.Close())
+	<-server.Done()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	st, err := server.Accept(ctx)
+	testifyassert.Error(t, err)
+	testifyassert.Nil(t, st)
+}
+
+// TestStatsCountRefusals gives the operator the two numbers the plan asks the pod
+// side to log.
+func TestStatsCountRefusals(t *testing.T) {
+	client, _ := sessionPair(t, Config{MaxStreams: 1})
+	_, err := client.Open("127.0.0.1", 1)
+	testifyassert.NoError(t, err)
+	_, err = client.Open("127.0.0.1", 2)
+	testifyassert.ErrorIs(t, err, ErrTooManyStreams)
+	client.CountDropped()
+
+	opened, open, dropped := client.Stats()
+	testifyassert.Equal(t, uint64(1), opened)
+	testifyassert.Equal(t, 1, open)
+	testifyassert.Equal(t, uint64(1), dropped)
+}
+
+func TestEncodeOpenRejectsAnOverlongAddress(t *testing.T) {
+	_, err := encodeOpen(string(bytes.Repeat([]byte("a"), maxOriginAddr+1)), 1)
+	testifyassert.Error(t, err)
+}
+
+func TestDecodeOpenNamesAnUnknownOrigin(t *testing.T) {
+	payload, err := encodeOpen("", 0)
+	testifyassert.NoError(t, err)
+	addr, port, err := decodeOpen(payload)
+	testifyassert.NoError(t, err)
+	testifyassert.Equal(t, "127.0.0.1", addr)
+	testifyassert.Equal(t, uint32(0), port)
+
+	_, _, err = decodeOpen([]byte{1})
+	testifyassert.Error(t, err)
+}
+
+func TestJoinClosesBothHalves(t *testing.T) {
+	r, w := io.Pipe()
+	conn := Join(r, io.Discard, r, w)
+	testifyassert.NoError(t, conn.Close())
+	_, err := w.Write([]byte("x"))
+	testifyassert.True(t, errors.Is(err, io.ErrClosedPipe))
+}
+
+// waitFor polls until cond holds, so a test states what it is waiting for rather
+// than sleeping for a guess.
+func waitFor(t *testing.T, cond func() bool, what string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+// TestDecodeOpenRefusesAnOverlongOrigin keeps a peer from spending the whole frame
+// on an origin address. The peer is a program inside a user's container and the
+// address travels on to the user's SSH client, so it is bounded where it is parsed.
+func TestDecodeOpenRefusesAnOverlongOrigin(t *testing.T) {
+	payload := append([]byte{0, 1}, bytes.Repeat([]byte("a"), maxOriginAddr+1)...)
+	_, _, err := decodeOpen(payload)
+	testifyassert.ErrorContains(t, err, "over the")
+}
+
+// TestDecodeOpenRejectsAnOriginThatIsNotAnAddress covers the same value reaching a
+// developer's terminal through a forwarded-tcpip channel open: whatever the peer
+// spells it as, what leaves here is an address.
+func TestDecodeOpenRejectsAnOriginThatIsNotAnAddress(t *testing.T) {
+	payload := append([]byte{0, 1}, []byte("\x1b]0;pwned\x07")...)
+	addr, port, err := decodeOpen(payload)
+	testifyassert.NoError(t, err)
+	testifyassert.Equal(t, "127.0.0.1", addr)
+	testifyassert.Equal(t, uint32(1), port)
+
+	addr, _, err = decodeOpen(append([]byte{0, 1}, []byte("2001:db8::1")...))
+	testifyassert.NoError(t, err)
+	testifyassert.Equal(t, "2001:db8::1", addr)
+}
+
+// TestResetReasonIsBoundedAndPrintable keeps a peer's diagnostic from becoming an
+// arbitrarily long line of control characters in the apiserver's log.
+func TestResetReasonIsBoundedAndPrintable(t *testing.T) {
+	reason := safeReason(append([]byte("clean\x00\x1b[2Jtext"), bytes.Repeat([]byte("x"), maxFramePayload)...))
+	testifyassert.LessOrEqual(t, len(reason), maxResetReason)
+	testifyassert.True(t, strings.HasPrefix(reason, "clean[2Jtext"),
+		"the text survives; only what could drive a terminal is dropped")
+	testifyassert.NotContains(t, reason, "\x1b")
+	testifyassert.NotContains(t, reason, "\x00")
+}
+
+// TestAHostileOriginDoesNotReachTheAcceptingEnd is the same property end to end: a
+// peer that opens a stream with a made-up origin has it replaced before anyone here
+// can pass it on.
+func TestAHostileOriginDoesNotReachTheAcceptingEnd(t *testing.T) {
+	a, b := net.Pipe()
+	server := NewSession(a, Config{})
+	t.Cleanup(func() { _ = server.Close(); _ = b.Close() })
+
+	go func() {
+		payload := append([]byte{0xC0, 0xDE}, []byte("\x1b[31mnot-an-address")...)
+		_ = writeFrame(b, frameBuffer(), header{typ: frameOpen, stream: 1}, payload)
+	}()
+
+	st := accept(t, server)
+	testifyassert.Equal(t, "127.0.0.1", st.OriginAddr())
+	testifyassert.Equal(t, uint32(0xC0DE), st.OriginPort())
+}

--- a/SaFE/apiserver/pkg/handlers/ssh-handlers/rfwdmux/session.go
+++ b/SaFE/apiserver/pkg/handlers/ssh-handlers/rfwdmux/session.go
@@ -32,10 +32,9 @@ const initialWindow = 128 * 1024
 // connection on bookkeeping than on payload.
 const windowUpdateThreshold = initialWindow / 2
 
-// ctrlQueueDepth bounds the frames the read loop may hand to the writer. The read
-// loop must never block on a write - it is what drains the connection, so a read
-// loop waiting on a full transport is a session that can never recover - and every
-// frame that travels this way is a courtesy the protocol works without.
+// ctrlQueueDepth bounds each class of frames the read loop may hand to the writer.
+// The read loop must never block on a write - it is what drains the connection, so
+// a read loop waiting on a full transport is a session that can never recover.
 const ctrlQueueDepth = 128
 
 var (
@@ -98,7 +97,8 @@ type Session struct {
 	writeMu  sync.Mutex
 	writeBuf []byte
 
-	ctrl chan ctrlFrame
+	ctrl     chan ctrlFrame
+	teardown chan ctrlFrame
 
 	mu      sync.Mutex
 	streams map[uint32]*Stream
@@ -124,6 +124,7 @@ func NewSession(conn io.ReadWriteCloser, cfg Config) *Session {
 		cfg:      cfg,
 		writeBuf: frameBuffer(),
 		ctrl:     make(chan ctrlFrame, ctrlQueueDepth),
+		teardown: make(chan ctrlFrame, ctrlQueueDepth),
 		streams:  map[uint32]*Stream{},
 		nextID:   1,
 		accept:   make(chan *Stream, cfg.maxStreams()),
@@ -280,8 +281,9 @@ func (s *Session) writeFrame(h header, payload []byte) error {
 	return nil
 }
 
-// enqueueCtrl hands a frame to the writer without waiting. It is how the read loop
-// answers a frame, and a frame dropped here only costs the peer a diagnostic.
+// enqueueCtrl hands a best-effort frame to the writer without waiting. Pings and
+// pongs keep a healthy session observable, but dropping one under backpressure
+// does not leave a stream open.
 func (s *Session) enqueueCtrl(h header, payload []byte) {
 	select {
 	case s.ctrl <- ctrlFrame{h: h, payload: payload}:
@@ -290,10 +292,36 @@ func (s *Session) enqueueCtrl(h header, payload []byte) {
 	}
 }
 
-// ctrlLoop writes the frames the read loop handed over.
+// enqueueTeardown gives a stream-ending frame its own queue. If that queue is
+// exhausted too, closing the session is the only bounded way to guarantee the
+// peer does not keep the refused stream open forever.
+func (s *Session) enqueueTeardown(h header, payload []byte) {
+	select {
+	case s.teardown <- ctrlFrame{h: h, payload: payload}:
+	case <-s.done:
+	default:
+		s.shutdown(errors.New("rfwdmux: teardown queue full"))
+	}
+}
+
+// ctrlLoop writes the frames the read loop handed over, always draining stream
+// teardown before best-effort health traffic.
 func (s *Session) ctrlLoop() {
 	for {
 		select {
+		case f := <-s.teardown:
+			if err := s.writeFrame(f.h, f.payload); err != nil {
+				return
+			}
+			continue
+		default:
+		}
+
+		select {
+		case f := <-s.teardown:
+			if err := s.writeFrame(f.h, f.payload); err != nil {
+				return
+			}
 		case f := <-s.ctrl:
 			if err := s.writeFrame(f.h, f.payload); err != nil {
 				return
@@ -490,7 +518,7 @@ func (s *Session) queueForAccept(st *Stream) bool {
 func (s *Session) refuse(id uint32, reason string) {
 	s.dropped.Add(1)
 	s.cfg.logf("rfwdmux: refused stream %d: %s", id, reason)
-	s.enqueueCtrl(header{typ: frameReset, stream: id}, []byte(reason))
+	s.enqueueTeardown(header{typ: frameReset, stream: id}, []byte(reason))
 }
 
 // stream looks up a live stream.

--- a/SaFE/apiserver/pkg/handlers/ssh-handlers/rfwdmux/session.go
+++ b/SaFE/apiserver/pkg/handlers/ssh-handlers/rfwdmux/session.go
@@ -37,6 +37,19 @@ const windowUpdateThreshold = initialWindow / 2
 // a read loop waiting on a full transport is a session that can never recover.
 const ctrlQueueDepth = 128
 
+// teardownQueueDepth sizes the queue refusals wait in. Overflowing it ends the
+// session, so it has to be able to hold every refusal an honest peer can have
+// outstanding: a stream the peer opened stays in its table until the reset lands,
+// so that is one per stream it is allowed to open. Sizing it to the control depth
+// alone would turn a burst of refusals - which is the overload behaviour this
+// design is meant to have - into the whole forward being torn down.
+func teardownQueueDepth(cfg Config) int {
+	if n := cfg.maxStreams(); n > ctrlQueueDepth {
+		return n
+	}
+	return ctrlQueueDepth
+}
+
 var (
 	// ErrSessionClosed reports a session that has ended.
 	ErrSessionClosed = errors.New("rfwdmux: session is closed")
@@ -124,7 +137,7 @@ func NewSession(conn io.ReadWriteCloser, cfg Config) *Session {
 		cfg:      cfg,
 		writeBuf: frameBuffer(),
 		ctrl:     make(chan ctrlFrame, ctrlQueueDepth),
-		teardown: make(chan ctrlFrame, ctrlQueueDepth),
+		teardown: make(chan ctrlFrame, teardownQueueDepth(cfg)),
 		streams:  map[uint32]*Stream{},
 		nextID:   1,
 		accept:   make(chan *Stream, cfg.maxStreams()),
@@ -493,17 +506,21 @@ func (s *Session) queueForAccept(st *Stream) bool {
 		return true
 	default:
 	}
-	for i := 0; i < cap(s.accept); i++ {
+	// Walk the whole queue once rather than stopping at the first entry still worth
+	// keeping: a live connection at the head says nothing about the abandoned ones
+	// behind it, and giving up there refuses a connection the queue had room for.
+	for i, n := 0, cap(s.accept); i < n; i++ {
 		select {
 		case queued := <-s.accept:
 			if queued.alive() {
-				// Still worth handing over. The order connections are accepted in
-				// is not a contract; losing one would be.
+				// Still worth handing over, so it goes to the back. Losing one
+				// would be a bug; the order they are accepted in is not a contract.
+				// This send cannot block: the read loop is the only producer, and
+				// it has just taken an entry out.
 				s.accept <- queued
-				return false
 			}
 		default:
-			return false
+			// Drained underneath us, which is the outcome this was after.
 		}
 		select {
 		case s.accept <- st:

--- a/SaFE/apiserver/pkg/handlers/ssh-handlers/rfwdmux/session.go
+++ b/SaFE/apiserver/pkg/handlers/ssh-handlers/rfwdmux/session.go
@@ -1,0 +1,508 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+package rfwdmux
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// DefaultMaxStreams bounds how many connections one forward carries at a time.
+// It is a ceiling on the pod's memory and on the framing bookkeeping, not a
+// throughput target: past it the pod side refuses the TCP connection outright so
+// that the process making it fails now instead of hanging.
+const DefaultMaxStreams = 256
+
+// initialWindow is how many bytes a peer may have in flight on one stream before
+// the receiving application has consumed any of them. It is the per-stream memory
+// cost of a stalled reader, and with DefaultMaxStreams bounds a session's buffers
+// at a few tens of megabytes.
+const initialWindow = 128 * 1024
+
+// windowUpdateThreshold is the share of the window that must be consumed before
+// credit is returned. Returning it on every read would spend more of the shared
+// connection on bookkeeping than on payload.
+const windowUpdateThreshold = initialWindow / 2
+
+// ctrlQueueDepth bounds the frames the read loop may hand to the writer. The read
+// loop must never block on a write - it is what drains the connection, so a read
+// loop waiting on a full transport is a session that can never recover - and every
+// frame that travels this way is a courtesy the protocol works without.
+const ctrlQueueDepth = 128
+
+var (
+	// ErrSessionClosed reports a session that has ended.
+	ErrSessionClosed = errors.New("rfwdmux: session is closed")
+	// ErrTooManyStreams reports that the stream cap is reached. The pod side turns
+	// it into a refused TCP connection.
+	ErrTooManyStreams = errors.New("rfwdmux: stream limit reached")
+	// ErrStreamReset reports a stream the peer aborted.
+	ErrStreamReset = errors.New("rfwdmux: stream reset by peer")
+	// ErrStreamClosed reports a stream this side has closed.
+	ErrStreamClosed = errors.New("rfwdmux: stream is closed")
+)
+
+// Config settles the behaviour of one session.
+type Config struct {
+	// MaxStreams caps concurrent streams; zero means DefaultMaxStreams.
+	MaxStreams int
+	// Initiator marks the end that opens streams. The other end refuses to, and
+	// treats an open it did not ask for as a protocol error, so stream ids have a
+	// single owner and cannot collide.
+	Initiator bool
+	// KeepaliveInterval sends a ping when the connection has been quiet for this
+	// long. Zero sends none.
+	KeepaliveInterval time.Duration
+	// IdleTimeout ends the session when nothing has arrived for this long. It is
+	// what stops a pod-side mux whose apiserver has gone from holding the listen
+	// port for the life of the pod. Zero waits forever.
+	IdleTimeout time.Duration
+	// Logf receives diagnostics. Zero discards them.
+	Logf func(format string, args ...any)
+}
+
+func (c Config) maxStreams() int {
+	if c.MaxStreams > 0 {
+		return c.MaxStreams
+	}
+	return DefaultMaxStreams
+}
+
+func (c Config) logf(format string, args ...any) {
+	if c.Logf != nil {
+		c.Logf(format, args...)
+	}
+}
+
+// ctrlFrame is a frame the read loop asked the writer to send on its behalf.
+type ctrlFrame struct {
+	h       header
+	payload []byte
+}
+
+// Session multiplexes streams over one duplex connection.
+type Session struct {
+	conn io.ReadWriteCloser
+	cfg  Config
+
+	// writeMu serialises frames onto the connection. A frame is written whole
+	// under it, so two streams cannot interleave a header and a payload.
+	writeMu  sync.Mutex
+	writeBuf []byte
+
+	ctrl chan ctrlFrame
+
+	mu      sync.Mutex
+	streams map[uint32]*Stream
+	nextID  uint32
+
+	accept chan *Stream
+
+	shutdownOnce sync.Once
+	done         chan struct{}
+	errMu        sync.Mutex
+	err          error
+
+	lastActivity atomic.Int64
+	dropped      atomic.Uint64
+	opened       atomic.Uint64
+}
+
+// NewSession starts multiplexing over conn. The session owns conn from here on and
+// closes it when it ends.
+func NewSession(conn io.ReadWriteCloser, cfg Config) *Session {
+	s := &Session{
+		conn:     conn,
+		cfg:      cfg,
+		writeBuf: frameBuffer(),
+		ctrl:     make(chan ctrlFrame, ctrlQueueDepth),
+		streams:  map[uint32]*Stream{},
+		nextID:   1,
+		accept:   make(chan *Stream, cfg.maxStreams()),
+		done:     make(chan struct{}),
+	}
+	s.lastActivity.Store(time.Now().UnixNano())
+	go s.readLoop()
+	go s.ctrlLoop()
+	if cfg.KeepaliveInterval > 0 || cfg.IdleTimeout > 0 {
+		go s.healthLoop()
+	}
+	return s
+}
+
+// Done closes when the session has ended.
+func (s *Session) Done() <-chan struct{} { return s.done }
+
+// Err reports why the session ended, or nil while it is running.
+func (s *Session) Err() error {
+	s.errMu.Lock()
+	defer s.errMu.Unlock()
+	return s.err
+}
+
+// MaxStreams is the cap this session enforces.
+func (s *Session) MaxStreams() int { return s.cfg.maxStreams() }
+
+// NumStreams reports how many streams are open right now.
+func (s *Session) NumStreams() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.streams)
+}
+
+// Stats reports the counters worth logging: streams opened, streams open now, and
+// connections refused because the cap was reached.
+func (s *Session) Stats() (opened uint64, open int, dropped uint64) {
+	return s.opened.Load(), s.NumStreams(), s.dropped.Load()
+}
+
+// CountDropped records a connection the caller refused before it became a stream.
+func (s *Session) CountDropped() { s.dropped.Add(1) }
+
+// Close ends the session and every stream on it.
+func (s *Session) Close() error {
+	s.shutdown(ErrSessionClosed)
+	return nil
+}
+
+// shutdown ends the session once, with the first reason given.
+func (s *Session) shutdown(err error) {
+	s.shutdownOnce.Do(func() {
+		if err == nil {
+			err = ErrSessionClosed
+		}
+		s.errMu.Lock()
+		s.err = err
+		s.errMu.Unlock()
+		close(s.done)
+
+		s.mu.Lock()
+		streams := make([]*Stream, 0, len(s.streams))
+		for id, st := range s.streams {
+			delete(s.streams, id)
+			streams = append(streams, st)
+		}
+		s.mu.Unlock()
+		for _, st := range streams {
+			st.terminate(err)
+		}
+		// Closing the connection is what unblocks the read loop; without it a
+		// session whose peer has stopped talking but not hung up never returns.
+		_ = s.conn.Close()
+	})
+}
+
+// Open starts a stream carrying a connection from origin. Only the initiating end
+// may call it.
+func (s *Session) Open(originAddr string, originPort uint32) (*Stream, error) {
+	if !s.cfg.Initiator {
+		return nil, errors.New("rfwdmux: this end of the session does not open streams")
+	}
+	payload, err := encodeOpen(originAddr, originPort)
+	if err != nil {
+		return nil, err
+	}
+
+	s.mu.Lock()
+	select {
+	case <-s.done:
+		s.mu.Unlock()
+		return nil, s.Err()
+	default:
+	}
+	if len(s.streams) >= s.cfg.maxStreams() {
+		s.mu.Unlock()
+		return nil, ErrTooManyStreams
+	}
+	id := s.nextID
+	s.nextID++
+	if s.nextID == 0 {
+		// Zero is never a stream id, so a header full of zeroes cannot be mistaken
+		// for a frame about a live stream.
+		s.nextID = 1
+	}
+	st := newStream(s, id, originAddr, originPort)
+	s.streams[id] = st
+	s.mu.Unlock()
+
+	if err = s.writeFrame(header{typ: frameOpen, stream: id}, payload); err != nil {
+		s.removeStream(id)
+		st.terminate(err)
+		return nil, err
+	}
+	s.opened.Add(1)
+	return st, nil
+}
+
+// Accept returns the next stream the peer opened.
+func (s *Session) Accept(ctx context.Context) (*Stream, error) {
+	for {
+		select {
+		case st := <-s.accept:
+			// A connection the peer gave up on before anyone took it is not worth
+			// handing over: the caller would open a channel to its client only to
+			// find the other end already gone.
+			if st.alive() {
+				return st, nil
+			}
+		case <-s.done:
+			// Nothing queued survives the session: ending it terminates every
+			// stream, so a connection still waiting here has no transport left to
+			// carry it and reporting why the session stopped is the useful answer.
+			return nil, s.Err()
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}
+
+// writeFrame sends one frame, waiting for the connection if it is busy.
+func (s *Session) writeFrame(h header, payload []byte) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	select {
+	case <-s.done:
+		return s.Err()
+	default:
+	}
+	if err := writeFrame(s.conn, s.writeBuf, h, payload); err != nil {
+		s.shutdown(fmt.Errorf("rfwdmux: write failed: %w", err))
+		return err
+	}
+	return nil
+}
+
+// enqueueCtrl hands a frame to the writer without waiting. It is how the read loop
+// answers a frame, and a frame dropped here only costs the peer a diagnostic.
+func (s *Session) enqueueCtrl(h header, payload []byte) {
+	select {
+	case s.ctrl <- ctrlFrame{h: h, payload: payload}:
+	default:
+		s.cfg.logf("rfwdmux: control queue full, dropping %s for stream %d", h.typ, h.stream)
+	}
+}
+
+// ctrlLoop writes the frames the read loop handed over.
+func (s *Session) ctrlLoop() {
+	for {
+		select {
+		case f := <-s.ctrl:
+			if err := s.writeFrame(f.h, f.payload); err != nil {
+				return
+			}
+		case <-s.done:
+			return
+		}
+	}
+}
+
+// healthLoop keeps the session honest about being alive.
+func (s *Session) healthLoop() {
+	interval := s.cfg.KeepaliveInterval
+	if interval <= 0 || (s.cfg.IdleTimeout > 0 && s.cfg.IdleTimeout/4 < interval) {
+		interval = s.cfg.IdleTimeout / 4
+	}
+	if interval <= 0 {
+		return
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.done:
+			return
+		case <-ticker.C:
+			idle := time.Since(time.Unix(0, s.lastActivity.Load()))
+			if s.cfg.IdleTimeout > 0 && idle > s.cfg.IdleTimeout {
+				s.shutdown(fmt.Errorf("rfwdmux: no frame from the peer for %s", idle.Truncate(time.Second)))
+				return
+			}
+			if s.cfg.KeepaliveInterval > 0 {
+				s.enqueueCtrl(header{typ: framePing}, nil)
+			}
+		}
+	}
+}
+
+// readLoop consumes frames until the connection ends.
+func (s *Session) readLoop() {
+	buf := make([]byte, maxFramePayload)
+	hdr := make([]byte, headerSize)
+	for {
+		if _, err := io.ReadFull(s.conn, hdr); err != nil {
+			if err == io.EOF || err == io.ErrUnexpectedEOF {
+				err = io.EOF
+			}
+			s.shutdown(err)
+			return
+		}
+		h := decodeHeader(hdr)
+		if int(h.length) > maxFramePayload {
+			s.shutdown(fmt.Errorf("rfwdmux: %s frame declares %d bytes, over the limit", h.typ, h.length))
+			return
+		}
+		payload := buf[:h.length]
+		if h.length > 0 {
+			if _, err := io.ReadFull(s.conn, payload); err != nil {
+				s.shutdown(err)
+				return
+			}
+		}
+		s.lastActivity.Store(time.Now().UnixNano())
+		if err := s.dispatch(h, payload); err != nil {
+			s.shutdown(err)
+			return
+		}
+	}
+}
+
+// dispatch acts on one frame. A returned error is a protocol violation and ends
+// the session; anything a well-behaved peer can cause is handled in place.
+func (s *Session) dispatch(h header, payload []byte) error {
+	switch h.typ {
+	case frameOpen:
+		return s.handleOpen(h, payload)
+	case frameData:
+		if st := s.stream(h.stream); st != nil {
+			return st.deliver(payload)
+		}
+		// A stream this end has already finished with: the peer's frames were in
+		// flight when it was closed, and it has our reset by now.
+		return nil
+	case frameFin:
+		if st := s.stream(h.stream); st != nil {
+			st.peerFinished()
+		}
+		return nil
+	case frameReset:
+		if st := s.stream(h.stream); st != nil {
+			s.removeStream(h.stream)
+			reason := safeReason(payload)
+			if reason == "" {
+				st.terminate(ErrStreamReset)
+			} else {
+				st.terminate(fmt.Errorf("%w: %s", ErrStreamReset, reason))
+			}
+		}
+		return nil
+	case frameWindow:
+		if len(payload) != 4 {
+			return fmt.Errorf("rfwdmux: window frame carries %d bytes, want 4", len(payload))
+		}
+		if st := s.stream(h.stream); st != nil {
+			st.grantWindow(int(uint32(payload[0])<<24 | uint32(payload[1])<<16 |
+				uint32(payload[2])<<8 | uint32(payload[3])))
+		}
+		return nil
+	case framePing:
+		s.enqueueCtrl(header{typ: framePong}, nil)
+		return nil
+	case framePong:
+		return nil
+	default:
+		return fmt.Errorf("rfwdmux: unknown frame type %d", uint8(h.typ))
+	}
+}
+
+// handleOpen registers a stream the peer opened, or refuses it.
+func (s *Session) handleOpen(h header, payload []byte) error {
+	if s.cfg.Initiator {
+		return errors.New("rfwdmux: peer opened a stream on the initiating end")
+	}
+	if h.stream == 0 {
+		return errors.New("rfwdmux: peer opened stream 0")
+	}
+	addr, port, err := decodeOpen(payload)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	if _, exists := s.streams[h.stream]; exists {
+		s.mu.Unlock()
+		return fmt.Errorf("rfwdmux: peer reopened stream %d", h.stream)
+	}
+	if len(s.streams) >= s.cfg.maxStreams() {
+		s.mu.Unlock()
+		s.refuse(h.stream, "stream limit reached")
+		return nil
+	}
+	st := newStream(s, h.stream, addr, port)
+	s.streams[h.stream] = st
+	s.mu.Unlock()
+
+	if s.queueForAccept(st) {
+		s.opened.Add(1)
+		return nil
+	}
+	// Nothing is taking connections off this session fast enough. Refusing is the
+	// honest answer: the process inside the pod sees its connection fail instead of
+	// waiting on one that will never be served.
+	s.removeStream(h.stream)
+	s.refuse(h.stream, "accept queue full")
+	return nil
+}
+
+// queueForAccept puts a stream in front of Accept, reporting whether there was room.
+//
+// A queue that is full is not the same as a session that is busy: a peer can open
+// connections and abandon them before anyone takes them, and those hold a place
+// without carrying anything. Clearing those out first is what keeps a burst of
+// abandoned connections from making the session refuse live ones.
+//
+// Only the read loop reaches this, so it is the sole producer on the queue.
+func (s *Session) queueForAccept(st *Stream) bool {
+	select {
+	case s.accept <- st:
+		return true
+	default:
+	}
+	for i := 0; i < cap(s.accept); i++ {
+		select {
+		case queued := <-s.accept:
+			if queued.alive() {
+				// Still worth handing over. The order connections are accepted in
+				// is not a contract; losing one would be.
+				s.accept <- queued
+				return false
+			}
+		default:
+			return false
+		}
+		select {
+		case s.accept <- st:
+			return true
+		default:
+		}
+	}
+	return false
+}
+
+// refuse tells the peer a stream will not be carried.
+func (s *Session) refuse(id uint32, reason string) {
+	s.dropped.Add(1)
+	s.cfg.logf("rfwdmux: refused stream %d: %s", id, reason)
+	s.enqueueCtrl(header{typ: frameReset, stream: id}, []byte(reason))
+}
+
+// stream looks up a live stream.
+func (s *Session) stream(id uint32) *Stream {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.streams[id]
+}
+
+// removeStream drops a stream from the table.
+func (s *Session) removeStream(id uint32) {
+	s.mu.Lock()
+	delete(s.streams, id)
+	s.mu.Unlock()
+}

--- a/SaFE/apiserver/pkg/handlers/ssh-handlers/rfwdmux/stream.go
+++ b/SaFE/apiserver/pkg/handlers/ssh-handlers/rfwdmux/stream.go
@@ -1,0 +1,298 @@
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ * See LICENSE for license information.
+ */
+
+package rfwdmux
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// Stream is one connection carried over a session. It behaves like a TCP
+// connection: bytes in both directions, either end able to say it has finished
+// writing while it goes on reading, and an abort that ends both directions.
+type Stream struct {
+	s          *Session
+	id         uint32
+	originAddr string
+	originPort uint32
+
+	// rmu and wmu serialise the application's own calls, so the window bookkeeping
+	// below only ever has one reader and one writer to answer to.
+	rmu sync.Mutex
+	wmu sync.Mutex
+
+	mu         sync.Mutex
+	buf        bytes.Buffer
+	unacked    int
+	sendWindow int
+	peerFin    bool
+	finSent    bool
+	terminated bool
+	failure    error
+	readNotify chan struct{}
+	winNotify  chan struct{}
+
+	closed    chan struct{}
+	closeOnce sync.Once
+}
+
+func newStream(s *Session, id uint32, originAddr string, originPort uint32) *Stream {
+	return &Stream{
+		s:          s,
+		id:         id,
+		originAddr: originAddr,
+		originPort: originPort,
+		sendWindow: initialWindow,
+		readNotify: make(chan struct{}, 1),
+		winNotify:  make(chan struct{}, 1),
+		closed:     make(chan struct{}),
+	}
+}
+
+// ID is the stream's identifier on the session.
+func (st *Stream) ID() uint32 { return st.id }
+
+// OriginAddr is the address of the peer whose connection opened this stream.
+func (st *Stream) OriginAddr() string { return st.originAddr }
+
+// OriginPort is the port of the peer whose connection opened this stream.
+func (st *Stream) OriginPort() uint32 { return st.originPort }
+
+// Read returns bytes the peer sent. It reports io.EOF once the peer has finished
+// writing and everything it sent has been handed over.
+func (st *Stream) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	st.rmu.Lock()
+	defer st.rmu.Unlock()
+	for {
+		st.mu.Lock()
+		if st.buf.Len() > 0 {
+			n, _ := st.buf.Read(p)
+			st.unacked += n
+			ack := 0
+			if st.unacked >= windowUpdateThreshold {
+				ack, st.unacked = st.unacked, 0
+			}
+			st.mu.Unlock()
+			if ack > 0 {
+				// Best effort: a window update that cannot be sent means the
+				// session is going, which the next read reports on its own.
+				st.sendWindowUpdate(ack)
+			}
+			return n, nil
+		}
+		// Buffered bytes outrank both of these, so a peer that sent data and then
+		// stopped is fully drained before its ending is reported.
+		if st.failure != nil {
+			err := st.failure
+			st.mu.Unlock()
+			return 0, err
+		}
+		if st.peerFin {
+			st.mu.Unlock()
+			return 0, io.EOF
+		}
+		notifyCh := st.readNotify
+		st.mu.Unlock()
+
+		select {
+		case <-notifyCh:
+		case <-st.closed:
+		}
+	}
+}
+
+// Write sends bytes to the peer, waiting when the peer's window is exhausted.
+func (st *Stream) Write(p []byte) (int, error) {
+	st.wmu.Lock()
+	defer st.wmu.Unlock()
+	total := 0
+	for len(p) > 0 {
+		st.mu.Lock()
+		if st.failure != nil {
+			err := st.failure
+			st.mu.Unlock()
+			return total, err
+		}
+		if st.finSent {
+			st.mu.Unlock()
+			return total, ErrStreamClosed
+		}
+		if st.sendWindow > 0 {
+			n := st.sendWindow
+			if n > len(p) {
+				n = len(p)
+			}
+			if n > maxFramePayload {
+				n = maxFramePayload
+			}
+			st.sendWindow -= n
+			st.mu.Unlock()
+			if err := st.s.writeFrame(header{typ: frameData, stream: st.id}, p[:n]); err != nil {
+				return total, err
+			}
+			total += n
+			p = p[n:]
+			continue
+		}
+		notifyCh := st.winNotify
+		st.mu.Unlock()
+
+		select {
+		case <-notifyCh:
+		case <-st.closed:
+			return total, st.terminalErr()
+		}
+	}
+	return total, nil
+}
+
+// CloseWrite reports that nothing further will be sent, leaving what the peer
+// still has to say on its way.
+func (st *Stream) CloseWrite() error {
+	st.wmu.Lock()
+	defer st.wmu.Unlock()
+	st.mu.Lock()
+	if st.failure != nil {
+		err := st.failure
+		st.mu.Unlock()
+		return err
+	}
+	if st.finSent {
+		st.mu.Unlock()
+		return nil
+	}
+	st.finSent = true
+	retire := st.peerFin
+	st.mu.Unlock()
+
+	err := st.s.writeFrame(header{typ: frameFin, stream: st.id}, nil)
+	// Both directions are finished, so the stream can give its slot back without
+	// waiting for the application to get around to closing it.
+	if retire {
+		st.s.removeStream(st.id)
+	}
+	return err
+}
+
+// Close ends the stream in both directions. A stream that has not finished
+// exchanging fins is aborted, so the peer's connection fails rather than waiting
+// on bytes that are not coming.
+func (st *Stream) Close() error {
+	st.mu.Lock()
+	if st.terminated {
+		st.mu.Unlock()
+		return nil
+	}
+	graceful := st.finSent && st.peerFin
+	st.mu.Unlock()
+
+	st.s.removeStream(st.id)
+	if !graceful {
+		_ = st.s.writeFrame(header{typ: frameReset, stream: st.id}, nil)
+	}
+	st.terminate(ErrStreamClosed)
+	return nil
+}
+
+// deliver buffers a data frame. A peer that sends past the window it was given, or
+// after saying it had finished, has broken the protocol and ends the session.
+func (st *Stream) deliver(payload []byte) error {
+	st.mu.Lock()
+	if st.terminated {
+		st.mu.Unlock()
+		return nil
+	}
+	if st.peerFin {
+		st.mu.Unlock()
+		return fmt.Errorf("rfwdmux: stream %d carried data after its fin", st.id)
+	}
+	if st.buf.Len()+st.unacked+len(payload) > initialWindow {
+		st.mu.Unlock()
+		return fmt.Errorf("rfwdmux: stream %d overran its %d byte window", st.id, initialWindow)
+	}
+	st.buf.Write(payload)
+	st.mu.Unlock()
+	notify(st.readNotify)
+	return nil
+}
+
+// peerFinished records the peer's fin.
+func (st *Stream) peerFinished() {
+	st.mu.Lock()
+	if st.peerFin {
+		st.mu.Unlock()
+		return
+	}
+	st.peerFin = true
+	retire := st.finSent
+	st.mu.Unlock()
+	notify(st.readNotify)
+	if retire {
+		st.s.removeStream(st.id)
+	}
+}
+
+// grantWindow returns credit the peer's application has consumed.
+func (st *Stream) grantWindow(n int) {
+	if n <= 0 {
+		return
+	}
+	st.mu.Lock()
+	st.sendWindow += n
+	st.mu.Unlock()
+	notify(st.winNotify)
+}
+
+// sendWindowUpdate tells the peer it may send n more bytes.
+func (st *Stream) sendWindowUpdate(n int) {
+	var payload [4]byte
+	binary.BigEndian.PutUint32(payload[:], uint32(n))
+	_ = st.s.writeFrame(header{typ: frameWindow, stream: st.id}, payload[:])
+}
+
+// terminate ends the stream locally, releasing whoever is waiting on it.
+func (st *Stream) terminate(err error) {
+	st.closeOnce.Do(func() {
+		st.mu.Lock()
+		st.terminated = true
+		if st.failure == nil {
+			st.failure = err
+		}
+		st.mu.Unlock()
+		close(st.closed)
+	})
+}
+
+// alive reports whether the stream can still carry anything.
+func (st *Stream) alive() bool {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	return !st.terminated
+}
+
+// terminalErr reports why the stream stopped.
+func (st *Stream) terminalErr() error {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	if st.failure != nil {
+		return st.failure
+	}
+	return ErrStreamClosed
+}
+
+// notify wakes a waiter without ever blocking the caller.
+func notify(ch chan struct{}) {
+	select {
+	case ch <- struct{}{}:
+	default:
+	}
+}

--- a/SaFE/apiserver/pkg/handlers/ssh-handlers/rfwdmux/stream.go
+++ b/SaFE/apiserver/pkg/handlers/ssh-handlers/rfwdmux/stream.go
@@ -248,6 +248,13 @@ func (st *Stream) grantWindow(n int) {
 	}
 	st.mu.Lock()
 	st.sendWindow += n
+	if st.sendWindow > initialWindow {
+		// An honest peer never returns more credit than it was spent. Clamping
+		// keeps a peer from inflating this into writes that overrun its own window
+		// - which it would then end the session over - and keeps the counter away
+		// from an overflow that would stall this stream's writer for good.
+		st.sendWindow = initialWindow
+	}
 	st.mu.Unlock()
 	notify(st.winNotify)
 }

--- a/SaFE/charts/primus-safe/values.yaml
+++ b/SaFE/charts/primus-safe/values.yaml
@@ -163,8 +163,8 @@ ssh:
   server_ip: ""
   # Remote port forwarding (`ssh -R` / RemoteForward). The listen socket is opened
   # inside the user's target Pod, letting Pod processes reach a proxy running on
-  # the developer's machine. The pod-side listener is a `socat`, which an Authoring pod
-  # installs at startup; other workload kinds need it in the image.
+  # the developer's machine. The apiserver copies the pod-side listener into the
+  # container for the life of the forward, so nothing has to be in the workload image.
   reverse_forward:
     # On by default. Set to false where pod traffic must not be able to leave through
     # a developer's network; what keeps it contained otherwise is the rest of this

--- a/docs-site/docs/tasks/interact-with-your-job.md
+++ b/docs-site/docs/tasks/interact-with-your-job.md
@@ -119,11 +119,15 @@ Requirements and limits for `-R`:
 
 - It is on by default. A platform administrator can turn it off for a cluster with
   `ssh.reverse_forward.enable: false`, in which case `-R` is refused.
-- The pod-side listener is built from `socat`, `awk`, `cat`, `date`, `grep`, `mkdir`,
-  `readlink` and `sleep`. An Authoring pod installs `socat` for you at startup, the way
-  it installs the SSH server; the rest are in any base image. Other workload kinds run
-  your image untouched, so there `socat` has to be in the image. Whichever is missing is
-  reported by name rather than as a mysterious failure to listen.
+- Nothing has to be installed in your image. The platform copies a small listener into
+  your pod for the life of the forward and removes it again; it needs only `/bin/sh`,
+  `uname`, `cat` and a directory it can execute from, which every base image has. If a
+  pod has none — `/tmp`, `/dev/shm` and `/var/tmp` all mounted `noexec`, or an
+  architecture other than x86-64 and arm64 — you are told which, rather than left with a
+  mysterious failure to listen.
+- One forward carries up to 256 connections at a time. Past that a new connection is
+  refused immediately rather than queued, so a client fails where you can see it instead
+  of hanging.
 - The pod-side listener may only bind `127.0.0.1`, so no other workload can use your tunnel.
 - The listen port must fall inside the configured range (`1024`–`65535` by default, so that a
   forward cannot shadow a privileged service inside your pod), and a session may hold at most 8


### PR DESCRIPTION
## Why

A `-R` listener was a socat: a long-lived acceptor exec running
`TCP-LISTEN,fork`, a `child.sh` per accepted connection republishing the socket
under a rendezvous directory, and a second exec per connection to attach to it.

Attach execs were capped at 32 (`maxConcurrentRelayExecs`) and waited on that cap
using the session's twelve-hour context, with no timeout. Once 32 were held the
listener went on accepting connections it would never answer. In the field this
shows up as a SOCKS proxy on `127.0.0.1:7890` that keeps a LISTEN socket while
every handshake times out, with hundreds of rendezvous directories and unreaped
`child.sh` processes behind it.

This is the hard cut described in the plan: one exec per forward, no feature flag,
no dual path, no patching `child.sh`.

## What

**`rfwdmux`** — the framing both ends speak. Length-prefixed frames carry OPEN,
DATA, FIN, RST, WINDOW, PING and PONG. Not yamux/smux, per the plan.

- FIN is a half-close, so a request followed by its reply is not truncated.
- Per-stream credit keeps one stalled consumer from stopping every other
  connection sharing the exec. Without it the multiplexer would simply trade a
  connection limit for head-of-line blocking.
- The read loop never writes: a read loop waiting on a full transport is a session
  that cannot recover, so control frames it needs to emit go through a queue.
- Everything a peer sends is bounded and checked. A session ends rather than
  buffer past a window, and an origin address is an IP literal by the time it
  leaves the decoder, because it travels on into a `forwarded-tcpip` channel open
  that the user's SSH client logs and displays.

**`safe-rfwd-mux`** — the pod-side program. It owns the listen socket and carries
what arrives on it over its own stdin and stdout. At the 256-stream cap it resets
the new TCP connection instead of queueing it, so the process making it fails where
that can be seen. It removes its own image from the container as soon as the port
is bound, so nothing is left to clean up however it ends, and it exits when the
apiserver stops answering.

The binaries are embedded in the apiserver (amd64 and arm64) and injected over an
exec, so a forward depends on nothing being present in the workload image. The
source tree carries placeholders; the image build replaces them, and tests that
need a multiplexer that runs build their own.

**`pod_listener.go`** — setting up a forward is now three commands: a probe
reporting the container's architecture and a directory it can execute from, an
install writing the matching multiplexer there and proving it runs, and the
long-lived exec whose stdin and stdout are the session. `Accept` takes a stream off
that session rather than starting an exec.

The probe exists because both answers have to come from inside the container: the
node's architecture is not the container's, and an image whose `/tmp` is `noexec`
would otherwise fail at the moment of running the binary, long after the reason
could be explained. It tries `/tmp`, then `/dev/shm`, then `/var/tmp`.

Both the probe and the install create their directory with a plain `mkdir` under an
unguessable name. These are shared, world-writable directories, and `mkdir -p` onto
a path something else put there writes through it.

**`reverse_forward.go`** — two ways a forward could outlive what it belonged to,
both found while replacing the relay underneath it:

- Opening the `forwarded-tcpip` channel had no deadline. The reply is the client's
  to send, so a suspended client held a goroutine and a pod-side connection for the
  twelve hours a session may last.
- Nothing stopped a listener that was still being started, and starting one now
  installs and runs a program inside the pod. Until it is activated nothing else
  knows it exists, so it would finish and leave a listen socket in a pod whose
  session had gone.

## Testing

Offline, no cluster, from a clean checkout:

```
cd SaFE
go test -race ./apiserver/pkg/handlers/ssh-handlers/... ./apiserver/cmd/safe-rfwd-mux/
```

Only the `SAFE_LIVE_*` tests skip. The whole-stack tests build a multiplexer and
run the real scripts over a local exec, including a 120-connection burst.

Covered: half-close in both directions, a reset that does not kill the listener, the
stream cap refusing and then recovering, prompt `Close` with a backlog, the
accept-queue refusal, credit exhaustion and recovery, a peer that overruns its
window or speaks an unknown frame, `Close` on a partially built listener, the
`OpenChannel` deadline, and the probe/install failure branches.

Live, against a real pod over the real Kubernetes exec transport:

```
SAFE_LIVE_KUBECONFIG=... SAFE_LIVE_NAMESPACE=... SAFE_LIVE_POD=... \
  go test -v -timeout 20m -run TestLive ./apiserver/pkg/handlers/ssh-handlers/
```

All three pass. A separate soak against a real pod ran 2,230,092 connections
through one forward over 11.5 minutes with zero failures, stayed usable across a
6m30s idle period (past the multiplexer's own idle timeout, so keepalives are load
bearing), held at one pod-side process and no leftover files throughout, and closed
in 8.9ms.

## Rollback

Revert the apiserver Deployment. There are no orphans to clean up in the pod: the
multiplexer removes its own files once the port is bound, and an install that never
got that far is removed explicitly.

## Not in this change

`SaFE/docker/preprocess/build_authoring.sh` still installs socat; removing it is a
follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
