### PR TITLE
Expose KubeSpray Kubernetes versions in the envs API

### DIFF
--- a/SaFE/apiserver/pkg/handlers/resources/backend.go
+++ b/SaFE/apiserver/pkg/handlers/resources/backend.go
@@ -28,6 +28,12 @@ func (h *Handler) getEnvs(_ *gin.Context) (interface{}, error) {
 		SSHPort:           commonconfig.GetSSHServerPort(),
 		SSOEnable:         commonconfig.IsSSOEnable(),
 		CDRequireApproval: commonconfig.IsCDRequireApproval(),
+		KubeSprayK8sVersions: map[string]string{
+			"primussafe/kubespray:20200530": "1.32.5",
+			"primussafe/kubespray:v2.31.0":  "1.35.4",
+			"primussafe/kubespray:v2.29.1":  "1.33.7",
+			"primussafe/kubespray:v2.30.0":  "1.34.3",
+		},
 	}
 	if resp.SSOEnable {
 		inst := authority.SSOInstance()

--- a/SaFE/apiserver/pkg/handlers/resources/backend_test.go
+++ b/SaFE/apiserver/pkg/handlers/resources/backend_test.go
@@ -31,4 +31,10 @@ func TestGetEnvs(t *testing.T) {
 
 	var resp view.GetEnvResponse
 	assert.NoError(t, json.Unmarshal(rsp.Body.Bytes(), &resp))
+	assert.Equal(t, map[string]string{
+		"primussafe/kubespray:20200530": "1.32.5",
+		"primussafe/kubespray:v2.31.0":  "1.35.4",
+		"primussafe/kubespray:v2.29.1":  "1.33.7",
+		"primussafe/kubespray:v2.30.0":  "1.34.3",
+	}, resp.KubeSprayK8sVersions)
 }

--- a/SaFE/apiserver/pkg/handlers/resources/view/backend_view.go
+++ b/SaFE/apiserver/pkg/handlers/resources/view/backend_view.go
@@ -22,4 +22,6 @@ type GetEnvResponse struct {
 	SSOAuthUrl string `json:"ssoAuthUrl"`
 	// Whether CD deployment requires approval from another user
 	CDRequireApproval bool `json:"cdRequireApproval"`
+	// KubeSpray image tags mapped to the Kubernetes versions they install.
+	KubeSprayK8sVersions map[string]string `json:"kubeSprayK8sVersions"`
 }


### PR DESCRIPTION
## Summary
- Add kubeSprayK8sVersions to the backend envs response so clients can map KubeSpray images to Kubernetes versions.

## Test plan
- [ ] GET /api/v1/envs returns kubeSprayK8sVersions with the four primussafe/kubespray image entries.


Made with [Cursor](https://cursor.com)